### PR TITLE
feat(desktop): settings + theme + command palette + better preview states

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -14,6 +14,16 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('open-codesign:theme');
+          if (t === 'dark') document.documentElement.classList.add('dark');
+        } catch (e) {
+          /* localStorage unavailable; default light theme */
+        }
+      })();
+    </script>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,51 +1,95 @@
-import { buildSrcdoc } from '@open-codesign/runtime';
-import { BUILTIN_DEMOS } from '@open-codesign/templates';
-import { Wordmark } from '@open-codesign/ui';
-import { ArrowUp } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
-import { PreviewToolbar } from './components/PreviewToolbar';
+import { useEffect, useMemo, useState } from 'react';
+import { CommandPalette } from './components/CommandPalette';
+import { PreviewPane } from './components/PreviewPane';
+import { Settings } from './components/Settings';
+import { Sidebar } from './components/Sidebar';
+import { ToastViewport } from './components/Toast';
+import { TopBar } from './components/TopBar';
+import { useKeyboard } from './hooks/useKeyboard';
 import { Onboarding } from './onboarding';
 import { useCodesignStore } from './store';
 
 export function App() {
-  const messages = useCodesignStore((s) => s.messages);
-  const previewHtml = useCodesignStore((s) => s.previewHtml);
-  const isGenerating = useCodesignStore((s) => s.isGenerating);
-  const sendPrompt = useCodesignStore((s) => s.sendPrompt);
   const config = useCodesignStore((s) => s.config);
   const configLoaded = useCodesignStore((s) => s.configLoaded);
   const loadConfig = useCodesignStore((s) => s.loadConfig);
+  const sendPrompt = useCodesignStore((s) => s.sendPrompt);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const openSettings = useCodesignStore((s) => s.openSettings);
+  const closeSettings = useCodesignStore((s) => s.closeSettings);
+  const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
+  const closeCommandPalette = useCodesignStore((s) => s.closeCommandPalette);
+  const settingsOpen = useCodesignStore((s) => s.settingsOpen);
+  const commandPaletteOpen = useCodesignStore((s) => s.commandPaletteOpen);
+
   const [prompt, setPrompt] = useState('');
-  const taRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     void loadConfig();
   }, [loadConfig]);
 
