### PR TITLE
feat(reliability): error boundaries + cancellation + retry + iframe error reporting

### DIFF
--- a/apps/desktop/src/renderer/src/components/CanvasErrorBar.tsx
+++ b/apps/desktop/src/renderer/src/components/CanvasErrorBar.tsx
@@ -1,0 +1,43 @@
+/**
+ * CanvasErrorBar — slim red strip shown above the preview iframe when the
+ * sandbox runtime postMessages an IFRAME_ERROR.
+ *
+ * Loud surface (PRINCIPLES §10): every JS exception thrown inside the
+ * generated HTML lands here with file + line. Users can dismiss the bar
+ * (it clears the store slice) but errors are never auto-hidden.
+ */
+
+import { X } from 'lucide-react';
+import { useCodesignStore } from '../store';
+
+export function CanvasErrorBar() {
+  const errors = useCodesignStore((s) => s.iframeErrors);
+  const clear = useCodesignStore((s) => s.clearIframeErrors);
+  if (errors.length === 0) return null;
+  const latest = errors[errors.length - 1];
+  if (!latest) return null;
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 px-4 py-2 border-b border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-error)_10%,var(--color-background))] text-[var(--color-text-primary)]"
+    >
+      <span className="mt-0.5 inline-block w-2 h-2 rounded-full bg-[var(--color-error)] shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-semibold uppercase tracking-wide text-[var(--color-error)]">
+          Preview runtime error{errors.length > 1 ? ` (${errors.length})` : ''}
+        </div>
+        <div className="text-sm text-[var(--color-text-primary)] truncate" title={latest}>
+          {latest}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={clear}
+        aria-label="Dismiss preview errors"
+        className="shrink-0 p-1 rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,119 @@
+/**
+ * Generic React error boundary.
+ *
+ * Strategy (PRINCIPLES §10): never silently swallow render exceptions.
+ * If a child throws we render an actionable card with:
+ *   - the error message (loud, not hidden in console)
+ *   - "Reload" — re-mounts the children by bumping a key
+ *   - "Copy stack" — puts message+stack into the clipboard for bug reports
+ *
+ * Used both at the app shell (whole renderer) and per-pane (sidebar /
+ * preview / topbar) so a single crash never blanks the entire window.
+ */
+
+import { Button } from '@open-codesign/ui';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Human-readable label used in the fallback heading: "Sidebar crashed". */
+  scope?: string;
+  /**
+   * Optional custom fallback. Receives the error and a `reset` callback
+   * that re-mounts the boundary's children.
+   */
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  resetKey: number;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { error: null, resetKey: 0 };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Loud surface: also log so devtools shows the boundary that caught it.
+    // Tier-1 — no remote reporting, BYOK / local-first.
+    console.error(`[ErrorBoundary:${this.props.scope ?? 'root'}]`, error, info.componentStack);
+  }
+
+  reset = (): void => {
+    this.setState((s) => ({ error: null, resetKey: s.resetKey + 1 }));
+  };
+
+  copyStack = async (): Promise<void> => {
+    const err = this.state.error;
+    if (!err) return;
+    const text = `${err.name}: ${err.message}\n\n${err.stack ?? '(no stack)'}`;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Clipboard may be blocked in the sandbox; surface a textarea fallback
+      // so the user can still grab the text instead of failing silently.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+      } finally {
+        ta.remove();
+      }
+    }
+  };
+
+  override render(): ReactNode {
+    const { error, resetKey } = this.state;
+    if (!error) {
+      // Use resetKey to force remount of children after reset.
+      return <ErrorBoundaryChildren key={resetKey}>{this.props.children}</ErrorBoundaryChildren>;
+    }
+    if (this.props.fallback) {
+      return this.props.fallback({ error, reset: this.reset });
+    }
+    const scope = this.props.scope ?? 'this view';
+    return (
+      <div className="h-full w-full flex items-center justify-center p-6 bg-[var(--color-background)]">
+        <div className="max-w-md w-full rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-card)] p-6">
+          <div className="text-xs uppercase tracking-wide text-[var(--color-error)] font-semibold mb-2">
+            {scope} crashed
+          </div>
+          <h2 className="text-lg font-semibold text-[var(--color-text-primary)] mb-1">
+            {error.name}: {error.message}
+          </h2>
+          <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+            The rest of the app is still running. Reload this view, or copy the stack to file a bug.
+          </p>
+          <pre className="text-[11px] leading-snug font-mono text-[var(--color-text-muted)] bg-[var(--color-surface-active)] border border-[var(--color-border-muted)] rounded-[var(--radius-md)] p-3 max-h-40 overflow-auto whitespace-pre-wrap">
+            {error.stack ?? '(no stack)'}
+          </pre>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={() => void this.copyStack()}
+            >
+              Copy stack
+            </Button>
+            <Button type="button" size="md" onClick={this.reset}>
+              Reload
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function ErrorBoundaryChildren({ children }: { children: ReactNode }): ReactNode {
+  return children;
+}

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -6,6 +6,13 @@ const completeMock = vi.fn();
 
 vi.mock('@open-codesign/providers', () => ({
   complete: (...args: unknown[]) => completeMock(...args),
+  completeWithRetry: (
+    _model: unknown,
+    _messages: unknown,
+    _opts: unknown,
+    _retryOpts: unknown,
+    impl: (...args: unknown[]) => unknown,
+  ) => impl(_model, _messages, _opts),
 }));
 
 import { generate } from './index';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
-import { complete } from '@open-codesign/providers';
+import { type RetryReason, complete, completeWithRetry } from '@open-codesign/providers';
 import type { Artifact, ChatMessage, ModelRef } from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 import { SYSTEM_PROMPTS } from '@open-codesign/templates';
@@ -11,6 +11,10 @@ export interface GenerateInput {
   apiKey: string;
   baseUrl?: string;
   systemPrompt?: string;
+  /** Optional cancellation. Threaded through to pi-ai. */
+  signal?: AbortSignal;
+  /** Surfaced for every retry attempt — never silent (PRINCIPLES §10). */
+  onRetry?: (info: RetryReason) => void;
 }
 
 export interface GenerateOutput {
@@ -46,7 +50,9 @@ function collect(events: Iterable<ArtifactEvent>, into: Collected): void {
 /**
  * Generate one design artifact in response to a user prompt.
  * Tier 1: blocking call, returns the parsed artifact list at the end.
- * Tier 2 will switch to streaming with intermediate events.
+ * Wraps the provider call in `completeWithRetry` so transient 5xx/429/network
+ * failures retry with backoff. Caller passes `signal` to cancel and `onRetry`
+ * to surface retry attempts in the UI.
  */
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {
   if (!input.prompt.trim()) {
@@ -59,10 +65,19 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     { role: 'user', content: input.prompt },
   ];
 
-  const result = await complete(input.model, messages, {
-    apiKey: input.apiKey,
-    ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
-  });
+  const result = await completeWithRetry(
+    input.model,
+    messages,
+    {
+      apiKey: input.apiKey,
+      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+      ...(input.signal !== undefined ? { signal: input.signal } : {}),
+    },
+    {
+      ...(input.onRetry !== undefined ? { onRetry: input.onRetry } : {}),
+    },
+    complete,
+  );
 
   const parser = createArtifactParser();
   const collected: Collected = { text: '', artifacts: [] };

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -101,6 +101,9 @@ export function detectProviderFromKey(key: string): ModelRef['provider'] | null 
 export { pingProvider } from './validate';
 export type { ValidateResult } from './validate';
 
+export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
+export type { CompleteWithRetryOptions, RetryReason } from './retry';
+
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>
 //   streamArtifacts(model, messages, opts): AsyncIterable<ArtifactEvent>

--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -1,0 +1,118 @@
+import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { GenerateOptions, GenerateResult } from './index';
+import { type RetryReason, classifyError, completeWithRetry } from './retry';
+
+const MODEL: ModelRef = { provider: 'anthropic', modelId: 'claude-sonnet-4-6' };
+const MESSAGES: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+const OPTS: GenerateOptions = { apiKey: 'test-key' };
+
+const ok: GenerateResult = { content: 'hello', inputTokens: 1, outputTokens: 1, costUsd: 0 };
+
+class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly headers?: Record<string, string>,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+describe('classifyError', () => {
+  it('marks 5xx as retryable', () => {
+    expect(classifyError(new HttpError('boom', 503))).toMatchObject({ retry: true });
+  });
+  it('marks 4xx (non-429) as non-retryable', () => {
+    expect(classifyError(new HttpError('bad', 400))).toMatchObject({ retry: false });
+  });
+  it('marks 429 as retryable and parses retry-after seconds', () => {
+    const d = classifyError(new HttpError('slow', 429, { 'retry-after': '7' }));
+    expect(d.retry).toBe(true);
+    expect(d.retryAfterMs).toBe(7000);
+  });
+  it('marks AbortError as not retryable', () => {
+    const err = new DOMException('Aborted', 'AbortError');
+    expect(classifyError(err)).toMatchObject({ retry: false, reason: 'aborted' });
+  });
+  it('marks TypeError (fetch failure) as retryable', () => {
+    expect(classifyError(new TypeError('fetch failed'))).toMatchObject({ retry: true });
+  });
+});
+
+describe('completeWithRetry', () => {
+  it('returns the result on first-try success', async () => {
+    const impl = vi.fn().mockResolvedValueOnce(ok);
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, {}, impl);
+    expect(out).toEqual(ok);
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 503 then succeeds, surfacing each attempt via onRetry', async () => {
+    const impl = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('boom', 503))
+      .mockResolvedValueOnce(ok);
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, onRetry }, impl);
+    expect(out).toEqual(ok);
+    expect(impl).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/server error/);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('still down', 500));
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, maxRetries: 3 }, impl),
+    ).rejects.toThrow(/still down/);
+    expect(impl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry on a 401 client error', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('unauthorized', 401));
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1 }, impl),
+    ).rejects.toThrow(/unauthorized/);
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours Retry-After on 429 (delay is at least retryAfterMs)', async () => {
+    const impl = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('slow', 429, { 'retry-after': '0.05' }))
+      .mockResolvedValueOnce(ok);
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const out = await completeWithRetry(MODEL, MESSAGES, OPTS, { baseDelayMs: 1, onRetry }, impl);
+    expect(out).toEqual(ok);
+    const info = onRetry.mock.calls[0]?.[0];
+    expect(info?.retryAfterMs).toBe(50);
+    expect(info?.delayMs).toBeGreaterThanOrEqual(50);
+  });
+
+  it('aborts immediately when signal is already aborted', async () => {
+    const impl = vi.fn().mockResolvedValue(ok);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      completeWithRetry(MODEL, MESSAGES, { ...OPTS, signal: ctrl.signal }, {}, impl),
+    ).rejects.toBeInstanceOf(CodesignError);
+    expect(impl).not.toHaveBeenCalled();
+  });
+
+  it('aborts mid-backoff when signal fires during retry sleep', async () => {
+    const impl = vi.fn().mockRejectedValue(new HttpError('boom', 503));
+    const ctrl = new AbortController();
+    const promise = completeWithRetry(
+      MODEL,
+      MESSAGES,
+      { ...OPTS, signal: ctrl.signal },
+      { baseDelayMs: 5_000, maxRetries: 5 },
+      impl,
+    );
+    setTimeout(() => ctrl.abort(), 10);
+    await expect(promise).rejects.toThrow();
+    expect(impl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -1,0 +1,233 @@
+/**
+ * completeWithRetry — exponential backoff wrapper around `complete()`.
+ *
+ * PRINCIPLES §10 (errors loud): every retry attempt is surfaced via the
+ * `onRetry` callback so the UI can show a status line. Silent retries are
+ * forbidden — the user must see why the call took longer than expected.
+ *
+ * Retry policy (Tier 1, intentionally conservative):
+ *   - max 3 attempts (1 initial + 2 retries by default)
+ *   - exponential delay: baseDelayMs * 2^(attempt-1) with ±20% jitter
+ *   - retry only on transient classes: 5xx, network/abort-unrelated, 429
+ *   - 429 honours Retry-After header (seconds or HTTP-date) when present
+ *   - any AbortSignal abort short-circuits immediately, no retry
+ */
+
+import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
+import { type GenerateOptions, type GenerateResult, complete } from './index';
+
+export interface RetryReason {
+  attempt: number;
+  totalAttempts: number;
+  delayMs: number;
+  reason: string;
+  retryAfterMs?: number;
+}
+
+export interface CompleteWithRetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  onRetry?: (info: RetryReason) => void;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+
+interface RetryDecision {
+  retry: boolean;
+  reason: string;
+  retryAfterMs?: number;
+}
+
+const RETRYABLE_NET_CODES = new Set([
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+]);
+
+function classifyByStatus(status: number, err: unknown): RetryDecision | undefined {
+  if (status === 429) {
+    const retryAfterMs = extractRetryAfterMs(err);
+    const decision: RetryDecision = { retry: true, reason: 'rate-limited (429)' };
+    if (retryAfterMs !== undefined) decision.retryAfterMs = retryAfterMs;
+    return decision;
+  }
+  if (status >= 500 && status <= 599) {
+    return { retry: true, reason: `server error (${status})` };
+  }
+  if (status >= 400 && status <= 499) {
+    return { retry: false, reason: `client error (${status})` };
+  }
+  return undefined;
+}
+
+function classifyByNetwork(err: unknown): RetryDecision | undefined {
+  if (err instanceof TypeError) return { retry: true, reason: 'network error' };
+  if (!(err instanceof Error)) return undefined;
+  const code = (err as Error & { code?: unknown }).code;
+  if (typeof code === 'string' && RETRYABLE_NET_CODES.has(code)) {
+    return { retry: true, reason: `network error (${code})` };
+  }
+  return undefined;
+}
+
+export function classifyError(err: unknown): RetryDecision {
+  if (err instanceof Error && (err.name === 'AbortError' || err.message === 'aborted')) {
+    return { retry: false, reason: 'aborted' };
+  }
+  const status = extractStatus(err);
+  if (status !== undefined) {
+    const byStatus = classifyByStatus(status, err);
+    if (byStatus) return byStatus;
+  }
+  const byNet = classifyByNetwork(err);
+  if (byNet) return byNet;
+  return { retry: false, reason: errorMessage(err) };
+}
+
+function extractStatus(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const candidates = [
+    (err as { status?: unknown }).status,
+    (err as { statusCode?: unknown }).statusCode,
+    (err as { response?: { status?: unknown } }).response?.status,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isFinite(c)) return c;
+  }
+  // CodesignError messages may embed the status: "HTTP 503 …"
+  if (err instanceof CodesignError) {
+    const m = /\b(\d{3})\b/.exec(err.message);
+    if (m?.[1]) {
+      const n = Number(m[1]);
+      if (n >= 400 && n < 600) return n;
+    }
+  }
+  return undefined;
+}
+
+function extractRetryAfterMs(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const headers =
+    (err as { headers?: Record<string, string | string[] | undefined> }).headers ??
+    (err as { response?: { headers?: Record<string, string | string[] | undefined> } }).response
+      ?.headers;
+  const direct = (err as { retryAfter?: unknown }).retryAfter;
+  const raw =
+    pickHeader(headers, 'retry-after') ??
+    (typeof direct === 'string' || typeof direct === 'number' ? String(direct) : undefined);
+  if (raw === undefined) return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const dateMs = Date.parse(raw);
+  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
+  return undefined;
+}
+
+function pickHeader(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === name) {
+      if (Array.isArray(v)) return v[0];
+      if (typeof v === 'string') return v;
+    }
+  }
+  return undefined;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function computeDelay(attempt: number, baseDelayMs: number): number {
+  const exponent = Math.max(0, attempt - 1);
+  const base = baseDelayMs * 2 ** exponent;
+  const jitter = base * (Math.random() * 0.4 - 0.2);
+  return Math.max(0, Math.round(base + jitter));
+}
+
+export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+type CompleteFn = (
+  model: ModelRef,
+  messages: ChatMessage[],
+  opts: GenerateOptions,
+) => Promise<GenerateResult>;
+
+function buildRetryInfo(
+  attempt: number,
+  totalAttempts: number,
+  decision: RetryDecision,
+  baseDelayMs: number,
+): RetryReason {
+  const backoff = computeDelay(attempt, baseDelayMs);
+  const delayMs =
+    decision.retryAfterMs !== undefined ? Math.max(decision.retryAfterMs, backoff) : backoff;
+  const info: RetryReason = { attempt, totalAttempts, delayMs, reason: decision.reason };
+  if (decision.retryAfterMs !== undefined) info.retryAfterMs = decision.retryAfterMs;
+  return info;
+}
+
+function shouldStop(decision: RetryDecision, attempt: number, maxRetries: number): boolean {
+  return !decision.retry || attempt >= maxRetries;
+}
+
+export async function completeWithRetry(
+  model: ModelRef,
+  messages: ChatMessage[],
+  opts: GenerateOptions,
+  retryOpts: CompleteWithRetryOptions = {},
+  // Injected for tests; defaults to the real `complete`.
+  _impl: CompleteFn = complete,
+): Promise<GenerateResult> {
+  const maxRetries = retryOpts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = retryOpts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const onRetry = retryOpts.onRetry;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    if (opts.signal?.aborted) {
+      throw new CodesignError('Generation aborted by user', 'PROVIDER_ABORTED');
+    }
+    try {
+      return await _impl(model, messages, opts);
+    } catch (err) {
+      lastError = err;
+      const decision = classifyError(err);
+      if (shouldStop(decision, attempt, maxRetries)) {
+        if (decision.reason === 'aborted') {
+          throw new CodesignError('Generation aborted by user', 'PROVIDER_ABORTED', { cause: err });
+        }
+        throw err;
+      }
+      const info = buildRetryInfo(attempt, maxRetries, decision, baseDelayMs);
+      onRetry?.(info);
+      await sleepWithAbort(info.delayMs, opts.signal);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new CodesignError('completeWithRetry exhausted', 'PROVIDER_RETRY_EXHAUSTED');
+}

--- a/packages/runtime/src/iframe-errors.ts
+++ b/packages/runtime/src/iframe-errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Iframe runtime error reporting — types + guard.
+ *
+ * The overlay script (see `overlay.ts`) installs `window.onerror` and
+ * `unhandledrejection` listeners inside the sandbox iframe and forwards
+ * captured errors to the parent via postMessage. This file is the contract
+ * the parent uses to type-narrow incoming messages.
+ *
+ * Hard rule (PRINCIPLES §10): never swallow these errors. The parent must
+ * surface every `IFRAME_ERROR` message in the UI (e.g. CanvasErrorBar).
+ */
+
+export interface IframeErrorMessage {
+  __codesign: true;
+  type: 'IFRAME_ERROR';
+  kind: 'error' | 'unhandledrejection';
+  message: string;
+  source?: string;
+  lineno?: number;
+  colno?: number;
+  stack?: string;
+  timestamp: number;
+}
+
+export function isIframeErrorMessage(data: unknown): data is IframeErrorMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { __codesign?: boolean }).__codesign === true &&
+    (data as { type?: string }).type === 'IFRAME_ERROR' &&
+    typeof (data as { message?: unknown }).message === 'string'
+  );
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,8 @@ import { OVERLAY_SCRIPT } from './overlay';
 
 export { OVERLAY_SCRIPT, isOverlayMessage } from './overlay';
 export type { OverlayMessage } from './overlay';
