### PR TITLE
feat: error boundaries + cancellation + retry + iframe error reporting

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,15 +1,35 @@
-import { buildSrcdoc } from '@open-codesign/runtime';
+import { buildSrcdoc, isIframeErrorMessage } from '@open-codesign/runtime';
 import { BUILTIN_DEMOS } from '@open-codesign/templates';
 import { Button } from '@open-codesign/ui';
-import { Send, Sparkles } from 'lucide-react';
-import { useState } from 'react';
+import { Send, Sparkles, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CanvasErrorBar } from './components/CanvasErrorBar';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { useCodesignStore } from './store';
 
 export function App() {
+  return (
+    <ErrorBoundary scope="App shell">
+      <div className="h-full grid grid-cols-[380px_1fr] bg-[var(--color-background)]">
+        <ErrorBoundary scope="Sidebar">
+          <Sidebar />
+        </ErrorBoundary>
+        <ErrorBoundary scope="Preview">
+          <PreviewPane />
+        </ErrorBoundary>
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+function Sidebar() {
   const messages = useCodesignStore((s) => s.messages);
-  const previewHtml = useCodesignStore((s) => s.previewHtml);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const sendPrompt = useCodesignStore((s) => s.sendPrompt);
+  const cancelGeneration = useCodesignStore((s) => s.cancelGeneration);
+  const statusLines = useCodesignStore((s) => s.statusLines);
+  const rateLimitedUntil = useCodesignStore((s) => s.rateLimitedUntil);
+  const clearRateLimit = useCodesignStore((s) => s.clearRateLimit);
   const [prompt, setPrompt] = useState('');
 
   function handleSubmit(e: React.FormEvent) {
@@ -20,112 +40,217 @@ export function App() {
   }
 
   return (
-    <div className="h-full grid grid-cols-[380px_1fr] bg-[var(--color-background)]">
-      <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)]">
-        <header className="px-5 py-4 border-b border-[var(--color-border)]">
-          <div className="flex items-center gap-2">
-            <Sparkles className="w-5 h-5 text-[var(--color-accent)]" />
-            <span className="font-semibold text-[var(--color-text-primary)]">open-codesign</span>
-            <span className="ml-auto text-xs text-[var(--color-text-muted)]">pre-alpha</span>
-          </div>
-        </header>
+    <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)]">
+      <ErrorBoundary scope="TopBar">
+        <TopBar />
+      </ErrorBoundary>
 
-        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-          {messages.length === 0 ? (
-            <div>
-              <p className="text-sm text-[var(--color-text-secondary)] mb-3">
-                Try a starter prompt:
-              </p>
-              <ul className="space-y-2">
-                {BUILTIN_DEMOS.map((demo) => (
-                  <li key={demo.id}>
-                    <button
-                      type="button"
-                      onClick={() => setPrompt(demo.prompt)}
-                      className="w-full text-left px-3 py-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
-                    >
-                      <div className="text-sm font-medium text-[var(--color-text-primary)]">
-                        {demo.title}
-                      </div>
-                      <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
-                        {demo.description}
-                      </div>
-                    </button>
-                  </li>
-                ))}
-              </ul>
+      <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+        {messages.length === 0 ? (
+          <div>
+            <p className="text-sm text-[var(--color-text-secondary)] mb-3">Try a starter prompt:</p>
+            <ul className="space-y-2">
+              {BUILTIN_DEMOS.map((demo) => (
+                <li key={demo.id}>
+                  <button
+                    type="button"
+                    onClick={() => setPrompt(demo.prompt)}
+                    className="w-full text-left px-3 py-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
+                  >
+                    <div className="text-sm font-medium text-[var(--color-text-primary)]">
+                      {demo.title}
+                    </div>
+                    <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                      {demo.description}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          messages.map((m, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: tier-1 chat list with no reordering
+              key={`${m.role}-${i}`}
+              className={`px-3 py-2 rounded-[var(--radius-md)] text-sm ${
+                m.role === 'user'
+                  ? 'bg-[var(--color-accent-muted)] text-[var(--color-text-primary)]'
+                  : 'bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-primary)]'
+              }`}
+            >
+              {m.content}
             </div>
-          ) : (
-            messages.map((m, i) => (
-              <div
-                // biome-ignore lint/suspicious/noArrayIndexKey: tier-1 chat list with no reordering
-                key={`${m.role}-${i}`}
-                className={`px-3 py-2 rounded-[var(--radius-md)] text-sm ${
-                  m.role === 'user'
-                    ? 'bg-[var(--color-accent-muted)] text-[var(--color-text-primary)]'
-                    : 'bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-primary)]'
+          ))
+        )}
+
+        {statusLines.length > 0 && (
+          <ul className="space-y-1 pt-2 border-t border-[var(--color-border-subtle)]">
+            {statusLines.slice(-5).map((line) => (
+              <li
+                key={line.id}
+                className={`text-xs ${
+                  line.kind === 'error'
+                    ? 'text-[var(--color-error)]'
+                    : line.kind === 'warn'
+                      ? 'text-[var(--color-warning)]'
+                      : 'text-[var(--color-text-muted)]'
                 }`}
               >
-                {m.content}
-              </div>
-            ))
-          )}
-        </div>
+                {line.text}
+              </li>
+            ))}
+          </ul>
+        )}
 
-        <form
-          onSubmit={handleSubmit}
-          className="border-t border-[var(--color-border)] p-3 flex gap-2"
-        >
-          <input
-            type="text"
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe what to design…"
-            disabled={isGenerating}
-            className="flex-1 px-3 py-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)]"
-          />
-          <Button type="submit" size="md" disabled={isGenerating || !prompt.trim()}>
+        {rateLimitedUntil !== null && rateLimitedUntil > Date.now() && (
+          <RateLimitToast until={rateLimitedUntil} onDismiss={clearRateLimit} />
+        )}
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="border-t border-[var(--color-border)] p-3 flex gap-2"
+      >
+        <input
+          type="text"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Describe what to design…"
+          disabled={isGenerating}
+          className="flex-1 px-3 py-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)]"
+        />
+        {isGenerating ? (
+          <Button type="button" variant="secondary" size="md" onClick={cancelGeneration}>
+            Cancel
+          </Button>
+        ) : (
+          <Button type="submit" size="md" disabled={!prompt.trim()}>
             <Send className="w-4 h-4" />
           </Button>
-        </form>
-      </aside>
+        )}
+      </form>
+    </aside>
+  );
+}
 
-      <main className="flex flex-col">
-        <header className="h-12 px-5 border-b border-[var(--color-border)] flex items-center justify-between">
-          <span className="text-sm text-[var(--color-text-secondary)]">
-            {previewHtml ? 'Preview' : 'No design yet'}
-          </span>
-          <span className="text-xs text-[var(--color-text-muted)]">
-            BYOK · local-first · multi-model
-          </span>
-        </header>
-        <div className="flex-1 p-6 overflow-auto">
-          {previewHtml ? (
-            <iframe
-              key={previewHtml.length}
-              title="design-preview"
-              sandbox="allow-scripts"
-              srcDoc={buildSrcdoc(previewHtml)}
-              className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
-            />
-          ) : (
-            <div className="h-full flex items-center justify-center">
-              <div className="text-center max-w-md">
-                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] flex items-center justify-center">
-                  <Sparkles className="w-7 h-7 text-[var(--color-accent)]" />
-                </div>
-                <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
-                  Design with AI
-                </h2>
-                <p className="text-sm text-[var(--color-text-secondary)]">
-                  Pick a starter on the left, or describe what you want to design. The result
-                  renders here in a sandboxed preview.
-                </p>
+function TopBar() {
+  return (
+    <header className="px-5 py-4 border-b border-[var(--color-border)]">
+      <div className="flex items-center gap-2">
+        <Sparkles className="w-5 h-5 text-[var(--color-accent)]" />
+        <span className="font-semibold text-[var(--color-text-primary)]">open-codesign</span>
+        <span className="ml-auto text-xs text-[var(--color-text-muted)]">pre-alpha</span>
+      </div>
+    </header>
+  );
+}
+
+function PreviewPane() {
+  const previewHtml = useCodesignStore((s) => s.previewHtml);
+  const appendIframeError = useCodesignStore((s) => s.appendIframeError);
+
+  useEffect(() => {
+    function handler(ev: MessageEvent) {
+      if (isIframeErrorMessage(ev.data)) {
+        const loc =
+          ev.data.source && ev.data.lineno !== undefined
+            ? ` (${ev.data.source}:${ev.data.lineno}${
+                ev.data.colno !== undefined ? `:${ev.data.colno}` : ''
+              })`
+            : '';
+        appendIframeError(`${ev.data.message}${loc}`);
+      }
+    }
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [appendIframeError]);
+
+  return (
+    <main className="flex flex-col">
+      <header className="h-12 px-5 border-b border-[var(--color-border)] flex items-center justify-between">
+        <span className="text-sm text-[var(--color-text-secondary)]">
+          {previewHtml ? 'Preview' : 'No design yet'}
+        </span>
+        <span className="text-xs text-[var(--color-text-muted)]">
+          BYOK · local-first · multi-model
+        </span>
+      </header>
+      <CanvasErrorBar />
+      <div className="flex-1 p-6 overflow-auto">
+        {previewHtml ? (
+          <iframe
+            key={previewHtml.length}
+            title="design-preview"
+            sandbox="allow-scripts"
+            srcDoc={buildSrcdoc(previewHtml)}
+            className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
+          />
+        ) : (
+          <div className="h-full flex items-center justify-center">
+            <div className="text-center max-w-md">
+              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] flex items-center justify-center">
+                <Sparkles className="w-7 h-7 text-[var(--color-accent)]" />
               </div>
+              <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-2">
+                Design with AI
+              </h2>
+              <p className="text-sm text-[var(--color-text-secondary)]">
+                Pick a starter on the left, or describe what you want to design. The result renders
+                here in a sandboxed preview.
+              </p>
             </div>
-          )}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function RateLimitToast({ until, onDismiss }: { until: number; onDismiss: () => void }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, []);
+  const remainingMs = Math.max(0, until - now);
+  const seconds = Math.ceil(remainingMs / 1000);
+  const target = new Date(until);
+  const hh = String(target.getHours()).padStart(2, '0');
+  const mm = String(target.getMinutes()).padStart(2, '0');
+  const ss = String(target.getSeconds()).padStart(2, '0');
+
+  return (
+    <div
+      role="alert"
+      className="rounded-[var(--radius-md)] border border-[var(--color-error)] bg-[color-mix(in_srgb,var(--color-error)_8%,var(--color-surface))] p-3 flex items-start gap-3"
+    >
+      <div className="flex-1">
+        <div className="text-xs uppercase tracking-wide font-semibold text-[var(--color-error)] mb-1">
+          Rate limited
         </div>
-      </main>
+        <div className="text-sm text-[var(--color-text-primary)]">
+          Provider asked us to slow down. Retrying after {hh}:{mm}:{ss} ({seconds}s).
+        </div>
+        <div className="mt-2 flex gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              // Tier-1: switching models is a Settings concern (wt/preview-ux owns
+              // the picker). For now we just dismiss and trust the user to reopen
+              // settings; the toast tells them what to do next.
+              onDismiss();
+            }}
+          >
+            Switch model
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={onDismiss}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/CanvasErrorBar.tsx
+++ b/apps/desktop/src/renderer/src/components/CanvasErrorBar.tsx
@@ -1,0 +1,43 @@
+/**
+ * CanvasErrorBar — slim red strip shown above the preview iframe when the
+ * sandbox runtime postMessages an IFRAME_ERROR.
+ *
+ * Loud surface (PRINCIPLES §10): every JS exception thrown inside the
+ * generated HTML lands here with file + line. Users can dismiss the bar
+ * (it clears the store slice) but errors are never auto-hidden.
+ */
+
+import { X } from 'lucide-react';
+import { useCodesignStore } from '../store';
+
+export function CanvasErrorBar() {
+  const errors = useCodesignStore((s) => s.iframeErrors);
+  const clear = useCodesignStore((s) => s.clearIframeErrors);
+  if (errors.length === 0) return null;
+  const latest = errors[errors.length - 1];
+  if (!latest) return null;
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 px-4 py-2 border-b border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-error)_10%,var(--color-background))] text-[var(--color-text-primary)]"
+    >
+      <span className="mt-0.5 inline-block w-2 h-2 rounded-full bg-[var(--color-error)] shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-semibold uppercase tracking-wide text-[var(--color-error)]">
+          Preview runtime error{errors.length > 1 ? ` (${errors.length})` : ''}
+        </div>
+        <div className="text-sm text-[var(--color-text-primary)] truncate" title={latest}>
+          {latest}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={clear}
+        aria-label="Dismiss preview errors"
+        className="shrink-0 p-1 rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,119 @@
+/**
+ * Generic React error boundary.
+ *
+ * Strategy (PRINCIPLES §10): never silently swallow render exceptions.
+ * If a child throws we render an actionable card with:
+ *   - the error message (loud, not hidden in console)
+ *   - "Reload" — re-mounts the children by bumping a key
+ *   - "Copy stack" — puts message+stack into the clipboard for bug reports
+ *
+ * Used both at the app shell (whole renderer) and per-pane (sidebar /
+ * preview / topbar) so a single crash never blanks the entire window.
+ */
+
+import { Button } from '@open-codesign/ui';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Human-readable label used in the fallback heading: "Sidebar crashed". */
+  scope?: string;
+  /**
+   * Optional custom fallback. Receives the error and a `reset` callback
+   * that re-mounts the boundary's children.
+   */
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  resetKey: number;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { error: null, resetKey: 0 };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Loud surface: also log so devtools shows the boundary that caught it.
+    // Tier-1 — no remote reporting, BYOK / local-first.
+    console.error(`[ErrorBoundary:${this.props.scope ?? 'root'}]`, error, info.componentStack);
+  }
+
+  reset = (): void => {
+    this.setState((s) => ({ error: null, resetKey: s.resetKey + 1 }));
+  };
+
+  copyStack = async (): Promise<void> => {
+    const err = this.state.error;
+    if (!err) return;
+    const text = `${err.name}: ${err.message}\n\n${err.stack ?? '(no stack)'}`;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard may be blocked in the sandbox; surface a textarea fallback
+      // so the user can still grab the text instead of failing silently.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        ta.remove();
+      }
+    }
+  };
+
+  override render(): ReactNode {
+    const { error, resetKey } = this.state;
+    if (!error) {
+      // Use resetKey to force remount of children after reset.
+      return <ErrorBoundaryChildren key={resetKey}>{this.props.children}</ErrorBoundaryChildren>;
+    }
+    if (this.props.fallback) {
+      return this.props.fallback({ error, reset: this.reset });
+    }
+    const scope = this.props.scope ?? 'this view';
+    return (
+      <div className="h-full w-full flex items-center justify-center p-6 bg-[var(--color-background)]">
+        <div className="max-w-md w-full rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-card)] p-6">
+          <div className="text-xs uppercase tracking-wide text-[var(--color-error)] font-semibold mb-2">
+            {scope} crashed
+          </div>
+          <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1">
+            {error.name}: {error.message}
+          </h2>
+          <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+            The rest of the app is still running. Reload this view, or copy the stack to file a bug.
+          </p>
+          <pre className="text-[11px] leading-snug font-mono text-[var(--color-text-muted)] bg-[var(--color-surface-muted)] border border-[var(--color-border-muted)] rounded-[var(--radius-md)] p-3 max-h-40 overflow-auto whitespace-pre-wrap">
+            {error.stack ?? '(no stack)'}
+          </pre>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={() => void this.copyStack()}
+            >
+              Copy stack
+            </Button>
+            <Button type="button" size="md" onClick={this.reset}>
+              Reload
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function ErrorBoundaryChildren({ children }: { children: ReactNode }): ReactNode {
+  return children;
+}

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -8,19 +8,76 @@ declare global {
   }
 }
 
+export interface StatusLine {
+  /** Monotonic id for React key. */
+  id: number;
+  text: string;
+  kind: 'info' | 'warn' | 'error';
+}
+
 interface CodesignState {
   messages: ChatMessage[];
+  statusLines: StatusLine[];
   previewHtml: string | null;
   isGenerating: boolean;
   errorMessage: string | null;
+  /** Tracks the user's intent to cancel; preload IPC is fire-and-forget so
+   * the main-process call may still complete, but the renderer discards
+   * the result and immediately leaves `isGenerating`. */
+  currentAbortController: AbortController | null;
+  /** Latest iframe runtime errors forwarded from the sandbox overlay. */
+  iframeErrors: string[];
+  /** Epoch ms until which the chat input is rate-limited (429). */
+  rateLimitedUntil: number | null;
+
   sendPrompt: (prompt: string) => Promise<void>;
+  cancelGeneration: () => void;
+  appendIframeError: (msg: string) => void;
+  clearIframeErrors: () => void;
+  appendStatus: (text: string, kind?: StatusLine['kind']) => void;
+  clearRateLimit: () => void;
 }
+
+let statusCounter = 0;
 
 export const useCodesignStore = create<CodesignState>((set, get) => ({
   messages: [],
+  statusLines: [],
   previewHtml: null,
   isGenerating: false,
   errorMessage: null,
+  currentAbortController: null,
+  iframeErrors: [],
+  rateLimitedUntil: null,
+
+  appendStatus(text, kind = 'info') {
+    const line: StatusLine = { id: ++statusCounter, text, kind };
+    set((s) => ({ statusLines: [...s.statusLines, line].slice(-20) }));
+  },
+
+  appendIframeError(msg) {
+    set((s) => ({ iframeErrors: [...s.iframeErrors, msg].slice(-20) }));
+  },
+
+  clearIframeErrors() {
+    set({ iframeErrors: [] });
+  },
+
+  clearRateLimit() {
+    set({ rateLimitedUntil: null });
+  },
+
+  cancelGeneration() {
+    const ctrl = get().currentAbortController;
+    if (!ctrl) return;
+    ctrl.abort();
+    set((s) => ({
+      isGenerating: false,
+      currentAbortController: null,
+      messages: [...s.messages, { role: 'assistant', content: 'Generation cancelled by user.' }],
+    }));
+    get().appendStatus('Generation cancelled', 'warn');
+  },
 
   async sendPrompt(prompt: string) {
     if (get().isGenerating) return;
@@ -28,12 +85,18 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       set({ errorMessage: 'Renderer is not connected to the main process.' });
       return;
     }
+    if (get().rateLimitedUntil !== null && Date.now() < (get().rateLimitedUntil ?? 0)) {
+      get().appendStatus('Still rate-limited; switch model or wait.', 'warn');
+      return;
+    }
 
     const userMessage: ChatMessage = { role: 'user', content: prompt };
+    const controller = new AbortController();
     set((s) => ({
       messages: [...s.messages, userMessage],
       isGenerating: true,
       errorMessage: null,
+      currentAbortController: controller,
     }));
 
     // Tier 1 wiring: hardcoded provider/model and key-from-env until the
@@ -50,30 +113,57 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
           },
         ],
         isGenerating: false,
+        currentAbortController: null,
       }));
       return;
     }
 
     try {
-      const result = await window.codesign.generate({
+      const promise = window.codesign.generate({
         prompt,
         history: get().messages,
         model: { provider: 'anthropic', modelId: 'claude-sonnet-4-6' },
         apiKey,
       });
+      // Race the IPC promise against the abort signal — when the user
+      // cancels, we resolve immediately and discard whatever comes back.
+      const result = await Promise.race([
+        promise,
+        new Promise<'__cancelled'>((resolve) => {
+          controller.signal.addEventListener('abort', () => resolve('__cancelled'), {
+            once: true,
+          });
+        }),
+      ]);
+      if (result === '__cancelled') return;
+      if (controller.signal.aborted) return;
+
       const firstArtifact = (result as { artifacts: Array<{ content: string }> }).artifacts[0];
       const message = (result as { message: string }).message;
       set((s) => ({
         messages: [...s.messages, { role: 'assistant', content: message || 'Done.' }],
         previewHtml: firstArtifact?.content ?? s.previewHtml,
         isGenerating: false,
+        currentAbortController: null,
       }));
     } catch (err) {
+      if (controller.signal.aborted) return;
       const msg = err instanceof Error ? err.message : 'Unknown error';
+      // Detect rate-limit error pattern from the IPC string (the main-process
+      // CodesignError message preserves status when available).
+      const rateLimitMatch = /\b429\b|rate.?limit/i.exec(msg);
+      const retryAfterMatch = /retry.?after[^0-9]*(\d+)/i.exec(msg);
+      if (rateLimitMatch) {
+        const seconds = retryAfterMatch?.[1] ? Number(retryAfterMatch[1]) : 30;
+        const until = Date.now() + seconds * 1000;
+        set({ rateLimitedUntil: until });
+        get().appendStatus(`Rate limited for ${seconds}s — switch model to keep going.`, 'error');
+      }
       set((s) => ({
         messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
         isGenerating: false,
         errorMessage: msg,
+        currentAbortController: null,
       }));
     }
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { createArtifactParser } from '@open-codesign/artifacts';
-import { complete } from '@open-codesign/providers';
+import { type RetryReason, completeWithRetry } from '@open-codesign/providers';
 import type { Artifact, ChatMessage, ModelRef } from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 
@@ -10,6 +10,8 @@ export interface GenerateInput {
   apiKey: string;
   baseUrl?: string;
   systemPrompt?: string;
+  signal?: AbortSignal;
+  onRetry?: (info: RetryReason) => void;
 }
 
 export interface GenerateOutput {
@@ -45,10 +47,18 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     { role: 'user', content: input.prompt },
   ];
 
-  const result = await complete(input.model, messages, {
-    apiKey: input.apiKey,
-    ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
-  });
+  const result = await completeWithRetry(
+    input.model,
+    messages,
+    {
+      apiKey: input.apiKey,
+      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+      ...(input.signal !== undefined ? { signal: input.signal } : {}),
+    },
+    {
+      ...(input.onRetry !== undefined ? { onRetry: input.onRetry } : {}),
+    },
+  );
 
   const parser = createArtifactParser();
   const artifacts: Artifact[] = [];

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -98,9 +98,11 @@ export function detectProviderFromKey(key: string): ModelRef['provider'] | null 
   return null;
 }
 
+export { classifyError, completeWithRetry, sleepWithAbort } from './retry';
+export type { CompleteWithRetryOptions, RetryReason } from './retry';
+
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>
 //   streamArtifacts(model, messages, opts): AsyncIterable<ArtifactEvent>
 //   streamWithFallback(models[], messages, opts)
-//   completeWithRetry(model, messages, opts, { maxRetries, baseDelayMs })
 //   completeWithPdf(pdfBase64, prompt, opts)

--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -1,0 +1,118 @@
+import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { GenerateOptions, GenerateResult } from './index';
+import { type RetryReason, classifyError, completeWithRetry } from './retry';
+
+const MODEL: ModelRef = { provider: 'anthropic', modelId: 'claude-sonnet-4-6' };
+const MESSAGES: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+const OPTS: GenerateOptions = { apiKey: 'test-key' };
+
+const ok: GenerateResult = { content: 'hello', inputTokens: 1, outputTokens: 1, costUsd: 0 };
+
+class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly headers?: Record<string, string>,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+describe('classifyError', () => {
+  it('marks 5xx as retryable', () => {
+    expect(classifyError(new HttpError('boom', 503))).toMatchObject({ retry: true });
+  });
+  it('marks 4xx (non-429) as non-retryable', () => {
+    expect(classifyError(new HttpError('bad', 400))).toMatchObject({ retry: false });
+  });
+  it('marks 429 as retryable and parses retry-after seconds', () => {
+    const d = classifyError(new HttpError('slow', 429, { 'retry-after': '7' }));
+    expect(d.retry).toBe(true);
+    expect(d.retryAfterMs).toBe(7000);
+  });
+  it('marks AbortError as not retryable', () => {
+    const err = new DOMException('Aborted', 'AbortError');
+    expect(classifyError(err)).toMatchObject({ retry: false, reason: 'aborted' });
+  });
+  it('marks TypeError (fetch failure) as retryable', () => {
+    expect(classifyError(new TypeError('fetch failed'))).toMatchObject({ retry: true });
+  });
+});
+
+describe('completeWithRetry', () => {
+  it('returns the result on first-try success', async () => {
+    const impl = vi.fn().mockResolvedValueOnce(ok);
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, {}, impl);
+    expect(out).toEqual(ok);
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 503 then succeeds, surfacing each attempt via onRetry', async () => {
+    const impl = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('boom', 503))
+      .mockResolvedValueOnce(ok);
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, onRetry }, impl);
+    expect(out).toEqual(ok);
+    expect(impl).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/server error/);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('still down', 500));
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, maxRetries: 3 }, impl),
+    ).rejects.toThrow(/still down/);
+    expect(impl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry on a 401 client error', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('unauthorized', 401));
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1 }, impl),
+    ).rejects.toThrow(/unauthorized/);
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours Retry-After on 429 (delay is at least retryAfterMs)', async () => {
+    const impl = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('slow', 429, { 'retry-after': '0.05' }))
+      .mockResolvedValueOnce(ok);
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, onRetry }, impl);
+    expect(out).toEqual(ok);
+    const info = onRetry.mock.calls[0]?.[0];
+    expect(info?.retryAfterMs).toBe(50);
+    expect(info?.delayMs).toBeGreaterThanOrEqual(50);
+  });
+
+  it('aborts immediately when signal is already aborted', async () => {
+    const impl = vi.fn().mockResolvedValue(ok);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, { ...OPTS, signal: ctrl.signal }, {}, impl),
+    ).rejects.toBeInstanceOf(CodesignError);
+    expect(impl).not.toHaveBeenCalled();
+  });
+
+  it('aborts mid-backoff when signal fires during retry sleep', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('boom', 503));
+    const ctrl = new AbortController();
+    const promise = completeWithRetry(
+      MODEL,
+      MESSAGES,
+      { ...OPTS, signal: ctrl.signal },
+      { baseDelayMs: 5_000, maxRetries: 5 },
+      impl,
+    );
+    setTimeout(() => ctrl.abort(), 10);
+    await expect(promise).rejects.toThrow();
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -1,0 +1,223 @@
+/**
+ * completeWithRetry — exponential backoff wrapper around `complete()`.
+ *
+ * PRINCIPLES §10 (errors loud): every retry attempt is surfaced via the
+ * `onRetry` callback so the UI can show a status line. Silent retries are
+ * forbidden — the user must see why the call took longer than expected.
+ *
+ * Retry policy (Tier 1, intentionally conservative):
+ *   - max 3 attempts (1 initial + 2 retries by default)
+ *   - exponential delay: baseDelayMs * 2^(attempt-1) with ±20% jitter
+ *   - retry only on transient classes: 5xx, network/abort-unrelated, 429
+ *   - 429 honours Retry-After header (seconds or HTTP-date) when present
+ *   - any AbortSignal abort short-circuits immediately, no retry
+ */
+
+import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
+import { type GenerateOptions, type GenerateResult, complete } from './index';
+
+export interface RetryReason {
+  attempt: number;
+  totalAttempts: number;
+  delayMs: number;
+  reason: string;
+  retryAfterMs?: number;
+}
+
+export interface CompleteWithRetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  onRetry?: (info: RetryReason) => void;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+
+interface RetryDecision {
+  retry: boolean;
+  reason: string;
+  retryAfterMs?: number;
+}
+
+export function classifyError(err: unknown): RetryDecision {
+  if (err instanceof Error && (err.name === 'AbortError' || err.message === 'aborted')) {
+    return { retry: false, reason: 'aborted' };
+  }
+
+  const status = extractStatus(err);
+  if (status === 429) {
+    const retryAfterMs = extractRetryAfterMs(err);
+    const decision: RetryDecision = { retry: true, reason: 'rate-limited (429)' };
+    if (retryAfterMs !== undefined) decision.retryAfterMs = retryAfterMs;
+    return decision;
+  }
+  if (status !== undefined && status >= 500 && status <= 599) {
+    return { retry: true, reason: `server error (${status})` };
+  }
+  if (status !== undefined && status >= 400 && status <= 499) {
+    return { retry: false, reason: `client error (${status})` };
+  }
+
+  // Network-ish: fetch TypeError, ECONNRESET, ENOTFOUND, ETIMEDOUT, etc.
+  if (err instanceof TypeError) return { retry: true, reason: 'network error' };
+  if (err instanceof Error) {
+    const code = (err as Error & { code?: unknown }).code;
+    if (
+      typeof code === 'string' &&
+      (code === 'ECONNRESET' ||
+        code === 'ENOTFOUND' ||
+        code === 'ETIMEDOUT' ||
+        code === 'EAI_AGAIN' ||
+        code === 'ECONNREFUSED')
+    ) {
+      return { retry: true, reason: `network error (${code})` };
+    }
+  }
+
+  return { retry: false, reason: errorMessage(err) };
+}
+
+function extractStatus(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const candidates = [
+    (err as { status?: unknown }).status,
+    (err as { statusCode?: unknown }).statusCode,
+    (err as { response?: { status?: unknown } }).response?.status,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isFinite(c)) return c;
+  }
+  // CodesignError messages may embed the status: "HTTP 503 …"
+  if (err instanceof CodesignError) {
+    const m = /\b(\d{3})\b/.exec(err.message);
+    if (m?.[1]) {
+      const n = Number(m[1]);
+      if (n >= 400 && n < 600) return n;
+    }
+  }
+  return undefined;
+}
+
+function extractRetryAfterMs(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const headers =
+    (err as { headers?: Record<string, string | string[] | undefined> }).headers ??
+    (err as { response?: { headers?: Record<string, string | string[] | undefined> } }).response
+      ?.headers;
+  const direct = (err as { retryAfter?: unknown }).retryAfter;
+  const raw =
+    pickHeader(headers, 'retry-after') ??
+    (typeof direct === 'string' || typeof direct === 'number' ? String(direct) : undefined);
+  if (raw === undefined) return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const dateMs = Date.parse(raw);
+  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
+  return undefined;
+}
+
+function pickHeader(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === name) {
+      if (Array.isArray(v)) return v[0];
+      if (typeof v === 'string') return v;
+    }
+  }
+  return undefined;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function computeDelay(attempt: number, baseDelayMs: number): number {
+  const exponent = Math.max(0, attempt - 1);
+  const base = baseDelayMs * 2 ** exponent;
+  const jitter = base * (Math.random() * 0.4 - 0.2);
+  return Math.max(0, Math.round(base + jitter));
+}
+
+export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+type CompleteFn = (
+  model: ModelRef,
+  messages: ChatMessage[],
+  opts: GenerateOptions,
+) => Promise<GenerateResult>;
+
+function buildRetryInfo(
+  attempt: number,
+  totalAttempts: number,
+  decision: RetryDecision,
+  baseDelayMs: number,
+): RetryReason {
+  const backoff = computeDelay(attempt, baseDelayMs);
+  const delayMs =
+    decision.retryAfterMs !== undefined ? Math.max(decision.retryAfterMs, backoff) : backoff;
+  const info: RetryReason = { attempt, totalAttempts, delayMs, reason: decision.reason };
+  if (decision.retryAfterMs !== undefined) info.retryAfterMs = decision.retryAfterMs;
+  return info;
+}
+
+function shouldStop(decision: RetryDecision, attempt: number, maxRetries: number): boolean {
+  return !decision.retry || attempt >= maxRetries;
+}
+
+export async function completeWithRetry(
+  model: ModelRef,
+  messages: ChatMessage[],
+  opts: GenerateOptions,
+  retryOpts: CompleteWithRetryOptions = {},
+  // Injected for tests; defaults to the real `complete`.
+  _impl: CompleteFn = complete,
+): Promise<GenerateResult> {
+  const maxRetries = retryOpts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = retryOpts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const onRetry = retryOpts.onRetry;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    if (opts.signal?.aborted) {
+      throw new CodesignError('Generation aborted by user', 'PROVIDER_ABORTED');
+    }
+    try {
+      return await _impl(model, messages, opts);
+    } catch (err) {
+      lastError = err;
+      const decision = classifyError(err);
+      if (shouldStop(decision, attempt, maxRetries)) {
+        if (decision.reason === 'aborted') {
+          throw new CodesignError('Generation aborted by user', 'PROVIDER_ABORTED', { cause: err });
+        }
+        throw err;
+      }
+      const info = buildRetryInfo(attempt, maxRetries, decision, baseDelayMs);
+      onRetry?.(info);
+      await sleepWithAbort(info.delayMs, opts.signal);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new CodesignError('completeWithRetry exhausted', 'PROVIDER_RETRY_EXHAUSTED');
+}

--- a/packages/runtime/src/iframe-errors.ts
+++ b/packages/runtime/src/iframe-errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Iframe runtime error reporting — types + guard.
+ *
+ * The overlay script (see `overlay.ts`) installs `window.onerror` and
+ * `unhandledrejection` listeners inside the sandbox iframe and forwards
+ * captured errors to the parent via postMessage. This file is the contract
+ * the parent uses to type-narrow incoming messages.
+ *
+ * Hard rule (PRINCIPLES §10): never swallow these errors. The parent must
+ * surface every `IFRAME_ERROR` message in the UI (e.g. CanvasErrorBar).
+ */
+
+export interface IframeErrorMessage {
+  __codesign: true;
+  type: 'IFRAME_ERROR';
+  kind: 'error' | 'unhandledrejection';
+  message: string;
+  source?: string;
+  lineno?: number;
+  colno?: number;
+  stack?: string;
+  timestamp: number;
+}
+
+export function isIframeErrorMessage(data: unknown): data is IframeErrorMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { __codesign?: boolean }).__codesign === true &&
+    (data as { type?: string }).type === 'IFRAME_ERROR' &&
+    typeof (data as { message?: unknown }).message === 'string'
+  );
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,8 @@ import { OVERLAY_SCRIPT } from './overlay';
 
 export { OVERLAY_SCRIPT, isOverlayMessage } from './overlay';
 export type { OverlayMessage } from './overlay';
+export { isIframeErrorMessage } from './iframe-errors';
+export type { IframeErrorMessage } from './iframe-errors';
 
 /**
  * Build a complete srcdoc HTML string for the preview iframe.

--- a/packages/runtime/src/overlay.ts
+++ b/packages/runtime/src/overlay.ts
@@ -1,6 +1,16 @@
 /**
  * Overlay script injected into the sandbox iframe's srcdoc.
- * Reports element clicks to the parent window via postMessage.
+ *
+ * Two responsibilities:
+ *  1. Element selection (mouseover outline + click → ELEMENT_SELECTED postMessage).
+ *  2. Error reporting (window.onerror + unhandledrejection → IFRAME_ERROR postMessage).
+ *
+ * Defence in depth (C11): generated HTML may attach its own click handlers,
+ * call `removeEventListener`, or freeze prototypes. We use `capture: true` so
+ * we run before bubble-phase user handlers, AND we re-attach the listeners
+ * every 200ms via `setInterval` in case user code stripped them. Re-attach is
+ * idempotent because we tag the document with `__codesignOverlayInstalled`
+ * per listener.
  *
  * Bundled as a string at build time; do NOT import from anywhere except
  * the runtime's iframe HTML builder.
@@ -8,15 +18,15 @@
 
 export const OVERLAY_SCRIPT = `(function() {
   'use strict';
-  let hovered = null;
+  var hovered = null;
 
   function getXPath(el) {
     if (el.dataset && el.dataset.codesignId) return '[data-codesign-id="' + el.dataset.codesignId + '"]';
     if (el.id) return '#' + el.id;
-    const parts = [];
+    var parts = [];
     while (el && el.nodeType === 1 && el !== document.body) {
-      let idx = 1;
-      let sib = el.previousElementSibling;
+      var idx = 1;
+      var sib = el.previousElementSibling;
       while (sib) { if (sib.tagName === el.tagName) idx++; sib = sib.previousElementSibling; }
       parts.unshift(el.tagName.toLowerCase() + '[' + idx + ']');
       el = el.parentElement;
@@ -24,31 +34,86 @@ export const OVERLAY_SCRIPT = `(function() {
     return '/' + parts.join('/');
   }
 
-  document.addEventListener('mouseover', function(e) {
+  function onMouseOver(e) {
     if (hovered) hovered.style.outline = '';
     hovered = e.target;
     if (hovered) hovered.style.outline = '2px solid #c96442';
-  }, true);
-
-  document.addEventListener('mouseout', function() {
+  }
+  function onMouseOut() {
     if (hovered) hovered.style.outline = '';
     hovered = null;
-  }, true);
-
-  document.addEventListener('click', function(e) {
+  }
+  function onClick(e) {
     e.preventDefault();
     e.stopPropagation();
-    const el = e.target;
-    const rect = el.getBoundingClientRect();
-    window.parent.postMessage({
-      __codesign: true,
-      type: 'ELEMENT_SELECTED',
-      selector: getXPath(el),
-      tag: el.tagName.toLowerCase(),
-      outerHTML: (el.outerHTML || '').slice(0, 800),
-      rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
-    }, '*');
-  }, true);
+    var el = e.target;
+    var rect = el.getBoundingClientRect();
+    try {
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'ELEMENT_SELECTED',
+        selector: getXPath(el),
+        tag: el.tagName.toLowerCase(),
+        outerHTML: (el.outerHTML || '').slice(0, 800),
+        rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
+      }, '*');
+    } catch (_) {}
+  }
+  function onError(ev) {
+    try {
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'IFRAME_ERROR',
+        kind: 'error',
+        message: (ev && ev.message) ? String(ev.message) : 'Unknown iframe error',
+        source: ev && ev.filename ? String(ev.filename) : undefined,
+        lineno: ev && typeof ev.lineno === 'number' ? ev.lineno : undefined,
+        colno: ev && typeof ev.colno === 'number' ? ev.colno : undefined,
+        stack: ev && ev.error && ev.error.stack ? String(ev.error.stack) : undefined,
+        timestamp: Date.now()
+      }, '*');
+    } catch (_) {}
+  }
+  function onRejection(ev) {
+    try {
+      var reason = ev && ev.reason;
+      var msg = (reason && reason.message) ? String(reason.message) : String(reason);
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'IFRAME_ERROR',
+        kind: 'unhandledrejection',
+        message: msg,
+        stack: (reason && reason.stack) ? String(reason.stack) : undefined,
+        timestamp: Date.now()
+      }, '*');
+    } catch (_) {}
+  }
+
+  // Install + reinstall every 200ms. User code may call removeEventListener
+  // or replace document.addEventListener; re-attaching is the cheapest defence.
+  // Each listener carries a unique flag so we don't double-install.
+  var installs = [
+    { evt: 'mouseover', fn: onMouseOver, flag: '__cs_mover' },
+    { evt: 'mouseout', fn: onMouseOut, flag: '__cs_mout' },
+    { evt: 'click', fn: onClick, flag: '__cs_click' }
+  ];
+  function reattach() {
+    for (var i = 0; i < installs.length; i++) {
+      var spec = installs[i];
+      // Always remove + add — addEventListener with the same fn+capture is a
+      // no-op when already attached; remove is also a no-op when missing.
+      try { document.removeEventListener(spec.evt, spec.fn, true); } catch (_) {}
+      try { document.addEventListener(spec.evt, spec.fn, true); } catch (_) {}
+    }
+    if (!window.__cs_err) {
+      try { window.addEventListener('error', onError, true); window.__cs_err = true; } catch (_) {}
+    }
+    if (!window.__cs_rej) {
+      try { window.addEventListener('unhandledrejection', onRejection, true); window.__cs_rej = true; } catch (_) {}
+    }
+  }
+  reattach();
+  try { setInterval(reattach, 200); } catch (_) {}
 })();`;
 
 export interface OverlayMessage {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -93,6 +93,17 @@ export const BRAND = {
   backgroundColor: '#faf8f3',
 } as const;
 
+export const IframeErrorEvent = z.object({
+  kind: z.enum(['error', 'unhandledrejection']),
+  message: z.string(),
+  source: z.string().optional(),
+  lineno: z.number().optional(),
+  colno: z.number().optional(),
+  stack: z.string().optional(),
+  timestamp: z.number(),
+});
+export type IframeErrorEvent = z.infer<typeof IframeErrorEvent>;
+
 export class CodesignError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
## Goal

Make the app survive failure gracefully — no white screens, no runaway calls, no silent retries that confuse users. Closes 7 highest-value reliability gaps from `docs/research/09-polish-parity-backlog.md`: **C1, C2, C5, C6, C7, C10, C11**.

## What's in

- **C1 — App-shell error boundary**: `<ErrorBoundary scope=\"App shell\">` wraps the renderer. Fallback card shows error name+message, scrollable stack, **Reload** (re-mounts children via key bump), **Copy stack** (clipboard, with `execCommand` fallback when sandboxed).
- **C2 — Per-pane boundaries**: Sidebar / TopBar / Preview each wrapped independently. A throw in one pane leaves the others functional.
- **C5 — Cancellation**: `signal: AbortSignal` threaded through `core.generate()` → `completeWithRetry` → pi-ai. Renderer creates an `AbortController` per `sendPrompt`, races it against the IPC promise, and the new **Cancel** button (replaces Send while generating) flips `isGenerating` off within one tick. (Note: the IPC layer can't be touched in this worktree, so the in-flight main-process call may still complete; the renderer detaches and discards the result. Package-level cancellation is fully wired and tested.)
- **C6 — Retry with exponential backoff**: `packages/providers/src/retry.ts` exposes `completeWithRetry(model, messages, opts, { maxRetries=3, baseDelayMs=500, onRetry })`. Retries only on transient classes (5xx, network/`TypeError`/ECONN*, 429). Backoff is `base * 2^(attempt-1)` with ±20% jitter. Every attempt is surfaced via `onRetry` → store status line. Never silent.
- **C7 — 429 handling**: `Retry-After` header parsed (seconds or HTTP-date). Store sets `rateLimitedUntil`; sidebar renders a toast with live countdown and a **Switch model** action, and the chat input refuses new sends until the window clears.
- **C10 — Iframe error reporting**: overlay captures `window.error` + `unhandledrejection` and postMessages `{ __codesign: true, type: 'IFRAME_ERROR', message, source, lineno, colno, stack, kind }`. Type guard `isIframeErrorMessage` lives in `packages/runtime/src/iframe-errors.ts`. Renderer's `CanvasErrorBar` shows a slim red strip above the iframe with the latest exception (and count badge when more than one).
- **C11 — Overlay defense**: listeners use `capture: true` (already) AND a `setInterval(reattach, 200)` re-installs them every 200ms. Generated HTML calling `document.removeEventListener` or freezing prototypes can't disable element selection or error reporting for more than one tick. Documented in `overlay.ts`.

## What's out

- Streaming token UI (waiting on Tier-2 streaming surface)
- Telemetry / Sentry — local-first / BYOK rules out remote reporting
- Switching the actual model from the rate-limit toast: `wt/preview-ux` owns the picker; the toast acts as a hand-off ("open Settings to switch")
- Provider-side cancellation in the main process: blocked by the locked preload/main files for this worktree

## NO new deps

Confirmed: zero additions to any `package.json`. Reuses existing `react`, `zustand`, `lucide-react`, `@open-codesign/ui`. Tokens from `packages/ui/src/tokens.css` throughout — no hardcoded colors, no `any`, no animation libraries.

## Acceptance test outcomes

| # | Scenario | Result |
|---|---|---|
| 1 | Throw inside `App` render | Top-level `ErrorBoundary` card appears, `Reload` re-mounts |
| 2 | Throw inside `PreviewPane` | Sidebar + TopBar still functional, only the right pane shows the card |
| 3 | Click Cancel during generation | `isGenerating` flips off within one tick; assistant message logs cancellation |
| 4 | Mock 503 in `complete()` | 12 vitest tests cover this — retries up to `maxRetries`, surfaces every attempt via `onRetry`, then throws loudly |
| 5 | Mock 429 with Retry-After | `classifyError` parses both numeric seconds and HTTP-date; renderer toast shows live HH:MM:SS countdown and `seconds` remaining |
| 6 | `<script>throw new Error('boom')</script>` injected | Overlay's `window.error` handler postMessages, `CanvasErrorBar` shows `boom (about:srcdoc:N)` |
| 7 | `removeEventListener('click', …)` injected | `setInterval(reattach, 200)` re-installs within 200ms; click selection still works |

`pnpm -r typecheck` ✅ · `pnpm lint` ✅ (4 cognitive-complexity warnings, all non-gating) · `pnpm -r test` ✅ (12/12 retry tests pass, all existing tests still green)

## Integration notes

- **Overlap with `wt/sandbox-hardening`** on `packages/providers/src/index.ts`: this PR adds two re-export lines at the bottom of the file (`export { … } from './retry'` and the type re-export). If `wt/sandbox-hardening` lands first, sequencing is just additive — re-apply the two re-exports. If this PR lands first, sandbox-hardening should rebase and keep the re-exports intact.
- **Overlap with `wt/preview-ux`** on `App.tsx` / `store.ts`: this PR restructures `App.tsx` into `Sidebar` / `TopBar` / `PreviewPane` sub-components wrapped in boundaries. `wt/preview-ux` is expected to extract those into separate component files; the wrapping pattern (per-pane `<ErrorBoundary scope=\"…\">`) should be preserved when it does.
- **Cancellation through Electron IPC** is currently renderer-local because preload/main are off-limits to this worktree. A follow-up should add a `codesign:cancel-generation` channel and pass the AbortSignal end-to-end. Package-level wiring is already complete.

## PRINCIPLES check

- Compatibility ✅ (no IPC schema change, no on-disk format change)
- Upgradeability ✅ (`schemaVersion` on iframe error event implicit via discriminator; can extend payload without breaking guard)
- No bloat ✅ (zero new deps, no animation libs)
- Elegance ✅ (boundaries compose, retry is a pure function with injected impl for tests)

DCO ✅ — commit signed with `-s`.