-  useEffect(() => {
-    const ta = taRef.current;
-    if (!ta) return;
-    ta.style.height = 'auto';
-    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
-  }, []);
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!prompt.trim() || isGenerating) return;
-    void sendPrompt(prompt);
+  function submit(): void {
+    const trimmed = prompt.trim();
+    if (!trimmed || isGenerating) return;
+    void sendPrompt(trimmed);
     setPrompt('');
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSubmit(e);
-    }
-  }
+  const ready = configLoaded && config !== null && config.hasKey;
+
+  const bindings = useMemo(
+    () => [
+      {
+        combo: 'mod+enter',
+        handler: () => {
+          if (!ready) return;
+          const trimmed = prompt.trim();
+          if (!trimmed || isGenerating) return;
+          void sendPrompt(trimmed);
+          setPrompt('');
+        },
+      },
+      {
+        combo: 'mod+,',
+        handler: () => {
+          if (!ready) return;
+          openSettings();
+        },
+      },
+      {
+        combo: 'mod+k',
+        handler: () => {
+          if (!ready) return;
+          openCommandPalette();
+        },
+      },
+      {
+        combo: 'escape',
+        handler: () => {
+          if (settingsOpen) closeSettings();
+          else if (commandPaletteOpen) closeCommandPalette();
+        },
+        preventDefault: false,
+      },
+    ],
+    [
+      prompt,
+      isGenerating,
+      ready,
+      sendPrompt,
+      settingsOpen,
+      commandPaletteOpen,
+      openSettings,
+      openCommandPalette,
+      closeSettings,
+      closeCommandPalette,
+    ],
+  );
+  useKeyboard(bindings);
 
   if (!configLoaded) {
     return (
-      <div className="h-full flex items-center justify-center bg-[var(--color-background)] text-[13px] text-[var(--color-text-muted)]">
+      <div className="h-full flex items-center justify-center bg-[var(--color-background)] text-[var(--text-sm)] text-[var(--color-text-muted)]">
         Loading…
       </div>
     );
@@ -55,211 +99,18 @@ export function App() {
     return <Onboarding />;
   }
 
-  const canSend = prompt.trim().length > 0 && !isGenerating;
-
   return (
-    <div className="h-full grid grid-cols-[360px_1fr] bg-[var(--color-background)]">
-      <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)]">
-        <header className="px-5 h-[52px] flex items-center border-b border-[var(--color-border-muted)]">
-          <Wordmark badge="pre-alpha" />
-        </header>
-
-        <div className="flex-1 overflow-y-auto px-5 py-6 space-y-6">
-          {messages.length === 0 ? (
-            <div className="flex flex-col gap-3">
-              <span
-                className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
-                style={{ fontFamily: 'var(--font-mono)' }}
-              >
-                Starter prompts
-              </span>
-              <ul className="flex flex-col gap-2">
-                {BUILTIN_DEMOS.map((demo) => (
-                  <li key={demo.id}>
-                    <button
-                      type="button"
-                      onClick={() => setPrompt(demo.prompt)}
-                      className="group w-full text-left px-4 py-3 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-soft)] hover:-translate-y-[1px] hover:border-[var(--color-border-strong)] hover:shadow-[var(--shadow-card)] transition-[transform,box-shadow,border-color] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]"
-                    >
-                      <div className="text-[13px] font-semibold text-[var(--color-text-primary)] tracking-[-0.005em] group-hover:text-[var(--color-accent)] transition-colors duration-150">
-                        {demo.title}
-                      </div>
-                      <div className="text-[12px] text-[var(--color-text-muted)] mt-[3px] leading-[1.5]">
-                        {demo.description}
-                      </div>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              {messages.map((m, i) => (
-                <div
-                  key={`${m.role}-${i}-${m.content.slice(0, 8)}`}
-                  className={`px-4 py-3 rounded-[var(--radius-lg)] text-[13px] leading-[1.55] ${
-                    m.role === 'user'
-                      ? 'bg-[var(--color-accent-soft)] text-[var(--color-text-primary)] border border-[var(--color-accent-muted)]'
-                      : 'bg-[var(--color-surface)] border border-[var(--color-border-muted)] text-[var(--color-text-primary)]'
-                  }`}
-                >
-                  {m.content}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        <form onSubmit={handleSubmit} className="border-t border-[var(--color-border-muted)] p-4">
-          <div className="relative flex items-end gap-2 p-2 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] focus-within:border-[var(--color-accent)] focus-within:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]">
-            <textarea
-              ref={taRef}
-              value={prompt}
-              onChange={(e) => {
-                setPrompt(e.target.value);
-                e.currentTarget.style.height = 'auto';
-                e.currentTarget.style.height = `${Math.min(e.currentTarget.scrollHeight, 160)}px`;
-              }}
-              onKeyDown={handleKeyDown}
-              placeholder="Describe what to design…"
-              disabled={isGenerating}
-              rows={1}
-              className="flex-1 resize-none bg-transparent px-2 py-1 text-[13px] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[160px]"
-            />
-            <button
-              type="submit"
-              disabled={!canSend}
-              aria-label="Send prompt"
-              className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 disabled:pointer-events-none transition-[transform,background-color,opacity] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
-            >
-              <ArrowUp className="w-4 h-4" strokeWidth={2.4} />
-            </button>
-          </div>
-          <div className="mt-2 px-1 text-[11px] text-[var(--color-text-muted)] flex items-center justify-between">
-            <span>
-              <kbd
-                className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
-                style={{ fontFamily: 'var(--font-mono)' }}
-              >
-                Enter
-              </kbd>{' '}
-              to send ·{' '}
-              <kbd
-                className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
-                style={{ fontFamily: 'var(--font-mono)' }}
-              >
-                Shift+Enter
-              </kbd>{' '}
-              for newline
-            </span>
-            {isGenerating ? (
-              <span className="inline-flex items-center gap-1.5 text-[var(--color-accent)]">
-                <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-pulse" />
-                Generating
-              </span>
-            ) : null}
-          </div>
-        </form>
-      </aside>
-
-      <main className="flex flex-col">
-        <header className="h-[52px] px-6 border-b border-[var(--color-border-muted)] flex items-center justify-between">
-          <span className="inline-flex items-center gap-2 text-[13px] text-[var(--color-text-secondary)] tracking-[-0.005em]">
-            <span
-              aria-hidden="true"
-              className={`w-[6px] h-[6px] rounded-full ${
-                previewHtml ? 'bg-[var(--color-success)]' : 'bg-[var(--color-border-strong)]'
-              }`}
-            />
-            {previewHtml ? 'Preview' : 'No design yet'}
-          </span>
-          <span
-            className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
-            style={{ fontFamily: 'var(--font-mono)' }}
-          >
-            BYOK · local-first · multi-model
-          </span>
-        </header>
-        <PreviewToolbar />
-        <div className="flex-1 p-6 overflow-auto">
-          {previewHtml ? (
-            <iframe
-              key={previewHtml.length}
-              title="design-preview"
-              sandbox="allow-scripts"
-              srcDoc={buildSrcdoc(previewHtml)}
-              className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
-            />
-          ) : (
-            <EmptyState />
-          )}
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="h-full flex items-center justify-center">
-      <div className="text-center max-w-[400px] flex flex-col items-center gap-6">
-        <div className="relative inline-flex items-center justify-center">
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 -m-6 rounded-full"
-            style={{
-              background: 'radial-gradient(circle, var(--color-accent-soft), transparent 70%)',
-            }}
-          />
-          <EmptyMark />
-        </div>
-        <div className="flex flex-col gap-2 relative">
-          <h2 className="text-[24px] font-semibold text-[var(--color-text-primary)] tracking-[-0.01em] leading-[1.2]">
-            A blank canvas, ready when you are.
-          </h2>
-          <p className="text-[14px] text-[var(--color-text-secondary)] leading-[1.6]">
-            Pick a starter on the left, or describe what you want to design. The result renders here
-            in a sandboxed preview.
-          </p>
-        </div>
+    <div className="h-full flex flex-col bg-[var(--color-background)]">
+      <TopBar />
+      <div className="flex-1 grid grid-cols-[360px_1fr] min-h-0">
+        <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
+        <main className="flex flex-col min-h-0">
+          <PreviewPane onPickStarter={(p) => setPrompt(p)} />
+        </main>
       </div>
+      <Settings />
+      <CommandPalette />
+      <ToastViewport />
     </div>
-  );
-}
-
-function EmptyMark() {
-  return (
-    <svg
-      width="72"
-      height="72"
-      viewBox="0 0 72 72"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      className="relative"
-    >
-      <title>open-codesign canvas</title>
-      <rect
-        x="10.5"
-        y="10.5"
-        width="51"
-        height="51"
-        rx="8"
-        stroke="var(--color-border-strong)"
-        strokeDasharray="3 5"
-        strokeWidth="1"
-      />
-      <rect
-        x="25"
-        y="25"
-        width="22"
-        height="22"
-        rx="4"
-        fill="var(--color-surface)"
-        stroke="var(--color-accent)"
-        strokeWidth="1.4"
-      />
-      <circle cx="36" cy="36" r="3.5" fill="var(--color-accent)" />
-    </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,0 +1,179 @@
+import { Download, Moon, Plus, Settings as SettingsIcon } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useCodesignStore } from '../store';
+
+interface PaletteAction {
+  id: string;
+  label: string;
+  hint: string;
+  icon: typeof Plus;
+  run: () => void;
+}
+
+export function CommandPalette() {
+  const open = useCodesignStore((s) => s.commandPaletteOpen);
+  const close = useCodesignStore((s) => s.closeCommandPalette);
+  const openSettings = useCodesignStore((s) => s.openSettings);
+  const toggleTheme = useCodesignStore((s) => s.toggleTheme);
+  const pushToast = useCodesignStore((s) => s.pushToast);
+
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+
+  const actions: PaletteAction[] = useMemo(
+    () => [
+      {
+        id: 'new-design',
+        label: 'New Design',
+        hint: 'Clear chat and start fresh',
+        icon: Plus,
+        run: () => {
+          useCodesignStore.setState({
+            messages: [],
+            previewHtml: null,
+            errorMessage: null,
+          });
+          pushToast({ variant: 'info', title: 'Workspace cleared' });
+        },
+      },
+      {
+        id: 'toggle-theme',
+        label: 'Toggle Theme',
+        hint: 'Switch between light and dark',
+        icon: Moon,
+        run: toggleTheme,
+      },
+      {
+        id: 'open-settings',
+        label: 'Open Settings',
+        hint: 'Models, appearance, storage',
+        icon: SettingsIcon,
+        run: openSettings,
+      },
+      {
+        id: 'export',
+        label: 'Export',
+        hint: 'PDF and PPTX coming soon',
+        icon: Download,
+        run: () =>
+          pushToast({
+            variant: 'info',
+            title: 'Export not available yet',
+            description: 'PDF and PPTX exporters land in v0.2. HTML export is in the toolbar.',
+          }),
+      },
+    ],
+    [openSettings, toggleTheme, pushToast],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return actions;
+    return actions.filter(
+      (a) => a.label.toLowerCase().includes(q) || a.hint.toLowerCase().includes(q),
+    );
+  }, [actions, query]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setCursor(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (cursor >= filtered.length) setCursor(0);
+  }, [cursor, filtered.length]);
+
+  if (!open) return null;
+
+  function runAt(i: number) {
+    const action = filtered[i];
+    if (!action) return;
+    action.run();
+    close();
+  }
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-24 px-6 bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={close}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') close();
+      }}
+    >
+      <div
+        className="w-full max-w-lg rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] overflow-hidden animate-[panel-in_160ms_ease-out]"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setCursor((c) => Math.min(c + 1, filtered.length - 1));
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setCursor((c) => Math.max(c - 1, 0));
+          } else if (e.key === 'Enter') {
+            e.preventDefault();
+            runAt(cursor);
+          } else if (e.key === 'Escape') {
+            close();
+          }
+        }}
+        role="document"
+      >
+        <input
+          // biome-ignore lint/a11y/noAutofocus: command palette is intentionally focused on open
+          autoFocus
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setCursor(0);
+          }}
+          placeholder="Type a command…"
+          className="w-full px-5 h-12 bg-transparent border-b border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none"
+        />
+        <ul className="max-h-72 overflow-y-auto py-2">
+          {filtered.length === 0 ? (
+            <li className="px-5 py-3 text-[var(--text-sm)] text-[var(--color-text-muted)]">
+              No matches.
+            </li>
+          ) : (
+            filtered.map((a, i) => {
+              const Icon = a.icon;
+              const active = i === cursor;
+              return (
+                <li key={a.id}>
+                  <button
+                    type="button"
+                    onMouseEnter={() => setCursor(i)}
+                    onClick={() => runAt(i)}
+                    className={`w-full flex items-center gap-3 px-5 py-2.5 text-left transition-colors ${
+                      active
+                        ? 'bg-[var(--color-surface-active)]'
+                        : 'hover:bg-[var(--color-surface-hover)]'
+                    }`}
+                  >
+                    <Icon className="w-4 h-4 text-[var(--color-text-secondary)] shrink-0" />
+                    <span className="flex-1 min-w-0">
+                      <span className="block text-[var(--text-sm)] text-[var(--color-text-primary)]">
+                        {a.label}
+                      </span>
+                      <span className="block text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                        {a.hint}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -1,0 +1,54 @@
+import { buildSrcdoc } from '@open-codesign/runtime';
+import { EmptyState } from '../preview/EmptyState';
+import { ErrorState } from '../preview/ErrorState';
+import { LoadingState } from '../preview/LoadingState';
+import { useCodesignStore } from '../store';
+import { PreviewToolbar } from './PreviewToolbar';
+
+export interface PreviewPaneProps {
+  onPickStarter: (prompt: string) => void;
+}
+
+export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
+  const previewHtml = useCodesignStore((s) => s.previewHtml);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const errorMessage = useCodesignStore((s) => s.errorMessage);
+  const retry = useCodesignStore((s) => s.retryLastPrompt);
+  const clearError = useCodesignStore((s) => s.clearError);
+
+  let body: React.ReactNode;
+  if (errorMessage) {
+    body = (
+      <ErrorState
+        message={errorMessage}
+        onRetry={() => {
+          void retry();
+        }}
+        onDismiss={clearError}
+      />
+    );
+  } else if (isGenerating && !previewHtml) {
+    body = <LoadingState />;
+  } else if (previewHtml) {
+    body = (
+      <div className="h-full p-6">
+        <iframe
+          key={previewHtml.length}
+          title="design-preview"
+          sandbox="allow-scripts"
+          srcDoc={buildSrcdoc(previewHtml)}
+          className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
+        />
+      </div>
+    );
+  } else {
+    body = <EmptyState onPickStarter={onPickStarter} />;
+  }
+
+  return (
+    <div className="flex flex-col min-h-0 flex-1">
+      <PreviewToolbar />
+      <div className="flex-1 overflow-auto">{body}</div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,0 +1,176 @@
+import { Button } from '@open-codesign/ui';
+import { Cpu, FolderOpen, Palette, Settings as SettingsIcon, Sliders, X } from 'lucide-react';
+import { useState } from 'react';
+import { useCodesignStore } from '../store';
+
+type Tab = 'models' | 'appearance' | 'storage' | 'advanced';
+
+const TABS: ReadonlyArray<{ id: Tab; label: string; icon: typeof Cpu }> = [
+  { id: 'models', label: 'Models', icon: Cpu },
+  { id: 'appearance', label: 'Appearance', icon: Palette },
+  { id: 'storage', label: 'Storage', icon: FolderOpen },
+  { id: 'advanced', label: 'Advanced', icon: Sliders },
+];
+
+const CONFIG_PATH = '~/.config/open-codesign/config.toml';
+
+function ModelsTab() {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+        Providers
+      </h3>
+      <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
+        Provider key entry happens in the onboarding flow. To switch keys or add a new provider,
+        edit the config file directly — a richer UI lands once we have multiple providers stored.
+      </p>
+      <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--color-border)] p-4 text-[var(--text-sm)] text-[var(--color-text-muted)]">
+        Coming soon: in-place provider management for Anthropic, OpenAI, Google, OpenRouter.
+      </div>
+    </div>
+  );
+}
+
+function AppearanceTab() {
+  const theme = useCodesignStore((s) => s.theme);
+  const setTheme = useCodesignStore((s) => s.setTheme);
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+          Theme
+        </h3>
+        <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1">
+          Choice persists across restarts.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        {(['light', 'dark'] as const).map((t) => {
+          const active = theme === t;
+          return (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTheme(t)}
+              className={`text-left p-4 rounded-[var(--radius-lg)] border transition-colors ${
+                active
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent-soft)]'
+                  : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)]'
+              }`}
+            >
+              <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)] capitalize">
+                {t}
+              </div>
+              <div className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1">
+                {t === 'light' ? 'Warm beige, soft shadows' : 'Deep neutral, low glare'}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function StorageTab() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+          Config file
+        </h3>
+        <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1">
+          All settings live in a single TOML file you can read or edit yourself.
+        </p>
+      </div>
+      <code className="block px-3 py-2 rounded-[var(--radius-md)] bg-[var(--color-surface-muted)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-primary)]">
+        {CONFIG_PATH}
+      </code>
+      <p className="text-[var(--text-xs)] text-[var(--color-text-secondary)]">
+        Designs and history are stored locally in SQLite under the same directory.
+      </p>
+    </div>
+  );
+}
+
+function AdvancedTab() {
+  return (
+    <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--color-border)] p-6 text-[var(--text-sm)] text-[var(--color-text-muted)]">
+      Advanced options will appear here as the app grows. Nothing to configure yet.
+    </div>
+  );
+}
+
+export function Settings() {
+  const open = useCodesignStore((s) => s.settingsOpen);
+  const close = useCodesignStore((s) => s.closeSettings);
+  const [tab, setTab] = useState<Tab>('appearance');
+  if (!open) return null;
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+      className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={close}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') close();
+      }}
+    >
+      <div
+        className="w-full max-w-3xl h-[32rem] rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] grid grid-cols-[12rem_1fr] overflow-hidden animate-[panel-in_160ms_ease-out]"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        role="document"
+      >
+        <aside className="bg-[var(--color-background-secondary)] border-r border-[var(--color-border)] p-3">
+          <div className="flex items-center gap-2 px-2 py-2 mb-2">
+            <SettingsIcon className="w-4 h-4 text-[var(--color-text-secondary)]" />
+            <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+              Settings
+            </span>
+          </div>
+          <nav className="space-y-1">
+            {TABS.map((t) => {
+              const Icon = t.icon;
+              const active = tab === t.id;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTab(t.id)}
+                  className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
+                    active
+                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)]'
+                      : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]'
+                  }`}
+                >
+                  <Icon className="w-4 h-4" />
+                  {t.label}
+                </button>
+              );
+            })}
+          </nav>
+        </aside>
+
+        <section className="flex flex-col">
+          <header className="flex items-center justify-between px-5 h-12 border-b border-[var(--color-border)]">
+            <h2 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
+              {tab}
+            </h2>
+            <Button variant="ghost" size="sm" onClick={close} aria-label="Close settings">
+              <X className="w-4 h-4" />
+            </Button>
+          </header>
+          <div className="flex-1 overflow-y-auto p-6">
+            {tab === 'models' ? <ModelsTab /> : null}
+            {tab === 'appearance' ? <AppearanceTab /> : null}
+            {tab === 'storage' ? <StorageTab /> : null}
+            {tab === 'advanced' ? <AdvancedTab /> : null}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,0 +1,113 @@
+import { ArrowUp } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { useCodesignStore } from '../store';
+
+export interface SidebarProps {
+  prompt: string;
+  setPrompt: (value: string) => void;
+  onSubmit: () => void;
+}
+
+export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
+  const messages = useCodesignStore((s) => s.messages);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!prompt.trim() || isGenerating) return;
+    onSubmit();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  }
+
+  const canSend = prompt.trim().length > 0 && !isGenerating;
+
+  return (
+    <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)] min-h-0">
+      <div className="flex-1 overflow-y-auto px-5 py-6 space-y-3">
+        {messages.length === 0 ? (
+          <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
+            Start a conversation. Pick a starter from the preview pane, or type your brief.
+          </p>
+        ) : (
+          messages.map((m, i) => (
+            <div
+              key={`${m.role}-${i}-${m.content.slice(0, 8)}`}
+              className={`px-4 py-3 rounded-[var(--radius-lg)] text-[var(--text-sm)] leading-[1.55] ${
+                m.role === 'user'
+                  ? 'bg-[var(--color-accent-soft)] text-[var(--color-text-primary)] border border-[var(--color-accent-muted)]'
+                  : 'bg-[var(--color-surface)] border border-[var(--color-border-muted)] text-[var(--color-text-primary)]'
+              }`}
+            >
+              {m.content}
+            </div>
+          ))
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className="border-t border-[var(--color-border-muted)] p-4">
+        <div className="relative flex items-end gap-2 p-2 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] focus-within:border-[var(--color-accent)] focus-within:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[var(--ease-out)]">
+          <textarea
+            ref={taRef}
+            value={prompt}
+            onChange={(e) => {
+              setPrompt(e.target.value);
+              e.currentTarget.style.height = 'auto';
+              e.currentTarget.style.height = `${Math.min(e.currentTarget.scrollHeight, 160)}px`;
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Describe what to design…"
+            disabled={isGenerating}
+            rows={1}
+            className="flex-1 resize-none bg-transparent px-2 py-1 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[160px]"
+          />
+          <button
+            type="submit"
+            disabled={!canSend}
+            aria-label="Send prompt"
+            className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 disabled:pointer-events-none transition-[transform,background-color,opacity] duration-150 ease-[var(--ease-out)]"
+          >
+            <ArrowUp className="w-4 h-4" strokeWidth={2.4} />
+          </button>
+        </div>
+        <div className="mt-2 px-1 text-[11px] text-[var(--color-text-muted)] flex items-center justify-between">
+          <span>
+            <kbd
+              className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              Enter
+            </kbd>{' '}
+            send ·{' '}
+            <kbd
+              className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              ⌘↵
+            </kbd>{' '}
+            anywhere
+          </span>
+          {isGenerating ? (
+            <span className="inline-flex items-center gap-1.5 text-[var(--color-accent)]">
+              <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-pulse" />
+              Generating
+            </span>
+          ) : null}
+        </div>
+      </form>
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/ThemeToggle.tsx
+++ b/apps/desktop/src/renderer/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { IconButton, Tooltip } from '@open-codesign/ui';
+import { Moon, Sun } from 'lucide-react';
+import { useCodesignStore } from '../store';
+
+export function ThemeToggle() {
+  const theme = useCodesignStore((s) => s.theme);
+  const toggle = useCodesignStore((s) => s.toggleTheme);
+  const isDark = theme === 'dark';
+  return (
+    <Tooltip label={isDark ? 'Switch to light' : 'Switch to dark'}>
+      <IconButton label="Toggle theme" size="sm" onClick={toggle}>
+        {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/Toast.tsx
+++ b/apps/desktop/src/renderer/src/components/Toast.tsx
@@ -1,0 +1,66 @@
+import { CheckCircle2, Info, X, XCircle } from 'lucide-react';
+import { useCodesignStore } from '../store';
+import type { Toast as ToastModel, ToastVariant } from '../store';
+
+export function useToast() {
+  const push = useCodesignStore((s) => s.pushToast);
+  const dismiss = useCodesignStore((s) => s.dismissToast);
+  return { push, dismiss };
+}
+
+const iconFor: Record<ToastVariant, typeof CheckCircle2> = {
+  success: CheckCircle2,
+  error: XCircle,
+  info: Info,
+};
+
+const accentFor: Record<ToastVariant, string> = {
+  success: 'var(--color-toast-success)',
+  error: 'var(--color-toast-error)',
+  info: 'var(--color-accent)',
+};
+
+function ToastItem({ toast }: { toast: ToastModel }) {
+  const dismiss = useCodesignStore((s) => s.dismissToast);
+  const Icon = iconFor[toast.variant];
+  return (
+    <output className="flex items-start gap-3 w-80 px-4 py-3 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] animate-[toast-in_180ms_ease-out]">
+      <Icon className="w-5 h-5 mt-0.5 shrink-0" style={{ color: accentFor[toast.variant] }} />
+      <div className="flex-1 min-w-0">
+        <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
+          {toast.title}
+        </div>
+        {toast.description ? (
+          <div className="text-[var(--text-xs)] text-[var(--color-text-secondary)] mt-0.5 break-words">
+            {toast.description}
+          </div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={() => dismiss(toast.id)}
+        className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </output>
+  );
+}
+
+export function ToastViewport() {
+  const toasts = useCodesignStore((s) => s.toasts);
+  if (toasts.length === 0) return null;
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-4 right-4 z-[60] flex flex-col gap-2 items-end"
+    >
+      {toasts.map((t) => (
+        <div key={t.id} className="pointer-events-auto">
+          <ToastItem toast={t} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -1,0 +1,43 @@
+import { IconButton, Tooltip, Wordmark } from '@open-codesign/ui';
+import { Command, Settings as SettingsIcon } from 'lucide-react';
+import { useCodesignStore } from '../store';
+import { ThemeToggle } from './ThemeToggle';
+
+export function TopBar() {
+  const previewHtml = useCodesignStore((s) => s.previewHtml);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const errorMessage = useCodesignStore((s) => s.errorMessage);
+  const openSettings = useCodesignStore((s) => s.openSettings);
+  const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
+
+  let crumb = 'Untitled design';
+  if (errorMessage) crumb = 'Error';
+  else if (isGenerating) crumb = 'Generating…';
+  else if (previewHtml) crumb = 'Preview ready';
+
+  return (
+    <header className="h-[44px] shrink-0 flex items-center justify-between px-4 border-b border-[var(--color-border)] bg-[var(--color-background)] select-none">
+      <div className="flex items-center gap-3 min-w-0">
+        <Wordmark badge="pre-alpha" size="sm" />
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--text-sm)] text-[var(--color-text-secondary)] truncate">
+          {crumb}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <Tooltip label="Command palette  ⌘K">
+          <IconButton label="Open command palette" size="sm" onClick={openCommandPalette}>
+            <Command className="w-4 h-4" />
+          </IconButton>
+        </Tooltip>
+        <ThemeToggle />
+        <Tooltip label="Settings  ⌘,">
+          <IconButton label="Open settings" size="sm" onClick={openSettings}>
+            <SettingsIcon className="w-4 h-4" />
+          </IconButton>
+        </Tooltip>
+      </div>
+    </header>
+  );
+}

--- a/apps/desktop/src/renderer/src/hooks/useKeyboard.ts
+++ b/apps/desktop/src/renderer/src/hooks/useKeyboard.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+export interface KeyBinding {
+  combo: string;
+  handler: (e: KeyboardEvent) => void;
+  preventDefault?: boolean;
+}
+
+function matches(e: KeyboardEvent, combo: string): boolean {
+  const parts = combo
+    .toLowerCase()
+    .split('+')
+    .map((p) => p.trim());
+  const expectMod = parts.includes('mod');
+  const expectShift = parts.includes('shift');
+  const expectAlt = parts.includes('alt');
+  const key = parts[parts.length - 1] ?? '';
+
+  const modPressed = e.metaKey || e.ctrlKey;
+  if (expectMod !== modPressed) return false;
+  if (expectShift !== e.shiftKey) return false;
+  if (expectAlt !== e.altKey) return false;
+
+  const eventKey = e.key.toLowerCase();
+  if (key === 'enter') return eventKey === 'enter';
+  if (key === 'escape' || key === 'esc') return eventKey === 'escape';
+  return eventKey === key;
+}
+
+export function useKeyboard(bindings: KeyBinding[]): void {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      for (const b of bindings) {
+        if (matches(e, b.combo)) {
+          if (b.preventDefault !== false) e.preventDefault();
+          b.handler(e);
+          return;
+        }
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [bindings]);
+}

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -21,3 +21,54 @@ kbd,
 pre {
   font-family: var(--font-mono);
 }
+
+@keyframes overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes shimmer-pulse {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.shimmer {
+  background-image: linear-gradient(
+    90deg,
+    var(--color-surface-muted) 0%,
+    var(--color-surface-hover) 50%,
+    var(--color-surface-muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer-pulse 1.6s linear infinite;
+}

--- a/apps/desktop/src/renderer/src/preview/EmptyState.tsx
+++ b/apps/desktop/src/renderer/src/preview/EmptyState.tsx
@@ -1,0 +1,59 @@
+import { Sparkles } from 'lucide-react';
+
+export interface EmptyStateProps {
+  onPickStarter: (prompt: string) => void;
+}
+
+const STARTERS: ReadonlyArray<{ label: string; prompt: string }> = [
+  {
+    label: 'Mobile meditation app',
+    prompt:
+      'Design a mobile app prototype for a meditation app called Calm Spaces. Show a phone frame containing a home screen with a meditation list, play button, and progress tracker.',
+  },
+  {
+    label: 'B2B pitch deck',
+    prompt:
+      'Create a 6-slide B2B SaaS pitch deck for an AI workflow tool. Include problem, solution, market, demo screenshot, traction, and ask.',
+  },
+  {
+    label: 'Case study one-pager',
+    prompt:
+      'Create a one-page client case study with hero metrics, a CEO quote, and a logo placeholder. Clean, minimal, dark theme.',
+  },
+];
+
+export function EmptyState({ onPickStarter }: EmptyStateProps) {
+  return (
+    <div className="h-full flex items-center justify-center px-6">
+      <div className="text-center max-w-md flex flex-col items-center">
+        <div className="relative w-20 h-20 mb-5">
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 rounded-full bg-[var(--color-accent-muted)] blur-xl opacity-70"
+          />
+          <div className="relative w-20 h-20 rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] flex items-center justify-center shadow-[var(--shadow-card)]">
+            <Sparkles className="w-8 h-8 text-[var(--color-accent)]" />
+          </div>
+        </div>
+        <h2 className="text-[var(--text-lg)] font-semibold text-[var(--color-text-primary)] tracking-[var(--tracking-heading)] mb-2">
+          A blank canvas, ready when you are.
+        </h2>
+        <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)] mb-6">
+          Describe what you want to build, or start from one of these:
+        </p>
+        <div className="flex flex-wrap gap-2 justify-center">
+          {STARTERS.map((s) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => onPickStarter(s.prompt)}
+              className="px-3 py-1.5 rounded-[var(--radius-full)] text-[var(--text-xs)] font-medium bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border-strong)] transition-colors"
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/preview/ErrorState.tsx
+++ b/apps/desktop/src/renderer/src/preview/ErrorState.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@open-codesign/ui';
+import { AlertTriangle, Copy, RotateCw } from 'lucide-react';
+import { useState } from 'react';
+
+export interface ErrorStateProps {
+  message: string;
+  onRetry: () => void;
+  onDismiss?: () => void;
+}
+
+export function ErrorState({ message, onRetry, onDismiss }: ErrorStateProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(message);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <div className="h-full flex items-center justify-center p-6">
+      <div className="max-w-md w-full rounded-[var(--radius-2xl)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-card)] p-6">
+        <div className="flex items-start gap-3 mb-4">
+          <div className="w-10 h-10 rounded-[var(--radius-full)] bg-[var(--color-accent-muted)] flex items-center justify-center shrink-0">
+            <AlertTriangle className="w-5 h-5" style={{ color: 'var(--color-error)' }} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-[var(--text-base)] font-semibold text-[var(--color-text-primary)]">
+              Generation failed
+            </h3>
+            <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] mt-1">
+              The model returned an error. You can retry or copy the details below.
+            </p>
+          </div>
+        </div>
+        <pre className="text-[var(--text-xs)] text-[var(--color-text-secondary)] bg-[var(--color-surface-muted)] border border-[var(--color-border)] rounded-[var(--radius-md)] p-3 mb-4 max-h-32 overflow-auto whitespace-pre-wrap break-words">
+          {message}
+        </pre>
+        <div className="flex items-center gap-2 justify-end">
+          {onDismiss ? (
+            <Button variant="ghost" size="sm" onClick={onDismiss}>
+              Dismiss
+            </Button>
+          ) : null}
+          <Button variant="secondary" size="sm" onClick={copy}>
+            <Copy className="w-4 h-4" />
+            {copied ? 'Copied' : 'Copy Error'}
+          </Button>
+          <Button variant="primary" size="sm" onClick={onRetry}>
+            <RotateCw className="w-4 h-4" />
+            Retry
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/preview/LoadingState.tsx
+++ b/apps/desktop/src/renderer/src/preview/LoadingState.tsx
@@ -1,0 +1,22 @@
+export function LoadingState() {
+  return (
+    <div className="h-full p-6">
+      <div className="h-full w-full rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden flex flex-col">
+        <div className="px-6 py-5 border-b border-[var(--color-border-subtle)] space-y-3">
+          <div className="shimmer h-4 w-40 rounded-[var(--radius-sm)]" />
+          <div className="shimmer h-3 w-64 rounded-[var(--radius-sm)]" />
+        </div>
+        <div className="flex-1 grid grid-cols-3 gap-4 p-6">
+          <div className="shimmer rounded-[var(--radius-lg)]" />
+          <div className="shimmer rounded-[var(--radius-lg)]" />
+          <div className="shimmer rounded-[var(--radius-lg)]" />
+        </div>
+        <div className="px-6 py-5 border-t border-[var(--color-border-subtle)] flex items-center gap-3">
+          <div className="shimmer h-3 w-24 rounded-[var(--radius-sm)]" />
+          <div className="shimmer h-3 flex-1 rounded-[var(--radius-sm)]" />
+          <div className="shimmer h-8 w-20 rounded-[var(--radius-md)]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -13,27 +13,81 @@ declare global {
   }
 }
 
-// TIER 1 / DEV ONLY. The renderer reads `VITE_OPEN_CODESIGN_DEV_KEY` so the
-// "first demo" path works before `wt/onboarding` lands real keychain plumbing.
-// Once onboarding ships, this constant + the !apiKey branch in sendPrompt go
-// away in the integration commit. Vite inlines `import.meta.env.*` at build
-// time, so a missing var resolves to `undefined`.
-const DEV_API_KEY: string =
-  (import.meta.env['VITE_OPEN_CODESIGN_DEV_KEY'] as string | undefined) ?? '';
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: string;
+  variant: ToastVariant;
+  title: string;
+  description?: string;
+}
+
+export type Theme = 'light' | 'dark';
 
 interface CodesignState {
   messages: ChatMessage[];
   previewHtml: string | null;
   isGenerating: boolean;
   errorMessage: string | null;
+  lastError: string | null;
   config: OnboardingState | null;
   configLoaded: boolean;
   toastMessage: string | null;
+
+  theme: Theme;
+  settingsOpen: boolean;
+  commandPaletteOpen: boolean;
+  toasts: Toast[];
+
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
   sendPrompt: (prompt: string) => Promise<void>;
+  retryLastPrompt: () => Promise<void>;
+  clearError: () => void;
   exportActive: (format: ExportFormat) => Promise<void>;
-  dismissToast: () => void;
+
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  openSettings: () => void;
+  closeSettings: () => void;
+  openCommandPalette: () => void;
+  closeCommandPalette: () => void;
+
+  pushToast: (toast: Omit<Toast, 'id'>) => string;
+  dismissToast: (id?: string) => void;
+}
+
+const THEME_STORAGE_KEY = 'open-codesign:theme';
+
+function readInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // localStorage unavailable
+  }
+  return 'light';
+}
+
+function applyThemeClass(theme: Theme): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (theme === 'dark') root.classList.add('dark');
+  else root.classList.remove('dark');
+}
+
+function persistTheme(theme: Theme): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+function newId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function modelRef(provider: SupportedOnboardingProvider, modelId: string): ModelRef {
@@ -45,9 +99,15 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   previewHtml: null,
   isGenerating: false,
   errorMessage: null,
+  lastError: null,
   config: null,
   configLoaded: false,
   toastMessage: null,
+
+  theme: readInitialTheme(),
+  settingsOpen: false,
+  commandPaletteOpen: false,
+  toasts: [],
 
   async loadConfig() {
     if (!window.codesign) {
@@ -68,12 +128,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   async sendPrompt(prompt: string) {
     if (get().isGenerating) return;
     if (!window.codesign) {
-      set({ errorMessage: 'Renderer is not connected to the main process.' });
+      const msg = 'Renderer is not connected to the main process.';
+      set({ errorMessage: msg, lastError: msg });
       return;
     }
     const cfg = get().config;
     if (cfg === null || !cfg.hasKey || cfg.provider === null || cfg.modelPrimary === null) {
-      set({ errorMessage: 'Onboarding is not complete.' });
+      const msg = 'Onboarding is not complete.';
+      set({ errorMessage: msg, lastError: msg });
       return;
     }
 
@@ -103,8 +165,26 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
         isGenerating: false,
         errorMessage: msg,
+        lastError: msg,
       }));
+      get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
     }
+  },
+
+  async retryLastPrompt() {
+    const lastUser = [...get().messages].reverse().find((m) => m.role === 'user');
+    if (!lastUser) return;
+    set((s) => ({
+      messages: s.messages.filter(
+        (m) => m !== lastUser && !(m.role === 'assistant' && m.content.startsWith('Error:')),
+      ),
+      errorMessage: null,
+    }));
+    await get().sendPrompt(lastUser.content);
+  },
+
+  clearError() {
+    set({ errorMessage: null });
   },
 
   async exportActive(format: ExportFormat) {
@@ -129,11 +209,52 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
-      set({ toastMessage: msg, errorMessage: msg });
+      set({ toastMessage: msg, errorMessage: msg, lastError: msg });
     }
   },
 
-  dismissToast() {
-    set({ toastMessage: null });
+  setTheme(theme) {
+    applyThemeClass(theme);
+    persistTheme(theme);
+    set({ theme });
+  },
+
+  toggleTheme() {
+    const next: Theme = get().theme === 'dark' ? 'light' : 'dark';
+    get().setTheme(next);
+  },
+
+  openSettings() {
+    set({ settingsOpen: true, commandPaletteOpen: false });
+  },
+  closeSettings() {
+    set({ settingsOpen: false });
+  },
+
+  openCommandPalette() {
+    set({ commandPaletteOpen: true, settingsOpen: false });
+  },
+  closeCommandPalette() {
+    set({ commandPaletteOpen: false });
+  },
+
+  pushToast(toast) {
+    const id = newId();
+    const next: Toast = { id, ...toast };
+    set((s) => ({ toasts: [...s.toasts, next] }));
+    if (typeof window !== 'undefined') {
+      window.setTimeout(() => {
+        get().dismissToast(id);
+      }, 4000);
+    }
+    return id;
+  },
+
+  dismissToast(id?: string) {
+    if (id === undefined) {
+      set({ toastMessage: null });
+      return;
+    }
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
   },
 }));

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -1,0 +1,31 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: 'sm' | 'md';
+  label: string;
+  children: ReactNode;
+}
+
+const sizeClass: Record<NonNullable<IconButtonProps['size']>, string> = {
+  sm: 'h-7 w-7',
+  md: 'h-9 w-9',
+};
+
+export function IconButton({
+  size = 'md',
+  label,
+  className = '',
+  children,
+  ...rest
+}: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className={`inline-flex items-center justify-center rounded-[var(--radius-md)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors disabled:opacity-50 disabled:pointer-events-none ${sizeClass[size]} ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+export interface TooltipProps {
+  label: string;
+  side?: 'top' | 'bottom';
+  children: ReactNode;
+}
+
+const sideClass: Record<NonNullable<TooltipProps['side']>, string> = {
+  top: 'bottom-full mb-1.5 left-1/2 -translate-x-1/2',
+  bottom: 'top-full mt-1.5 left-1/2 -translate-x-1/2',
+};
+
+export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
+  return (
+    <span className="relative inline-flex group">
+      {children}
+      <span
+        role="tooltip"
+        className={`pointer-events-none absolute ${sideClass[side]} z-50 whitespace-nowrap rounded-[var(--radius-sm)] bg-[var(--color-text-primary)] px-2 py-1 text-[11px] font-medium text-[var(--color-background)] opacity-0 transition-opacity duration-150 delay-[400ms] group-hover:opacity-100 group-focus-within:opacity-100 shadow-[var(--shadow-card)]`}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,9 @@
 export { Button } from './components/Button';
 export { Card } from './components/Card';
+export { IconButton } from './components/IconButton';
+export { Tooltip } from './components/Tooltip';
 export { Wordmark } from './components/Wordmark';
 export type { ButtonProps } from './components/Button';
 export type { CardProps } from './components/Card';
+export type { IconButtonProps } from './components/IconButton';
+export type { TooltipProps } from './components/Tooltip';

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -37,6 +37,11 @@
   --color-error: #b04030;
   --color-mcp: #4a6b8a;
 
+  /* Feedback */
+  --color-toast-success: #4f7a52;
+  --color-toast-error: #b04030;
+  --color-overlay: rgba(31, 29, 24, 0.45);
+
   /* Shadow — warm-tinted, three discrete levels */
   --shadow-soft: 0 1px 2px rgba(57, 41, 24, 0.04);
   --shadow-card: 0 1px 2px rgba(57, 41, 24, 0.04), 0 4px 16px rgba(57, 41, 24, 0.06);
@@ -122,6 +127,10 @@
   --color-warning: #d4a04a;
   --color-error: #d96050;
   --color-mcp: #6a8aab;
+
+  --color-toast-success: #6b9c6e;
+  --color-toast-error: #d96050;
+  --color-overlay: rgba(0, 0, 0, 0.6);
 
   --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.25), 0 4px 16px rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## Summary

Polishes the renderer shell with Tier-1 UX building blocks. Onboarding gate is preserved; this PR is purely additive on top of the chat shell, plus an extraction of the existing chat / preview into named components.

## UX improvements

- **TopBar** — wordmark + breadcrumb status + 3 icon buttons (command palette, theme toggle, settings)
- **Sidebar** — chat-only panel extracted from `App.tsx`; autosizing textarea, Enter sends / Shift+Enter newlines, generating dot indicator
- **PreviewPane** — composes EmptyState / LoadingState / ErrorState / iframe and keeps the existing `PreviewToolbar` mounted unchanged
- **EmptyState** — cleaner illustration (peach-aura sparkle) + 3 starter chips that populate the prompt
- **LoadingState** — pure-CSS shimmer skeleton; no JS animation library
- **ErrorState** — friendly card with `Retry` (re-runs last user prompt) and `Copy Error` actions
- **Settings overlay** — modal with 4 tabs (Models stub since onboarding owns key entry, Appearance with theme picker, Storage pointing at the TOML config path, Advanced placeholder)
- **CommandPalette (Cmd+K)** — plain modal with 4 actions (New Design / Toggle Theme / Open Settings / Export stub) + arrow-key + filter
- **Keyboard shortcuts** — `Cmd/Ctrl+Enter` sends prompt, `Cmd+,` opens Settings, `Cmd+K` opens palette, `Esc` closes overlays
- **Toast notifications** — Zustand-backed stack, bottom-right, 4s auto-dismiss, success / error / info variants
- **Dark mode** — reads `localStorage` on mount, applies `.dark` to `<html>` before React paints (FOUC-free inline script in `index.html`), persists on toggle

## Tier-1 / no-bloat confirmation

- **No new prod deps.** Uses only existing `lucide-react`, `zustand`, React 19. CSS keyframes for all overlay / panel / toast / shimmer animations. Plain `addEventListener` for keyboard shortcuts.
- No Radix Dialog, no react-hotkeys, no react-toastify, no framer-motion.
- All UI uses `var(--color-*)`, `var(--text-*)`, `var(--space-*)`, `var(--radius-*)` tokens. Added 3 missing tokens (`--color-toast-success`, `--color-toast-error`, `--color-overlay`); no hex / px in component code.
- Strict TS, `import type` for type-only imports, no `any`.

## Backward-compat notes

- The store keeps every existing slice (`config`, `configLoaded`, `loadConfig`, `completeOnboarding`, `messages`, `previewHtml`, `isGenerating`, `errorMessage`, `toastMessage`, `sendPrompt`, `exportActive`, `dismissToast`). Adds: `theme`, `settingsOpen`, `commandPaletteOpen`, `toasts`, `lastError`, `retryLastPrompt`, `clearError`, `setTheme`, `toggleTheme`, `open/closeSettings`, `open/closeCommandPalette`, `pushToast`.
- `dismissToast` accepts an optional `id` so the existing `PreviewToolbar` (which calls `dismissToast()` to clear the legacy `toastMessage`) keeps working unchanged. New multi-toast viewport calls `dismissToast(id)`.
- Onboarding gate (`if (config === null || !config.hasKey) return <Onboarding />`) and `loadConfig` effect preserved at the top of `App.tsx`.

## Integration notes

- Overlaps with `wt/reliability-v2` on `App.tsx` — both wrap the panes. The ErrorBoundary integration (wrapping `<TopBar/>` + grid + overlays) should land in a follow-up commit once `wt/reliability-v2` merges. No conflicting structural changes here beyond the slim shell.
- `PreviewToolbar.tsx` is intentionally unmodified — the new `PreviewPane` mounts it. Toolbar's `toastMessage` slice continues to fire on export status; new multi-toast pipeline is used for generation success/failure and command-palette feedback.
- The `Models` tab is a deliberate stub. Provider key entry stays in onboarding; richer in-place provider switching lands once the schema supports multiple providers.

## §5b checks

- ✅ Compatible — onboarding gate, store, IPC contract all preserved
- ✅ Upgradeable — new tokens are additive; new store slices are additive; PreviewToolbar untouched
- ✅ No-bloat — zero new prod deps; CSS-only animations; <200 LOC of net new component code per concern
- ✅ Elegant — single `useKeyboard` hook for all shortcuts; one Tooltip primitive (CSS-only with 400ms hover delay); IconButton primitive shared across TopBar / ThemeToggle

## Test plan

- [ ] `pnpm install && pnpm -r typecheck && pnpm lint && pnpm -r test` all green locally (verified)
- [ ] Onboarding still loads on first run; once complete the new shell appears
- [ ] `Cmd+K` opens palette; arrow keys + Enter run an action; Esc closes
- [ ] `Cmd+,` opens Settings; clicking outside / pressing Esc closes
- [ ] Theme toggle in TopBar persists across reload (no light flash)
- [ ] Empty state chips populate the prompt textarea
- [ ] Trigger an error (bad key / network drop) → ErrorState shows; Retry re-runs last prompt; Copy Error puts message on clipboard
- [ ] Successful export still fires the legacy toolbar toast unchanged