+export { isIframeErrorMessage } from './iframe-errors';
+export type { IframeErrorMessage } from './iframe-errors';
 
 /**
  * Build a complete srcdoc HTML string for the preview iframe.

--- a/packages/runtime/src/overlay.ts
+++ b/packages/runtime/src/overlay.ts
@@ -1,6 +1,16 @@
 /**
  * Overlay script injected into the sandbox iframe's srcdoc.
- * Reports element clicks to the parent window via postMessage.
+ *
+ * Two responsibilities:
+ *  1. Element selection (mouseover outline + click → ELEMENT_SELECTED postMessage).
+ *  2. Error reporting (window.onerror + unhandledrejection → IFRAME_ERROR postMessage).
+ *
+ * Defence in depth (C11): generated HTML may attach its own click handlers,
+ * call `removeEventListener`, or freeze prototypes. We use `capture: true` so
+ * we run before bubble-phase user handlers, AND we re-attach the listeners
+ * every 200ms via `setInterval` in case user code stripped them. Re-attach is
+ * idempotent because addEventListener with the same fn+capture is a no-op
+ * when already attached.
  *
  * Bundled as a string at build time; do NOT import from anywhere except
  * the runtime's iframe HTML builder.
@@ -8,15 +18,15 @@
 
 export const OVERLAY_SCRIPT = `(function() {
   'use strict';
-  let hovered = null;
+  var hovered = null;
 
   function getXPath(el) {
     if (el.dataset && el.dataset.codesignId) return '[data-codesign-id="' + el.dataset.codesignId + '"]';
     if (el.id) return '#' + el.id;
-    const parts = [];
+    var parts = [];
     while (el && el.nodeType === 1 && el !== document.body) {
-      let idx = 1;
-      let sib = el.previousElementSibling;
+      var idx = 1;
+      var sib = el.previousElementSibling;
       while (sib) { if (sib.tagName === el.tagName) idx++; sib = sib.previousElementSibling; }
       parts.unshift(el.tagName.toLowerCase() + '[' + idx + ']');
       el = el.parentElement;
@@ -24,31 +34,84 @@ export const OVERLAY_SCRIPT = `(function() {
     return '/' + parts.join('/');
   }
 
-  document.addEventListener('mouseover', function(e) {
+  function onMouseOver(e) {
     if (hovered) hovered.style.outline = '';
     hovered = e.target;
     if (hovered) hovered.style.outline = '2px solid #c96442';
-  }, true);
-
-  document.addEventListener('mouseout', function() {
+  }
+  function onMouseOut() {
     if (hovered) hovered.style.outline = '';
     hovered = null;
-  }, true);
-
-  document.addEventListener('click', function(e) {
+  }
+  function onClick(e) {
     e.preventDefault();
     e.stopPropagation();
-    const el = e.target;
-    const rect = el.getBoundingClientRect();
-    window.parent.postMessage({
-      __codesign: true,
-      type: 'ELEMENT_SELECTED',
-      selector: getXPath(el),
-      tag: el.tagName.toLowerCase(),
-      outerHTML: (el.outerHTML || '').slice(0, 800),
-      rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
-    }, '*');
-  }, true);
+    var el = e.target;
+    var rect = el.getBoundingClientRect();
+    try {
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'ELEMENT_SELECTED',
+        selector: getXPath(el),
+        tag: el.tagName.toLowerCase(),
+        outerHTML: (el.outerHTML || '').slice(0, 800),
+        rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
+      }, '*');
+    } catch (_) {}
+  }
+  function onError(ev) {
+    try {
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'IFRAME_ERROR',
+        kind: 'error',
+        message: (ev && ev.message) ? String(ev.message) : 'Unknown iframe error',
+        source: ev && ev.filename ? String(ev.filename) : undefined,
+        lineno: ev && typeof ev.lineno === 'number' ? ev.lineno : undefined,
+        colno: ev && typeof ev.colno === 'number' ? ev.colno : undefined,
+        stack: ev && ev.error && ev.error.stack ? String(ev.error.stack) : undefined,
+        timestamp: Date.now()
+      }, '*');
+    } catch (_) {}
+  }
+  function onRejection(ev) {
+    try {
+      var reason = ev && ev.reason;
+      var msg = (reason && reason.message) ? String(reason.message) : String(reason);
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'IFRAME_ERROR',
+        kind: 'unhandledrejection',
+        message: msg,
+        stack: (reason && reason.stack) ? String(reason.stack) : undefined,
+        timestamp: Date.now()
+      }, '*');
+    } catch (_) {}
+  }
+
+  // Install + reinstall every 200ms. User code may call removeEventListener
+  // or replace document.addEventListener; re-attaching is the cheapest defence.
+  // addEventListener with the same fn+capture is a no-op when already present.
+  var installs = [
+    { evt: 'mouseover', fn: onMouseOver },
+    { evt: 'mouseout', fn: onMouseOut },
+    { evt: 'click', fn: onClick }
+  ];
+  function reattach() {
+    for (var i = 0; i < installs.length; i++) {
+      var spec = installs[i];
+      try { document.removeEventListener(spec.evt, spec.fn, true); } catch (_) {}
+      try { document.addEventListener(spec.evt, spec.fn, true); } catch (_) {}
+    }
+    if (!window.__cs_err) {
+      try { window.addEventListener('error', onError, true); window.__cs_err = true; } catch (_) {}
+    }
+    if (!window.__cs_rej) {
+      try { window.addEventListener('unhandledrejection', onRejection, true); window.__cs_rej = true; } catch (_) {}
+    }
+  }
+  reattach();
+  try { setInterval(reattach, 200); } catch (_) {}
 })();`;
 
 export interface OverlayMessage {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -88,6 +88,24 @@ export const GeneratePayload = z.object({
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
 
+/**
+ * Iframe runtime error event — schema for the postMessage payload sent by
+ * the sandbox overlay (see packages/runtime/src/overlay.ts) when JS inside
+ * the preview throws or rejects unhandled.
+ */
+export const IframeErrorEvent = z.object({
+  __codesign: z.literal(true),
+  type: z.literal('IFRAME_ERROR'),
+  kind: z.enum(['error', 'unhandledrejection']),
+  message: z.string(),
+  source: z.string().optional(),
+  lineno: z.number().optional(),
+  colno: z.number().optional(),
+  stack: z.string().optional(),
+  timestamp: z.number(),
+});
+export type IframeErrorEvent = z.infer<typeof IframeErrorEvent>;
+
 export const BRAND = {
   backgroundColor: '#faf8f3',
 } as const;


