### PR TITLE
feat(exporters): real PDF/PPTX/ZIP via system Chrome + pptxgenjs + zip-lib (lazy-loaded)

### DIFF
--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -56,9 +56,8 @@ export function registerExporterIpc(getWindow: () => BrowserWindow | null): void
       return { status: 'cancelled' };
     }
 
-    // Tier 1: HTML succeeds, others throw EXPORTER_NOT_READY. We deliberately
-    // do NOT swallow the error here — let it propagate so the renderer can
-    // surface it as a toast (PRINCIPLES §10).
+    // All four formats ship in tier 1; the heavy deps load lazily inside
+    // exportArtifact. Errors propagate to the renderer as toasts (PRINCIPLES §10).
     const result = await exportArtifact(req.format, req.htmlContent, picked.filePath);
     return { status: 'saved', path: result.path, bytes: result.bytes };
   });

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -11,10 +11,10 @@ interface ExportItem {
 }
 
 const EXPORT_ITEMS: ExportItem[] = [
-  { format: 'html', label: 'HTML', ready: true },
-  { format: 'pdf', label: 'PDF', ready: false, hint: 'Coming in Phase 2' },
-  { format: 'pptx', label: 'PPTX', ready: false, hint: 'Coming in Phase 2' },
-  { format: 'zip', label: 'ZIP bundle', ready: false, hint: 'Coming in Phase 2' },
+  { format: 'html', label: 'HTML', ready: true, hint: 'Single self-contained .html file' },
+  { format: 'pdf', label: 'PDF', ready: true, hint: 'Rendered via your installed Chrome' },
+  { format: 'pptx', label: 'PPTX', ready: true, hint: 'Editable slides; one per <section>' },
+  { format: 'zip', label: 'ZIP bundle', ready: true, hint: 'index.html + assets + README.md' },
 ];
 
 export function PreviewToolbar(): ReactElement {
@@ -74,7 +74,7 @@ export function PreviewToolbar(): ReactElement {
                 type="button"
                 role="menuitem"
                 disabled={!item.ready}
-                title={item.ready ? undefined : item.hint}
+                title={item.hint}
                 onClick={() => {
                   setOpen(false);
                   void exportActive(item.format);
@@ -82,8 +82,10 @@ export function PreviewToolbar(): ReactElement {
                 className="w-full flex items-center justify-between gap-3 px-3 py-2 text-[13px] text-left text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent disabled:cursor-not-allowed transition-colors duration-100"
               >
                 <span>{item.label}</span>
-                {!item.ready && (
-                  <span className="text-[11px] text-[var(--color-text-muted)]">{item.hint}</span>
+                {item.hint && (
+                  <span className="text-[11px] text-[var(--color-text-muted)] truncate max-w-[60%]">
+                    {item.hint}
+                  </span>
                 )}
               </button>
             ))}

--- a/packages/exporters/package.json
+++ b/packages/exporters/package.json
@@ -17,7 +17,10 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@open-codesign/shared": "workspace:*"
+    "@open-codesign/shared": "workspace:*",
+    "pptxgenjs": "^3.12.0",
+    "puppeteer-core": "^24.10.0",
+    "zip-lib": "^1.0.4"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/exporters/src/chrome-discovery.test.ts
+++ b/packages/exporters/src/chrome-discovery.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { findSystemChrome } from './chrome-discovery';
+
+const macPath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const winPath = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+const linuxPath = '/usr/bin/google-chrome';
+
+describe('findSystemChrome', () => {
+  it('finds Chrome on macOS at the canonical path', async () => {
+    const found = await findSystemChrome({
+      platform: 'darwin',
+      env: {},
+      fileExists: (p) => p === macPath,
+      which: () => null,
+    });
+    expect(found).toBe(macPath);
+  });
+
+  it('finds Chrome on Windows under ProgramFiles', async () => {
+    const found = await findSystemChrome({
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files' },
+      fileExists: (p) => p === winPath,
+      which: () => null,
+    });
+    expect(found).toBe(winPath);
+  });
+
+  it('finds Chrome on Linux via which()', async () => {
+    const found = await findSystemChrome({
+      platform: 'linux',
+      env: {},
+      fileExists: (p) => p === linuxPath,
+      which: (bin) => (bin === 'google-chrome-stable' ? linuxPath : null),
+    });
+    expect(found).toBe(linuxPath);
+  });
+
+  it('prefers CODESIGN_CHROME_PATH override when set', async () => {
+    const custom = '/opt/brave/brave';
+    const found = await findSystemChrome({
+      platform: 'darwin',
+      env: { CODESIGN_CHROME_PATH: custom },
+      fileExists: (p) => p === custom,
+      which: () => null,
+    });
+    expect(found).toBe(custom);
+  });
+
+  it('throws EXPORTER_NO_CHROME with install link when nothing is found', async () => {
+    await expect(
+      findSystemChrome({
+        platform: 'darwin',
+        env: {},
+        fileExists: () => false,
+        which: () => null,
+      }),
+    ).rejects.toMatchObject({
+      code: 'EXPORTER_NO_CHROME',
+      message: expect.stringContaining('https://www.google.com/chrome'),
+    });
+  });
+
+  it('throws on Linux when no candidate binary resolves', async () => {
+    await expect(
+      findSystemChrome({
+        platform: 'linux',
+        env: {},
+        fileExists: () => false,
+        which: () => null,
+      }),
+    ).rejects.toMatchObject({ code: 'EXPORTER_NO_CHROME' });
+  });
+});

--- a/packages/exporters/src/chrome-discovery.ts
+++ b/packages/exporters/src/chrome-discovery.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { CodesignError } from '@open-codesign/shared';
+
+/**
+ * Locate a system Chrome/Chromium binary. We refuse to bundle Chromium —
+ * PRINCIPLES §1 caps the installer at 80 MB and a Chrome download is ~150 MB.
+ * Throws `EXPORTER_NO_CHROME` (loud, with install link) when nothing is found.
+ */
+const CHROME_INSTALL_URL = 'https://www.google.com/chrome';
+
+const MAC_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+];
+
+const WIN_RELATIVE = [
+  'Google\\Chrome\\Application\\chrome.exe',
+  'Google\\Chrome Beta\\Application\\chrome.exe',
+  'Chromium\\Application\\chrome.exe',
+  'Microsoft\\Edge\\Application\\msedge.exe',
+];
+
+const LINUX_BINARIES = [
+  'google-chrome-stable',
+  'google-chrome',
+  'chromium-browser',
+  'chromium',
+  'microsoft-edge',
+];
+
+export interface ChromeDiscoveryDeps {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  fileExists?: (p: string) => boolean;
+  which?: (binary: string) => string | null;
+}
+
+export async function findSystemChrome(deps: ChromeDiscoveryDeps = {}): Promise<string> {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const fileExists = deps.fileExists ?? defaultFileExists;
+  const which = deps.which ?? defaultWhich;
+
+  const found = locate({ platform, env, fileExists, which });
+  if (found) return found;
+
+  throw new CodesignError(
+    `System Chrome not found. Install from ${CHROME_INSTALL_URL} (or any Chromium-based browser: Edge, Chromium).`,
+    'EXPORTER_NO_CHROME',
+  );
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: per-OS branching is inherently a switch — extracting per-OS helpers obscures the resolution order
+function locate(d: {
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  fileExists: (p: string) => boolean;
+  which: (binary: string) => string | null;
+}): string | null {
+  const override = d.env['CODESIGN_CHROME_PATH'];
+  if (override && d.fileExists(override)) return override;
+
+  if (d.platform === 'darwin') {
+    for (const p of MAC_PATHS) if (d.fileExists(p)) return p;
+    return null;
+  }
+  if (d.platform === 'win32') {
+    const roots = uniq([d.env['ProgramFiles'], d.env['ProgramFiles(x86)'], d.env['LOCALAPPDATA']]);
+    for (const root of roots) {
+      for (const rel of WIN_RELATIVE) {
+        const candidate = `${root}\\${rel}`;
+        if (d.fileExists(candidate)) return candidate;
+      }
+    }
+    return null;
+  }
+  for (const bin of LINUX_BINARIES) {
+    const resolved = d.which(bin);
+    if (resolved && d.fileExists(resolved)) return resolved;
+  }
+  return null;
+}
+
+function uniq(items: ReadonlyArray<string | undefined>): string[] {
+  const out: string[] = [];
+  for (const item of items) {
+    if (item && !out.includes(item)) out.push(item);
+  }
+  return out;
+}
+
+function defaultFileExists(p: string): boolean {
+  try {
+    return existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+function defaultWhich(binary: string): string | null {
+  try {
+    const out = execFileSync('which', [binary], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const path = out.trim();
+    return path.length > 0 ? path : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/exporters/src/index.ts
+++ b/packages/exporters/src/index.ts
@@ -2,8 +2,9 @@
  * Exporter entry point. Each format lives in its own subpath export and is
  * loaded lazily so the cold-start bundle stays lean (PRINCIPLES §1).
  *
- * Tier 1 ships HTML. PDF / PPTX / ZIP throw `CodesignError` with code
- * `EXPORTER_NOT_READY` — never silently succeed (PRINCIPLES §10).
+ * Tier 1 ships HTML, PDF, PPTX, and ZIP — all four lazy-loaded so the heavy
+ * runtime deps (`puppeteer-core`, `pptxgenjs`, `zip-lib`) only enter the
+ * module graph the first time a user actually exports.
  */
 
 import { CodesignError } from '@open-codesign/shared';
@@ -21,11 +22,14 @@ export interface ExportResult {
   path: string;
 }
 
-export function isExporterReady(format: ExporterFormat): boolean {
-  return format === 'html';
+export function isExporterReady(_format: ExporterFormat): boolean {
+  return true;
 }
 
 export type { ExportHtmlOptions } from './html';
+export type { ExportPdfOptions } from './pdf';
+export type { ExportPptxOptions } from './pptx';
+export type { ExportZipOptions, ZipAsset } from './zip';
 
 export async function exportHtml(
   htmlContent: string,
@@ -46,15 +50,15 @@ export async function exportArtifact(
   }
   if (format === 'pdf') {
     const mod = await import('./pdf');
-    return mod.exportPdf();
+    return mod.exportPdf(htmlContent, destinationPath);
   }
   if (format === 'pptx') {
     const mod = await import('./pptx');
-    return mod.exportPptx();
+    return mod.exportPptx(htmlContent, destinationPath);
   }
   if (format === 'zip') {
     const mod = await import('./zip');
-    return mod.exportZip();
+    return mod.exportZip(htmlContent, destinationPath);
   }
   throw new CodesignError(`Unknown exporter format: ${format as string}`, 'EXPORTER_UNKNOWN');
 }

--- a/packages/exporters/src/pdf.test.ts
+++ b/packages/exporters/src/pdf.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const fakePdfBytes = Buffer.from('%PDF-1.4 fake');
+
+const launchMock = vi.fn();
+const newPageMock = vi.fn();
+const setViewportMock = vi.fn();
+const setContentMock = vi.fn();
+const pdfMock = vi.fn();
+const closeMock = vi.fn();
+const evaluateMock = vi.fn();
+
+vi.mock('puppeteer-core', () => ({
+  default: { launch: launchMock },
+}));
+
+vi.mock('./chrome-discovery', () => ({
+  findSystemChrome: vi.fn(
+    async () => '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ),
+}));
+
+let tempDir = '';
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'codesign-pdf-test-'));
+  launchMock.mockResolvedValue({
+    newPage: newPageMock,
+    close: closeMock,
+  });
+  newPageMock.mockResolvedValue({
+    setViewport: setViewportMock,
+    setContent: setContentMock,
+    pdf: pdfMock,
+    evaluate: evaluateMock,
+  });
+  pdfMock.mockResolvedValue(fakePdfBytes);
+  evaluateMock.mockResolvedValue(2400);
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('exportPdf', () => {
+  it('writes a PDF via puppeteer-core against the discovered Chrome', async () => {
+    const { exportPdf } = await import('./pdf');
+    const dest = join(tempDir, 'out.pdf');
+    const result = await exportPdf('<h1>hi</h1>', dest);
+
+    expect(launchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executablePath: expect.stringContaining('Chrome'),
+        headless: true,
+      }),
+    );
+    expect(setContentMock).toHaveBeenCalledWith(
+      '<h1>hi</h1>',
+      expect.objectContaining({ waitUntil: 'networkidle0' }),
+    );
+    expect(pdfMock).toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(result.path).toBe(dest);
+    expect(result.bytes).toBe(fakePdfBytes.length);
+  });
+
+  it('respects a chromePath override (no discovery call needed)', async () => {
+    launchMock.mockClear();
+    const { exportPdf } = await import('./pdf');
+    const dest = join(tempDir, 'override.pdf');
+    await exportPdf('<p>x</p>', dest, { chromePath: '/tmp/fake-chrome' });
+    expect(launchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ executablePath: '/tmp/fake-chrome' }),
+    );
+  });
+
+  it('wraps puppeteer failures in EXPORTER_PDF_FAILED', async () => {
+    pdfMock.mockRejectedValueOnce(new Error('boom'));
+    const { exportPdf } = await import('./pdf');
+    await expect(exportPdf('<p>x</p>', join(tempDir, 'fail.pdf'))).rejects.toMatchObject({
+      code: 'EXPORTER_PDF_FAILED',
+    });
+  });
+});

--- a/packages/exporters/src/pdf.ts
+++ b/packages/exporters/src/pdf.ts
@@ -1,9 +1,70 @@
 import { CodesignError } from '@open-codesign/shared';
+import type { ExportResult } from './index';
+
+export interface ExportPdfOptions {
+  /** Override the discovered Chrome binary path. Useful for tests / CI. */
+  chromePath?: string;
+  /**
+   * Page format. Defaults to 'Letter'. Pass 'auto' to render the page as
+   * a single tall sheet (no pagination) which is what Claude Design does
+   * for HTML prototypes that aren't paginated.
+   */
+  format?: 'Letter' | 'A4' | 'auto';
+}
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 } as const;
 
 /**
- * Tier 2 — Chromium print-to-PDF via Electron's offscreen `webContents`.
- * Throws loudly so callers cannot mistake "not yet shipped" for "succeeded silently".
+ * Render an HTML string to PDF via the user's installed Chrome.
+ *
+ * Tier 1: no header/footer, no font embedding, no PDF tagging. We deliberately
+ * avoid Puppeteer's full distribution (~150 MB Chromium download) — `puppeteer-core`
+ * connects to the system Chrome we discover at runtime. PRINCIPLES §1 + §10.
  */
-export async function exportPdf(): Promise<never> {
-  throw new CodesignError('PDF export ships in Phase 2', 'EXPORTER_NOT_READY');
+export async function exportPdf(
+  htmlContent: string,
+  destinationPath: string,
+  opts: ExportPdfOptions = {},
+): Promise<ExportResult> {
+  const fs = await import('node:fs/promises');
+  const { findSystemChrome } = await import('./chrome-discovery');
+  const puppeteer = (await import('puppeteer-core')).default;
+
+  const executablePath = opts.chromePath ?? (await findSystemChrome());
+
+  let browser: Awaited<ReturnType<typeof puppeteer.launch>> | null = null;
+  try {
+    browser = await puppeteer.launch({
+      executablePath,
+      headless: true,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    });
+    const page = await browser.newPage();
+    await page.setViewport(DEFAULT_VIEWPORT);
+    await page.setContent(htmlContent, { waitUntil: 'networkidle0', timeout: 30_000 });
+
+    const format = opts.format ?? 'Letter';
+    const pdfBuf =
+      format === 'auto'
+        ? await page.pdf({
+            printBackground: true,
+            width: `${DEFAULT_VIEWPORT.width}px`,
+            height: `${await page.evaluate('document.documentElement.scrollHeight')}px`,
+            margin: { top: '0', right: '0', bottom: '0', left: '0' },
+          })
+        : await page.pdf({ printBackground: true, format, preferCSSPageSize: true });
+
+    await fs.writeFile(destinationPath, pdfBuf);
+    const stat = await fs.stat(destinationPath);
+    return { bytes: stat.size, path: destinationPath };
+  } catch (err) {
+    if (err instanceof CodesignError) throw err;
+    throw new CodesignError(
+      `PDF export failed: ${err instanceof Error ? err.message : String(err)}`,
+      'EXPORTER_PDF_FAILED',
+      { cause: err },
+    );
+  } finally {
+    if (browser) await browser.close();
+  }
 }

--- a/packages/exporters/src/pptx.test.ts
+++ b/packages/exporters/src/pptx.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { exportPptx, extractSlides } from './pptx';
+
+let tempDir = '';
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'codesign-pptx-test-'));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('extractSlides', () => {
+  it('treats each <section> as a slide and pulls the heading + bullets', () => {
+    const html = `
+      <section><h1>One</h1><ul><li>alpha</li><li>beta</li></ul></section>
+      <section><h2>Two</h2><p>paragraph body</p></section>
+    `;
+    const slides = extractSlides(html);
+    expect(slides).toHaveLength(2);
+    expect(slides[0]).toEqual({ title: 'One', bullets: ['alpha', 'beta'] });
+    expect(slides[1]).toEqual({ title: 'Two', bullets: ['paragraph body'] });
+  });
+
+  it('falls back to a single slide when no <section> exists', () => {
+    const slides = extractSlides('<h1>Solo</h1><p>body</p>');
+    expect(slides).toEqual([{ title: 'Solo', bullets: ['body'] }]);
+  });
+
+  it('preserves CJK characters end-to-end', () => {
+    const slides = extractSlides('<section><h1>你好</h1><p>世界</p></section>');
+    expect(slides[0]).toEqual({ title: '你好', bullets: ['世界'] });
+  });
+
+  it('strips inline <style> and <script> blocks from text content', () => {
+    const slides = extractSlides(
+      '<section><h1>x</h1><style>h1{color:red}</style><p>visible</p></section>',
+    );
+    expect(slides[0]?.bullets).toEqual(['visible']);
+  });
+});
+
+describe('exportPptx', () => {
+  it('writes a real .pptx with a CJK slide that downstream tools can open', async () => {
+    const dest = join(tempDir, 'cjk.pptx');
+    const result = await exportPptx(
+      '<section><h1>你好世界</h1><p>第一张幻灯片</p></section>',
+      dest,
+      { deckTitle: 'CJK smoke test' },
+    );
+
+    expect(existsSync(dest)).toBe(true);
+    expect(result.path).toBe(dest);
+    expect(result.bytes).toBeGreaterThan(1000);
+
+    const { readFile } = await import('node:fs/promises');
+    const buf = await readFile(dest);
+    // PPTX is a zip; magic bytes are PK\x03\x04
+    expect(buf[0]).toBe(0x50);
+    expect(buf[1]).toBe(0x4b);
+  }, 20_000);
+
+  it('throws EXPORTER_PPTX_FAILED on writeFile errors', async () => {
+    await expect(
+      exportPptx('<section>x</section>', join(tempDir, 'nope', 'missing-dir', 'fail.pptx')),
+    ).rejects.toMatchObject({ code: 'EXPORTER_PPTX_FAILED' });
+  });
+});

--- a/packages/exporters/src/pptx.ts
+++ b/packages/exporters/src/pptx.ts
@@ -1,9 +1,144 @@
 import { CodesignError } from '@open-codesign/shared';
+import type { ExportResult } from './index';
+
+export interface ExportPptxOptions {
+  /** Slide title shown in PowerPoint's outline view. */
+  deckTitle?: string;
+}
+
+interface SlideContent {
+  title: string;
+  bullets: string[];
+}
 
 /**
- * Tier 2 — wired through `dom-to-pptx` once research/04 is implemented.
- * Throws loudly so callers cannot mistake "not yet shipped" for "succeeded silently".
+ * Render an HTML artifact to PPTX using pptxgenjs.
+ *
+ * Tier 1 strategy: walk top-level `<section>` elements (one slide each); if
+ * none exist, the whole document becomes a single slide. We do NOT use
+ * dom-to-pptx in tier 1 — the package is unmaintained and only adds
+ * editability for pure-text slides we already cover.
+ *
+ * CJK fix: per research/04, the dom-to-pptx wrap bug is sidestepped by
+ * keeping pptxgenjs' default `wrap=square` and explicitly enabling
+ * `fit: 'shrink'` (emits `normAutofit`). Verified with PowerPoint Mac.
  */
-export async function exportPptx(): Promise<never> {
-  throw new CodesignError('PPTX export ships in Phase 2', 'EXPORTER_NOT_READY');
+export async function exportPptx(
+  htmlContent: string,
+  destinationPath: string,
+  opts: ExportPptxOptions = {},
+): Promise<ExportResult> {
+  const fs = await import('node:fs/promises');
+  const PptxGenJS = (await import('pptxgenjs')).default;
+
+  try {
+    const slides = extractSlides(htmlContent);
+    const pres = new PptxGenJS();
+    pres.layout = 'LAYOUT_WIDE';
+    if (opts.deckTitle) pres.title = opts.deckTitle;
+
+    for (const s of slides) {
+      const slide = pres.addSlide();
+      slide.background = { color: 'FFFFFF' };
+      if (s.title) {
+        slide.addText(s.title, {
+          x: 0.5,
+          y: 0.4,
+          w: 12,
+          h: 1,
+          fontSize: 32,
+          bold: true,
+          color: '111111',
+          fontFace: 'Helvetica',
+          wrap: true,
+          fit: 'shrink',
+        });
+      }
+      if (s.bullets.length > 0) {
+        slide.addText(
+          s.bullets.map((b) => ({ text: b, options: { bullet: true } })),
+          {
+            x: 0.5,
+            y: 1.6,
+            w: 12,
+            h: 5.5,
+            fontSize: 18,
+            color: '333333',
+            fontFace: 'Helvetica',
+            wrap: true,
+            fit: 'shrink',
+            valign: 'top',
+            paraSpaceAfter: 8,
+          },
+        );
+      }
+    }
+
+    await pres.writeFile({ fileName: destinationPath });
+    const stat = await fs.stat(destinationPath);
+    return { bytes: stat.size, path: destinationPath };
+  } catch (err) {
+    throw new CodesignError(
+      `PPTX export failed: ${err instanceof Error ? err.message : String(err)}`,
+      'EXPORTER_PPTX_FAILED',
+      { cause: err },
+    );
+  }
+}
+
+const SECTION_RE = /<section\b[^>]*>([\s\S]*?)<\/section>/gi;
+const TAG_RE = /<[^>]+>/g;
+const HEADING_RE = /<h[1-3]\b[^>]*>([\s\S]*?)<\/h[1-3]>/i;
+const LIST_ITEM_RE = /<li\b[^>]*>([\s\S]*?)<\/li>/gi;
+const PARAGRAPH_RE = /<p\b[^>]*>([\s\S]*?)<\/p>/gi;
+
+export function extractSlides(html: string): SlideContent[] {
+  const sections: string[] = [];
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((m = SECTION_RE.exec(html)) !== null) sections.push(m[1] ?? '');
+  if (sections.length === 0) sections.push(html);
+  return sections.map(parseSlide);
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: HTML-to-slide extraction is a small state machine; splitting hides the priority order (heading → li → p → fallback)
+function parseSlide(fragment: string): SlideContent {
+  const headingMatch = HEADING_RE.exec(fragment);
+  const title = headingMatch ? stripHtml(headingMatch[1] ?? '') : '';
+
+  const bullets: string[] = [];
+  let li: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+  while ((li = LIST_ITEM_RE.exec(fragment)) !== null) {
+    const text = stripHtml(li[1] ?? '');
+    if (text) bullets.push(text);
+  }
+  if (bullets.length === 0) {
+    let p: RegExpExecArray | null;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration
+    while ((p = PARAGRAPH_RE.exec(fragment)) !== null) {
+      const text = stripHtml(p[1] ?? '');
+      if (text) bullets.push(text);
+    }
+  }
+  if (bullets.length === 0 && !title) {
+    const text = stripHtml(fragment);
+    if (text) bullets.push(text);
+  }
+  return { title, bullets };
+}
+
+function stripHtml(s: string): string {
+  return s
+    .replace(/<style\b[\s\S]*?<\/style>/gi, '')
+    .replace(/<script\b[\s\S]*?<\/script>/gi, '')
+    .replace(TAG_RE, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/packages/exporters/src/zip.test.ts
+++ b/packages/exporters/src/zip.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { exportZip } from './zip';
+
+let tempDir = '';
+
+beforeAll(() => {
+  tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'codesign-zip-test-')));
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('exportZip', () => {
+  it('writes a multi-asset bundle with index.html, README.md and assets/', async () => {
+    const dest = join(tempDir, 'bundle.zip');
+    const result = await exportZip('<h1>hi</h1>', dest, {
+      assets: [
+        { path: 'assets/logo.svg', content: '<svg></svg>' },
+        { path: 'assets/data.bin', content: Buffer.from([1, 2, 3, 4]) },
+      ],
+      readmeTitle: 'Test bundle',
+    });
+
+    expect(existsSync(dest)).toBe(true);
+    expect(result.bytes).toBeGreaterThan(100);
+
+    const { Unzip } = await import('zip-lib');
+    const extractDir = join(tempDir, 'extracted');
+    const unzip = new Unzip();
+    await unzip.extract(dest, extractDir);
+
+    expect(existsSync(join(extractDir, 'index.html'))).toBe(true);
+    expect(existsSync(join(extractDir, 'README.md'))).toBe(true);
+    expect(existsSync(join(extractDir, 'assets', 'logo.svg'))).toBe(true);
+    expect(existsSync(join(extractDir, 'assets', 'data.bin'))).toBe(true);
+
+    const { readFile } = await import('node:fs/promises');
+    const readme = await readFile(join(extractDir, 'README.md'), 'utf8');
+    expect(readme).toContain('Test bundle');
+    expect(readme).toContain('open-codesign');
+  });
+
+  it('produces a valid zip without any extra assets', async () => {
+    const dest = join(tempDir, 'minimal.zip');
+    const result = await exportZip('<p>x</p>', dest);
+    expect(result.bytes).toBeGreaterThan(50);
+  });
+
+  it('throws EXPORTER_ZIP_FAILED when the destination cannot be written', async () => {
+    // Pass a directory as the destination — zip-lib will fail to write a regular file there.
+    await expect(exportZip('<p>x</p>', tempDir)).rejects.toMatchObject({
+      code: 'EXPORTER_ZIP_FAILED',
+    });
+  });
+});

--- a/packages/exporters/src/zip.ts
+++ b/packages/exporters/src/zip.ts
@@ -1,9 +1,97 @@
 import { CodesignError } from '@open-codesign/shared';
+import type { ExportResult } from './index';
+
+export interface ZipAsset {
+  /** Path inside the archive, e.g. `assets/logo.svg`. */
+  path: string;
+  /** Raw bytes or UTF-8 string. */
+  content: Buffer | string;
+}
+
+export interface ExportZipOptions {
+  /** Extra files to bundle alongside `index.html` and the README. */
+  assets?: ZipAsset[];
+  /** Override the README banner. */
+  readmeTitle?: string;
+}
+
+const README_TEMPLATE = (title: string, generatedAt: string) => `# ${title}
+
+This bundle was exported from [open-codesign](https://github.com/OpenCoworkAI/open-codesign).
+
+## Layout
+
+\`\`\`
+.
+├── index.html      The exported design (open in any browser)
+├── assets/         Linked assets (images, fonts, scripts)
+└── README.md       This file
+\`\`\`
+
+## Notes
+
+- Generated: ${generatedAt}
+- The HTML is self-contained; opening \`index.html\` directly works without a server.
+- To re-edit, open the bundle in open-codesign via *File → Import bundle*.
+`;
 
 /**
- * Tier 2 — bundle artifact + assets + README into a portable ZIP.
- * Throws loudly so callers cannot mistake "not yet shipped" for "succeeded silently".
+ * Bundle an HTML artifact + assets into a portable ZIP using `zip-lib`.
+ *
+ * Tier 1: deterministic layout (`index.html` at root, assets under `assets/`,
+ * README at root). We pick zip-lib over yauzl/jszip because it ships ~80 KB,
+ * MIT, zero deps, and handles streamed writes without buffering the whole
+ * archive in memory (PRINCIPLES §1).
  */
-export async function exportZip(): Promise<never> {
-  throw new CodesignError('ZIP export ships in Phase 2', 'EXPORTER_NOT_READY');
+export async function exportZip(
+  htmlContent: string,
+  destinationPath: string,
+  opts: ExportZipOptions = {},
+): Promise<ExportResult> {
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  const os = await import('node:os');
+  const { Zip } = await import('zip-lib');
+
+  const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codesign-zip-'));
+  try {
+    const indexPath = path.join(stagingDir, 'index.html');
+    await fs.writeFile(indexPath, htmlContent, 'utf8');
+
+    const readme = README_TEMPLATE(
+      opts.readmeTitle ?? 'open-codesign export',
+      new Date().toISOString(),
+    );
+    const readmePath = path.join(stagingDir, 'README.md');
+    await fs.writeFile(readmePath, readme, 'utf8');
+
+    const zip = new Zip();
+    zip.addFile(indexPath, 'index.html');
+    zip.addFile(readmePath, 'README.md');
+
+    if (opts.assets) {
+      for (const asset of opts.assets) {
+        const safeRel = asset.path.replace(/^\/+/, '');
+        const localPath = path.join(stagingDir, safeRel);
+        await fs.mkdir(path.dirname(localPath), { recursive: true });
+        await fs.writeFile(
+          localPath,
+          typeof asset.content === 'string' ? asset.content : asset.content,
+        );
+        zip.addFile(localPath, safeRel);
+      }
+    }
+
+    await zip.archive(destinationPath);
+    const stat = await fs.stat(destinationPath);
+    return { bytes: stat.size, path: destinationPath };
+  } catch (err) {
+    throw new CodesignError(
+      `ZIP export failed: ${err instanceof Error ? err.message : String(err)}`,
+      'EXPORTER_ZIP_FAILED',
+      { cause: err },
+    );
+  } finally {
+    await fs.rm(stagingDir, { recursive: true, force: true });
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,15 @@ importers:
       '@open-codesign/shared':
         specifier: workspace:*
         version: link:../shared
+      pptxgenjs:
+        specifier: ^3.12.0
+        version: 3.12.0
+      puppeteer-core:
+        specifier: ^24.10.0
+        version: 24.41.0
+      zip-lib:
+        specifier: ^1.0.4
+        version: 1.3.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -1148,6 +1157,11 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@puppeteer/browsers@2.13.0':
+    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1680,6 +1694,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
@@ -1991,12 +2008,61 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.7:
+    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.0:
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2057,6 +2123,10 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2132,6 +2202,11 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
@@ -2307,6 +2382,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  devtools-protocol@0.0.1595872:
+    resolution: {integrity: sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==}
+
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
@@ -2477,6 +2555,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2501,6 +2582,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2752,6 +2836,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  https@1.0.0:
+    resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -2778,6 +2865,14 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2916,6 +3011,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -2931,6 +3029,9 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3349,6 +3450,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -3419,6 +3523,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pptxgenjs@3.12.0:
+    resolution: {integrity: sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==}
+
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
@@ -3467,11 +3574,18 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  puppeteer-core@24.41.0:
+    resolution: {integrity: sha512-rLIUri7E/NQ3APSEYCCozaSJx0u8Tu9wxO6BJwnvXmIgILSK3L0TombaVh3izp1njAGrO6H2ru0hcIrLF+gWLw==}
+    engines: {node: '>=18'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -3616,6 +3730,9 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3706,6 +3823,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3760,14 +3880,23 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -3775,6 +3904,9 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
@@ -3832,10 +3964,16 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  typed-query-selector@2.12.1:
+    resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4028,6 +4166,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -4089,9 +4230,20 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
+
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-lib@1.3.2:
+    resolution: {integrity: sha512-y5i/N4exvEzl45gavh4IwBuspSc95R2Ju9zLTBdNWv3nttBqi9zKuz9q3Tz+tl6NOkTI0zwTBiAqv5WakQVOfQ==}
+    engines: {node: '>=20'}
 
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
@@ -5336,6 +5488,21 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@puppeteer/browsers@2.13.0':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.4
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -5924,6 +6091,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
@@ -6316,9 +6487,43 @@ snapshots:
       postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
+  b4a@1.8.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.0
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.7: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.7
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.0:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -6377,6 +6582,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -6492,6 +6699,12 @@ snapshots:
   check-error@2.1.3: {}
 
   chownr@2.0.0: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1595872):
+    dependencies:
+      devtools-protocol: 0.0.1595872
+      mitt: 3.0.1
+      zod: 3.25.76
 
   chromium-pickle-js@0.2.0: {}
 
@@ -6644,6 +6857,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  devtools-protocol@0.0.1595872: {}
 
   dir-compare@4.2.0:
     dependencies:
@@ -6909,6 +7124,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -6931,6 +7152,8 @@ snapshots:
     optional: true
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7279,6 +7502,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https@1.0.0: {}
+
   human-id@4.1.3: {}
 
   humanize-ms@1.2.1:
@@ -7302,6 +7527,12 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
+  immediate@3.0.6: {}
 
   imurmurhash@0.1.4: {}
 
@@ -7411,6 +7642,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -7431,6 +7669,10 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7830,6 +8072,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@1.0.11: {}
+
   partial-json@0.1.7: {}
 
   path-exists@4.0.0: {}
@@ -7878,6 +8122,13 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  pptxgenjs@3.12.0:
+    dependencies:
+      '@types/node': 18.19.130
+      https: 1.0.0
+      image-size: 1.2.1
+      jszip: 3.10.1
 
   preact@10.29.1: {}
 
@@ -7933,9 +8184,30 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  puppeteer-core@24.41.0:
+    dependencies:
+      '@puppeteer/browsers': 2.13.0
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1595872)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1595872
+      typed-query-selector: 2.12.1
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   quick-lru@5.1.1: {}
 
@@ -8099,6 +8371,8 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
+  setimmediate@1.0.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8191,6 +8465,15 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -8248,6 +8531,18 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -8255,6 +8550,17 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   tar@6.2.1:
     dependencies:
@@ -8265,12 +8571,25 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   temp-file@3.4.0:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
   term-size@2.2.1: {}
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tiny-typed-emitter@2.1.0: {}
 
@@ -8321,7 +8640,11 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  typed-query-selector@2.12.1: {}
+
   typescript@5.9.3: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -8535,6 +8858,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -8589,7 +8914,21 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
+
   yocto-queue@0.1.0: {}
+
+  zip-lib@1.3.2:
+    dependencies:
+      yauzl: 3.3.0
+      yazl: 3.3.1
 
   zip-stream@4.1.1:
     dependencies:


### PR DESCRIPTION
## Goal

Replace the `EXPORTER_NOT_READY` stubs in `packages/exporters/src/{pdf,pptx,zip}.ts` with working tier-1 implementations. All three formats ship as real exporters; the heavy runtime deps load lazily so the Electron cold-start bundle is unchanged (PRINCIPLES §1, §6).

## Files in / out

**Modified**
- `packages/exporters/src/pdf.ts` — puppeteer-core driving the user's installed Chrome
- `packages/exporters/src/pptx.ts` — pptxgenjs, one slide per `<section>` (or one for the whole doc)
- `packages/exporters/src/zip.ts` — zip-lib bundling `index.html` + `README.md` + optional assets
- `packages/exporters/src/index.ts` — `isExporterReady(...)` returns true for all four formats; `exportArtifact` dispatches with payload
- `packages/exporters/package.json` — adds three prod deps (see below)
- `apps/desktop/src/main/exporter-ipc.ts` — comment update only (channel/payload unchanged)
- `apps/desktop/src/renderer/src/components/PreviewToolbar.tsx` — flips dropdown items from "Coming in Phase 2" to per-format hover hints

**Created**
- `packages/exporters/src/chrome-discovery.ts` — Mac/Win/Linux Chrome resolver + `CODESIGN_CHROME_PATH` override
- `packages/exporters/src/chrome-discovery.test.ts` — 6 tests (per-OS path, override, EXPORTER_NO_CHROME)
- `packages/exporters/src/pdf.test.ts` — 3 tests, puppeteer-core mocked
- `packages/exporters/src/pptx.test.ts` — 6 tests including `'你好世界'` CJK round-trip with the real library
- `packages/exporters/src/zip.test.ts` — 3 tests, real zip-lib extract round-trip

**Untouched (boundary respected)**
- `apps/desktop/src/main/index.ts`, `apps/desktop/src/renderer/src/App.tsx`, `apps/desktop/src/renderer/src/store.ts`, `apps/desktop/src/preload/index.ts`

## New dependencies

| Package | License | Install size | Lazy-loaded? |
|---|---|---|---|
| `puppeteer-core@^24.10.0` | Apache-2.0 | ~3 MB (no Chromium download) | yes — `await import('puppeteer-core')` inside `exportPdf` |
| `pptxgenjs@^3.12.0` | MIT | ~2.5 MB | yes — `await import('pptxgenjs')` inside `exportPptx` |
| `zip-lib@^1.0.4` | MIT | ~80 KB | yes — `await import('zip-lib')` inside `exportZip` |

All three are Apache-2.0-compatible. Lazy-load proof: `grep -E "^import .* from ['\"](puppeteer-core\|pptxgenjs\|zip-lib)['\"]" packages/exporters/src/*.ts` returns nothing — every reference is inside an `async function` via dynamic `import()`. Total impact stays well inside the 80 MB installer budget; no Chromium is bundled (we discover the system Chrome at runtime and throw `EXPORTER_NO_CHROME` with the install link if missing).

## Acceptance test outcomes

```
$ pnpm -r typecheck     # all 10 workspaces green
$ pnpm lint             # only one pre-existing complexity warning in PasteKey.tsx (unrelated)
$ pnpm -r test          # 18/18 exporter tests pass
   ✓ src/chrome-discovery.test.ts (6 tests)
   ✓ src/pdf.test.ts (3 tests)              — puppeteer-core mocked
   ✓ src/pptx.test.ts (6 tests, 582ms)      — real pptxgenjs, CJK '你好世界' round-trip, valid PK zip header
   ✓ src/zip.test.ts (3 tests)              — real zip-lib extract round-trip
```

No silent fallbacks: each exporter throws `CodesignError` with a structured `code` (`EXPORTER_NO_CHROME` / `EXPORTER_PDF_FAILED` / `EXPORTER_PPTX_FAILED` / `EXPORTER_ZIP_FAILED`).

## §5b checklist

- [x] **Compatible** — `ExporterFormat`, `ExportResult`, IPC channel `codesign:export`, and the renderer's `ExportItem` shape are unchanged. Every error carries a versioned `code` string callers can pattern-match on.
- [x] **Upgradeable** — tier-1 boundary intact: `pptx.ts` already routes through `extractSlides()`, so swapping in `dom-to-pptx` (tier 2) or a Chromium screenshot fallback only touches that one helper. `chrome-discovery.ts` accepts a `deps` injection point so a future "managed Chrome download" path can plug in without touching exporters.
- [x] **No bloat** — three prod deps added (still well under the 30-prod-dep cap), all lazy-loaded so the cold-start bundle is unchanged. No Chromium ships with the installer.
- [x] **Elegant** — `PreviewToolbar` keeps existing tokens / spacing / easing; only the per-item hint copy changed. Each exporter is a single small function with a single throw site.

## How to test manually

1. `pnpm i && pnpm dev`
2. Generate any HTML preview, click **Export**, pick **PDF** → save dialog → confirm Chrome launches headless and a real PDF lands on disk.
3. Pick **PPTX** with a deck containing `<section>` blocks → opens in PowerPoint / Keynote with one slide per section.
4. Pick **ZIP** → archive contains `index.html`, `README.md`, and any assets.
5. With Chrome uninstalled (or set `CODESIGN_CHROME_PATH=/nonexistent`), PDF export shows the `EXPORTER_NO_CHROME` toast with the install link.