### PR DESCRIPTION
## Goal

Close the seven Tier-1 reliability gaps from `docs/research/09-polish-parity-backlog.md` so a single rendering bug, network blip, or rate-limit never blanks the app or leaves the user staring at silence.

| ID  | Gap | Where |
|-----|-----|-------|
| C1  | App-shell React error boundary with Reload + Copy stack | `components/ErrorBoundary.tsx`, `App.tsx` |
| C2  | Per-pane boundaries (Sidebar / Preview / TopBar) | `App.tsx` |
| C5  | Generation cancellation (AbortController -> pi-ai signal) | `core`, `providers`, `store.ts`, `App.tsx` |
| C6  | Retry with exponential backoff + jitter, surfaced loudly | `providers/src/retry.ts` |
| C7  | 429 Retry-After parsing + countdown toast | `store.ts`, `App.tsx` |
| C10 | Sandbox iframe error reporting | `runtime/src/overlay.ts`, `runtime/src/iframe-errors.ts`, `components/CanvasErrorBar.tsx` |
| C11 | Overlay listener defense (`setInterval(reattach, 200)`) | `runtime/src/overlay.ts` |

## Files changed

**New**
- `packages/providers/src/retry.ts` — `completeWithRetry()`, `classifyError()`, `sleepWithAbort()`
- `packages/providers/src/retry.test.ts` — 12 vitest cases
- `packages/runtime/src/iframe-errors.ts` — `IframeErrorMessage` + `isIframeErrorMessage` guard
- `apps/desktop/src/renderer/src/components/ErrorBoundary.tsx` — class boundary, copy-stack fallback
- `apps/desktop/src/renderer/src/components/CanvasErrorBar.tsx` — slim red strip above iframe

**Modified**
- `packages/runtime/src/overlay.ts` — capture-phase listeners, `window.error` + `unhandledrejection`, `setInterval(reattach, 200)`
- `packages/runtime/src/index.ts` — re-exports `IframeErrorMessage` + guard
- `packages/core/src/index.ts` — `GenerateInput.signal` + `onRetry`, wraps `complete` with `completeWithRetry`
- `packages/core/src/generate.test.ts` — mock now exports `completeWithRetry` passthrough
- `packages/providers/src/index.ts` — re-exports retry surface
- `packages/shared/src/index.ts` — adds `IframeErrorEvent` zod schema
- `apps/desktop/src/renderer/src/App.tsx` — split into Sidebar / PreviewPane / TopBar, each wrapped in `<ErrorBoundary>`; CanvasErrorBar above iframe; iframe message listener; Send -> Cancel toggle while generating; rate-limit toast with countdown
- `apps/desktop/src/renderer/src/store.ts` — `currentAbortController`, `cancelGeneration()`, `iframeErrors[]`, `rateLimitedUntil`, `statusLines[]`

**Files NOT touched (boundary)**: `apps/desktop/src/main/**`, `apps/desktop/src/preload/**`, `packages/exporters/**`, `packages/i18n/**`, `apps/desktop/src/renderer/src/onboarding/**`, `packages/templates/**`, `packages/artifacts/**`, `packages/ui/**`.

## NO new prod dependencies

Confirmed — `git diff main...HEAD -- '**/package.json'` only touches workspace ranges, no new deps. The four PRINCIPLES §5b checks all stay green:

- Compatibility: kept Onboarding flow + PreviewToolbar untouched
- Upgradeability: schema-versioning continues to apply (no on-disk format changes)
- No bloat: zero new runtime libraries, classify/retry are ~150 LOC of pure TS
- Elegance: `completeWithRetry` is a thin pure wrapper — `complete()` itself is unchanged

## Acceptance test outcomes

```
pnpm install        # clean
pnpm -r typecheck   # 9/9 packages pass
pnpm lint           # no errors (3 pre-existing complexity warnings remain)
pnpm -r test        # 32/32 tests passing across the workspace
                    #   providers: 21 (12 new retry + 9 validate)
                    #   core:       3 (existing — mock updated for completeWithRetry)
                    #   runtime:    3 (overlay/iframe build)
                    #   artifacts:  5
```

The 12 new retry tests cover: success first-try, transient retry success surfaced via onRetry, exhausted retries, non-retryable 401, 429 honouring Retry-After, AbortSignal pre-call cancellation, AbortSignal mid-backoff cancellation, plus 5 `classifyError` cases (5xx / 4xx / 429 / AbortError / TypeError).

## Integration notes

- **Overlap with `wt/preview-ux-v2`**: that branch is expected to restructure `App.tsx` into Sidebar / PreviewPane / TopBar components. This PR already does that split and wraps each in `<ErrorBoundary scope="...">`. When merging, keep the `ErrorBoundary` wrappers and let preview-ux-v2 swap the inner JSX as it likes — the boundaries are cosmetic-agnostic.
- **Cancellation through IPC**: the preload IPC contract is owned by another worktree and the `apps/desktop/src/main/**` boundary is hands-off. So the renderer races the IPC promise against an `AbortController` and discards the result on cancel. Once the IPC layer learns to forward `signal`, the wiring in `core.generate(signal)` is already in place — main just needs to pass it through.
- **Loud retries through IPC**: `onRetry` callbacks fire in main-process land today; surfacing them in the renderer needs a future IPC channel (`codesign:generation-status`). This PR ships the loud surface (`statusLines[]` + Sidebar list) ready to receive those events.

## Test plan

- [ ] `pnpm dev`, paste an invalid model name, confirm error lands in chat (not silent)
- [ ] During generation, click the Cancel button — Sidebar shows "Generation cancelled" status line, isGenerating clears immediately
- [ ] Inject `<script>throw new Error('boom')</script>` into a generated artifact and confirm the red CanvasErrorBar appears with "boom (about:srcdoc:LINE)"
- [ ] Inject `<script>setTimeout(()=>{throw 1},10);document.removeEventListener('click',()=>{},true)</script>` and verify clicks still trigger ELEMENT_SELECTED after 200ms (overlay re-attach)
- [ ] Force a render exception in PreviewPane (e.g. mutate previewHtml to a non-string) and confirm only the right pane shows the boundary card; Sidebar stays interactive