### PR TITLE
feat(desktop): redesign sidebar input + add cancellation IPC

### DIFF
--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -1,4 +1,4 @@
-import { CodesignError } from '@open-codesign/shared';
+import { CancelGenerationPayloadV1, CodesignError } from '@open-codesign/shared';
 import { describe, expect, it, vi } from 'vitest';
 import { cancelGenerationRequest } from './generation-ipc';
 
@@ -7,6 +7,18 @@ function makeController() {
 }
 
 describe('cancelGenerationRequest', () => {
+  it('parses the public v1 cancel-generation payload', () => {
+    const payload = CancelGenerationPayloadV1.parse({
+      schemaVersion: 1,
+      generationId: 'gen-1',
+    });
+
+    expect(payload).toEqual({
+      schemaVersion: 1,
+      generationId: 'gen-1',
+    });
+  });
+
   it('throws on invalid IPC payloads without aborting in-flight requests', () => {
     const controller = makeController();
     const inFlight = new Map([['gen-1', controller]]);

--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -47,4 +47,24 @@ describe('cancelGenerationRequest', () => {
     expect(inFlight.has('gen-2')).toBe(true);
     expect(logIpc.info).toHaveBeenCalledWith('generate.cancelled', { id: 'gen-1' });
   });
+
+  it('is a noop when the generationId is not in the in-flight map', () => {
+    const other = makeController();
+    const inFlight = new Map([['gen-2', other]]);
+    const logIpc = { info: vi.fn() };
+
+    cancelGenerationRequest('gen-unknown', inFlight, logIpc);
+
+    expect(other.abort).not.toHaveBeenCalled();
+    expect(inFlight.has('gen-2')).toBe(true);
+    expect(logIpc.info).not.toHaveBeenCalled();
+  });
+
+  it('rejects CancelGenerationPayloadV1 with empty generationId or missing schemaVersion', () => {
+    expect(() => CancelGenerationPayloadV1.parse({ schemaVersion: 1, generationId: '' })).toThrow();
+    expect(() => CancelGenerationPayloadV1.parse({ generationId: 'gen-1' })).toThrow();
+    expect(() =>
+      CancelGenerationPayloadV1.parse({ schemaVersion: 2, generationId: 'gen-1' }),
+    ).toThrow();
+  });
 });

--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -1,0 +1,38 @@
+import { CodesignError } from '@open-codesign/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { cancelGenerationRequest } from './generation-ipc';
+
+function makeController() {
+  return { abort: vi.fn() } as unknown as AbortController;
+}
+
+describe('cancelGenerationRequest', () => {
+  it('throws on invalid IPC payloads without aborting in-flight requests', () => {
+    const controller = makeController();
+    const inFlight = new Map([['gen-1', controller]]);
+    const logIpc = { info: vi.fn() };
+
+    expect(() => cancelGenerationRequest(undefined, inFlight, logIpc)).toThrow(CodesignError);
+    expect(controller.abort).not.toHaveBeenCalled();
+    expect(inFlight.has('gen-1')).toBe(true);
+    expect(logIpc.info).not.toHaveBeenCalled();
+  });
+
+  it('aborts only the requested generation', () => {
+    const target = makeController();
+    const other = makeController();
+    const inFlight = new Map([
+      ['gen-1', target],
+      ['gen-2', other],
+    ]);
+    const logIpc = { info: vi.fn() };
+
+    cancelGenerationRequest('gen-1', inFlight, logIpc);
+
+    expect(target.abort).toHaveBeenCalledOnce();
+    expect(other.abort).not.toHaveBeenCalled();
+    expect(inFlight.has('gen-1')).toBe(false);
+    expect(inFlight.has('gen-2')).toBe(true);
+    expect(logIpc.info).toHaveBeenCalledWith('generate.cancelled', { id: 'gen-1' });
+  });
+});

--- a/apps/desktop/src/main/generation-ipc.ts
+++ b/apps/desktop/src/main/generation-ipc.ts
@@ -1,0 +1,22 @@
+import { CodesignError } from '@open-codesign/shared';
+
+export interface CancellationLogger {
+  info: (event: string, payload: { id: string }) => void;
+}
+
+export function cancelGenerationRequest(
+  raw: unknown,
+  inFlight: Map<string, AbortController>,
+  logIpc: CancellationLogger,
+): void {
+  if (typeof raw !== 'string') {
+    throw new CodesignError('cancel-generation expects a generationId string', 'IPC_BAD_INPUT');
+  }
+
+  const controller = inFlight.get(raw);
+  if (!controller) return;
+
+  controller.abort();
+  inFlight.delete(raw);
+  logIpc.info('generate.cancelled', { id: raw });
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
 import { BrowserWindow, app, ipcMain, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { registerExporterIpc } from './exporter-ipc';
+import { cancelGenerationRequest } from './generation-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
 import {
   getApiKeyForProvider,
@@ -127,21 +128,7 @@ function registerIpcHandlers(): void {
   });
 
   ipcMain.handle('codesign:cancel-generation', (_e, raw: unknown) => {
-    const id = typeof raw === 'string' ? raw : undefined;
-    if (id !== undefined) {
-      const controller = inFlight.get(id);
-      if (controller) {
-        controller.abort();
-        inFlight.delete(id);
-        logIpc.info('generate.cancelled', { id });
-      }
-    } else {
-      for (const [key, controller] of inFlight) {
-        controller.abort();
-        logIpc.info('generate.cancelled', { id: key });
-      }
-      inFlight.clear();
-    }
+    cancelGenerationRequest(raw, inFlight, logIpc);
   });
 
   ipcMain.handle('codesign:open-log-folder', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,29 +1,38 @@
-import { dirname, join } from 'node:path';
+import { stat } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { generate } from '@open-codesign/core';
+import { applyComment, generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
 import {
+  ApplyCommentPayload,
   BRAND,
   CancelGenerationPayloadV1,
   CodesignError,
   GeneratePayload,
 } from '@open-codesign/shared';
-import { BrowserWindow, app, ipcMain, shell } from 'electron';
+import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { scanDesignSystem } from './design-system';
+import { BrowserWindow, app, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
 import { cancelGenerationRequest } from './generation-ipc';
+import { registerLocaleIpc } from './locale-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
 import {
   getApiKeyForProvider,
   getBaseUrlForProvider,
+  getCachedConfig,
+  getOnboardingState,
   loadConfigOnBoot,
   registerOnboardingIpc,
+  setDesignSystem,
 } from './onboarding-ipc';
+import { preparePromptContext } from './prompt-context';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-let mainWindow: BrowserWindow | null = null;
+let mainWindow: ElectronBrowserWindow | null = null;
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -31,6 +40,7 @@ function createWindow(): void {
     height: 820,
     minWidth: 960,
     minHeight: 640,
+    autoHideMenuBar: process.platform !== 'darwin',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     backgroundColor: BRAND.backgroundColor,
     show: false,
@@ -44,7 +54,7 @@ function createWindow(): void {
 
   mainWindow.on('ready-to-show', () => mainWindow?.show());
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
     void shell.openExternal(url);
     return { action: 'deny' };
   });
@@ -56,59 +66,8 @@ function createWindow(): void {
   }
 }
 
-interface RunGenerateArgs {
-  payload: GeneratePayload;
-  controller: AbortController;
-  logIpc: ReturnType<typeof getLogger>;
-}
-
-async function runGenerate({ payload, controller, logIpc }: RunGenerateArgs): Promise<unknown> {
-  const apiKey = getApiKeyForProvider(payload.model.provider);
-  const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
-  const baseUrl = payload.baseUrl ?? storedBaseUrl;
-  const id = payload.generationId ?? `gen-${Date.now()}`;
-
-  logIpc.info('generate', {
-    id,
-    provider: payload.model.provider,
-    modelId: payload.model.modelId,
-    promptLen: payload.prompt.length,
-    historyLen: payload.history.length,
-    baseUrl: baseUrl ?? '<default>',
-  });
-  const t0 = Date.now();
-  try {
-    const result = await generate({
-      prompt: payload.prompt,
-      history: payload.history,
-      model: payload.model,
-      apiKey,
-      ...(baseUrl !== undefined ? { baseUrl } : {}),
-      signal: controller.signal,
-    });
-    logIpc.info('generate.ok', {
-      id,
-      ms: Date.now() - t0,
-      artifacts: (result as { artifacts?: unknown[] }).artifacts?.length ?? 0,
-      cost: (result as { costUsd?: number }).costUsd,
-    });
-    return result;
-  } catch (err) {
-    logIpc.error('generate.fail', {
-      id,
-      ms: Date.now() - t0,
-      provider: payload.model.provider,
-      modelId: payload.model.modelId,
-      baseUrl: baseUrl ?? '<default>',
-      message: err instanceof Error ? err.message : String(err),
-      code: err instanceof CodesignError ? err.code : undefined,
-    });
-    throw err;
-  }
-}
-
 function registerIpcHandlers(): void {
-  const logIpc = getLogger('ipc');
+  const logIpc = getLogger('main:ipc');
 
   /** In-flight requests: generationId → AbortController */
   const inFlight = new Map<string, AbortController>();
@@ -120,13 +79,115 @@ function registerIpcHandlers(): void {
     return detectProviderFromKey(key);
   });
 
+  ipcMain.handle('codesign:pick-input-files', async () => {
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, {
+          properties: ['openFile', 'multiSelections'],
+        })
+      : await dialog.showOpenDialog({
+          properties: ['openFile', 'multiSelections'],
+        });
+    if (result.canceled || result.filePaths.length === 0) return [];
+    return Promise.all(
+      result.filePaths.map(async (path) => {
+        try {
+          const info = await stat(path);
+          return { path, name: basename(path), size: info.size };
+        } catch {
+          return { path, name: basename(path), size: 0 };
+        }
+      }),
+    );
+  });
+
+  ipcMain.handle('codesign:pick-design-system-directory', async () => {
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, {
+          properties: ['openDirectory'],
+        })
+      : await dialog.showOpenDialog({
+          properties: ['openDirectory'],
+        });
+    if (result.canceled || result.filePaths.length === 0) return getOnboardingState();
+    const rootPath = result.filePaths[0];
+    if (!rootPath) return getOnboardingState();
+    logIpc.info('designSystem.scan.start', { rootPath });
+    const snapshot = await scanDesignSystem(rootPath);
+    const nextState = await setDesignSystem(snapshot);
+    logIpc.info('designSystem.scan.ok', {
+      rootPath,
+      sourceFiles: snapshot.sourceFiles.length,
+      colors: snapshot.colors.length,
+      fonts: snapshot.fonts.length,
+    });
+    return nextState;
+  });
+
+  ipcMain.handle('codesign:clear-design-system', async () => {
+    const nextState = await setDesignSystem(null);
+    logIpc.info('designSystem.clear');
+    return nextState;
+  });
+
   ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
     const payload = GeneratePayload.parse(raw);
     const controller = new AbortController();
     const id = payload.generationId ?? `gen-${Date.now()}`;
     inFlight.set(id, controller);
+
+    const apiKey = getApiKeyForProvider(payload.model.provider);
+    const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
+    const baseUrl = payload.baseUrl ?? storedBaseUrl;
+    const cfg = getCachedConfig();
+    const promptContext = await preparePromptContext({
+      attachments: payload.attachments,
+      referenceUrl: payload.referenceUrl,
+      designSystem: cfg?.designSystem ?? null,
+    });
+
+    logIpc.info('generate', {
+      id,
+      provider: payload.model.provider,
+      modelId: payload.model.modelId,
+      promptLen: payload.prompt.length,
+      historyLen: payload.history.length,
+      attachmentCount: payload.attachments.length,
+      hasReferenceUrl: payload.referenceUrl !== undefined,
+      hasDesignSystem: promptContext.designSystem !== null,
+      baseUrl: baseUrl ?? '<default>',
+    });
+
+    const t0 = Date.now();
     try {
-      return await runGenerate({ payload, controller, logIpc });
+      const result = await generate({
+        prompt: payload.prompt,
+        history: payload.history,
+        model: payload.model,
+        apiKey,
+        attachments: promptContext.attachments,
+        referenceUrl: promptContext.referenceUrl,
+        designSystem: promptContext.designSystem ?? null,
+        ...(baseUrl !== undefined ? { baseUrl } : {}),
+        signal: controller.signal,
+      });
+      logIpc.info('generate.ok', {
+        id,
+        ms: Date.now() - t0,
+        artifacts: result.artifacts.length,
+        cost: result.costUsd,
+      });
+      return result;
+    } catch (err) {
+      logIpc.error('generate.fail', {
+        id,
+        ms: Date.now() - t0,
+        provider: payload.model.provider,
+        modelId: payload.model.modelId,
+        baseUrl: baseUrl ?? '<default>',
+        message: err instanceof Error ? err.message : String(err),
+        code: err instanceof CodesignError ? err.code : undefined,
+      });
+      throw err;
     } finally {
       inFlight.delete(id);
     }
@@ -135,6 +196,66 @@ function registerIpcHandlers(): void {
   ipcMain.handle('codesign:v1:cancel-generation', (_e, raw: unknown) => {
     const { generationId } = CancelGenerationPayloadV1.parse(raw);
     cancelGenerationRequest(generationId, inFlight, logIpc);
+  });
+
+  ipcMain.handle('codesign:apply-comment', async (_e, raw: unknown) => {
+    const payload = ApplyCommentPayload.parse(raw);
+    const cfg = getCachedConfig();
+    if (cfg === null) {
+      throw new CodesignError(
+        'No configuration found. Complete onboarding first.',
+        'CONFIG_MISSING',
+      );
+    }
+    const model = payload.model ?? { provider: cfg.provider, modelId: cfg.modelFast };
+    const apiKey = getApiKeyForProvider(model.provider);
+    const storedBaseUrl = getBaseUrlForProvider(model.provider);
+    const promptContext = await preparePromptContext({
+      attachments: payload.attachments,
+      referenceUrl: payload.referenceUrl,
+      designSystem: cfg.designSystem ?? null,
+    });
+
+    logIpc.info('applyComment', {
+      provider: model.provider,
+      modelId: model.modelId,
+      selector: payload.selection.selector,
+      attachmentCount: payload.attachments.length,
+      hasReferenceUrl: payload.referenceUrl !== undefined,
+      hasDesignSystem: promptContext.designSystem !== null,
+      baseUrl: storedBaseUrl ?? '<default>',
+    });
+
+    const t0 = Date.now();
+    try {
+      const result = await applyComment({
+        html: payload.html,
+        comment: payload.comment,
+        selection: payload.selection,
+        model,
+        apiKey,
+        attachments: promptContext.attachments,
+        referenceUrl: promptContext.referenceUrl,
+        designSystem: promptContext.designSystem ?? null,
+        ...(storedBaseUrl !== undefined ? { baseUrl: storedBaseUrl } : {}),
+      });
+      logIpc.info('applyComment.ok', {
+        ms: Date.now() - t0,
+        artifacts: result.artifacts.length,
+        cost: result.costUsd,
+      });
+      return result;
+    } catch (err) {
+      logIpc.error('applyComment.fail', {
+        ms: Date.now() - t0,
+        provider: model.provider,
+        modelId: model.modelId,
+        selector: payload.selection.selector,
+        message: err instanceof Error ? err.message : String(err),
+        code: err instanceof CodesignError ? err.code : undefined,
+      });
+      throw err;
+    }
   });
 
   ipcMain.handle('codesign:open-log-folder', async () => {
@@ -160,6 +281,7 @@ void app.whenReady().then(async () => {
   initLogger();
   await loadConfigOnBoot();
   registerIpcHandlers();
+  registerLocaleIpc();
   registerOnboardingIpc();
   registerExporterIpc(() => mainWindow);
   setupAutoUpdater();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,31 +1,23 @@
-import { stat } from 'node:fs/promises';
-import { basename, dirname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { applyComment, generate } from '@open-codesign/core';
+import { generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
-import { ApplyCommentPayload, BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
-import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
+import { BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
+import { BrowserWindow, app, ipcMain, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import { scanDesignSystem } from './design-system';
-import { BrowserWindow, app, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
-import { registerLocaleIpc } from './locale-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
 import {
   getApiKeyForProvider,
   getBaseUrlForProvider,
-  getCachedConfig,
-  getOnboardingState,
   loadConfigOnBoot,
   registerOnboardingIpc,
-  setDesignSystem,
 } from './onboarding-ipc';
-import { preparePromptContext } from './prompt-context';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-let mainWindow: ElectronBrowserWindow | null = null;
+let mainWindow: BrowserWindow | null = null;
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -33,7 +25,6 @@ function createWindow(): void {
     height: 820,
     minWidth: 960,
     minHeight: 640,
-    autoHideMenuBar: process.platform !== 'darwin',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     backgroundColor: BRAND.backgroundColor,
     show: false,
@@ -47,7 +38,7 @@ function createWindow(): void {
 
   mainWindow.on('ready-to-show', () => mainWindow?.show());
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: 'deny' };
   });
@@ -59,8 +50,62 @@ function createWindow(): void {
   }
 }
 
+interface RunGenerateArgs {
+  payload: GeneratePayload;
+  controller: AbortController;
+  logIpc: ReturnType<typeof getLogger>;
+}
+
+async function runGenerate({ payload, controller, logIpc }: RunGenerateArgs): Promise<unknown> {
+  const apiKey = getApiKeyForProvider(payload.model.provider);
+  const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
+  const baseUrl = payload.baseUrl ?? storedBaseUrl;
+  const id = payload.generationId ?? `gen-${Date.now()}`;
+
+  logIpc.info('generate', {
+    id,
+    provider: payload.model.provider,
+    modelId: payload.model.modelId,
+    promptLen: payload.prompt.length,
+    historyLen: payload.history.length,
+    baseUrl: baseUrl ?? '<default>',
+  });
+  const t0 = Date.now();
+  try {
+    const result = await generate({
+      prompt: payload.prompt,
+      history: payload.history,
+      model: payload.model,
+      apiKey,
+      ...(baseUrl !== undefined ? { baseUrl } : {}),
+      signal: controller.signal,
+    });
+    logIpc.info('generate.ok', {
+      id,
+      ms: Date.now() - t0,
+      artifacts: (result as { artifacts?: unknown[] }).artifacts?.length ?? 0,
+      cost: (result as { costUsd?: number }).costUsd,
+    });
+    return result;
+  } catch (err) {
+    logIpc.error('generate.fail', {
+      id,
+      ms: Date.now() - t0,
+      provider: payload.model.provider,
+      modelId: payload.model.modelId,
+      baseUrl: baseUrl ?? '<default>',
+      message: err instanceof Error ? err.message : String(err),
+      code: err instanceof CodesignError ? err.code : undefined,
+    });
+    throw err;
+  }
+}
+
 function registerIpcHandlers(): void {
-  const logIpc = getLogger('main:ipc');
+  const logIpc = getLogger('ipc');
+
+  /** In-flight requests: generationId → AbortController */
+  const inFlight = new Map<string, AbortController>();
 
   ipcMain.handle('codesign:detect-provider', (_e, key: unknown) => {
     if (typeof key !== 'string') {
@@ -69,167 +114,33 @@ function registerIpcHandlers(): void {
     return detectProviderFromKey(key);
   });
 
-  ipcMain.handle('codesign:pick-input-files', async () => {
-    const result = mainWindow
-      ? await dialog.showOpenDialog(mainWindow, {
-          properties: ['openFile', 'multiSelections'],
-        })
-      : await dialog.showOpenDialog({
-          properties: ['openFile', 'multiSelections'],
-        });
-    if (result.canceled || result.filePaths.length === 0) return [];
-    return Promise.all(
-      result.filePaths.map(async (path) => {
-        try {
-          const info = await stat(path);
-          return { path, name: basename(path), size: info.size };
-        } catch {
-          return { path, name: basename(path), size: 0 };
-        }
-      }),
-    );
-  });
-
-  ipcMain.handle('codesign:pick-design-system-directory', async () => {
-    const result = mainWindow
-      ? await dialog.showOpenDialog(mainWindow, {
-          properties: ['openDirectory'],
-        })
-      : await dialog.showOpenDialog({
-          properties: ['openDirectory'],
-        });
-    if (result.canceled || result.filePaths.length === 0) return getOnboardingState();
-    const rootPath = result.filePaths[0];
-    if (!rootPath) return getOnboardingState();
-    logIpc.info('designSystem.scan.start', { rootPath });
-    const snapshot = await scanDesignSystem(rootPath);
-    const nextState = await setDesignSystem(snapshot);
-    logIpc.info('designSystem.scan.ok', {
-      rootPath,
-      sourceFiles: snapshot.sourceFiles.length,
-      colors: snapshot.colors.length,
-      fonts: snapshot.fonts.length,
-    });
-    return nextState;
-  });
-
-  ipcMain.handle('codesign:clear-design-system', async () => {
-    const nextState = await setDesignSystem(null);
-    logIpc.info('designSystem.clear');
-    return nextState;
-  });
-
   ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
     const payload = GeneratePayload.parse(raw);
-    const apiKey = getApiKeyForProvider(payload.model.provider);
-    const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
-    const baseUrl = payload.baseUrl ?? storedBaseUrl;
-    const cfg = getCachedConfig();
-    const promptContext = await preparePromptContext({
-      attachments: payload.attachments,
-      referenceUrl: payload.referenceUrl,
-      designSystem: cfg?.designSystem ?? null,
-    });
-
-    logIpc.info('generate', {
-      provider: payload.model.provider,
-      modelId: payload.model.modelId,
-      promptLen: payload.prompt.length,
-      historyLen: payload.history.length,
-      attachmentCount: payload.attachments.length,
-      hasReferenceUrl: payload.referenceUrl !== undefined,
-      hasDesignSystem: promptContext.designSystem !== null,
-      baseUrl: baseUrl ?? '<default>',
-    });
-
-    const t0 = Date.now();
+    const controller = new AbortController();
+    const id = payload.generationId ?? `gen-${Date.now()}`;
+    inFlight.set(id, controller);
     try {
-      const result = await generate({
-        prompt: payload.prompt,
-        history: payload.history,
-        model: payload.model,
-        apiKey,
-        attachments: promptContext.attachments,
-        referenceUrl: promptContext.referenceUrl,
-        designSystem: promptContext.designSystem ?? null,
-        ...(baseUrl !== undefined ? { baseUrl } : {}),
-      });
-      logIpc.info('generate.ok', {
-        ms: Date.now() - t0,
-        artifacts: result.artifacts.length,
-        cost: result.costUsd,
-      });
-      return result;
-    } catch (err) {
-      logIpc.error('generate.fail', {
-        ms: Date.now() - t0,
-        provider: payload.model.provider,
-        modelId: payload.model.modelId,
-        baseUrl: baseUrl ?? '<default>',
-        message: err instanceof Error ? err.message : String(err),
-        code: err instanceof CodesignError ? err.code : undefined,
-      });
-      throw err;
+      return await runGenerate({ payload, controller, logIpc });
+    } finally {
+      inFlight.delete(id);
     }
   });
 
-  ipcMain.handle('codesign:apply-comment', async (_e, raw: unknown) => {
-    const payload = ApplyCommentPayload.parse(raw);
-    const cfg = getCachedConfig();
-    if (cfg === null) {
-      throw new CodesignError(
-        'No configuration found. Complete onboarding first.',
-        'CONFIG_MISSING',
-      );
-    }
-    const model = payload.model ?? { provider: cfg.provider, modelId: cfg.modelFast };
-    const apiKey = getApiKeyForProvider(model.provider);
-    const storedBaseUrl = getBaseUrlForProvider(model.provider);
-    const promptContext = await preparePromptContext({
-      attachments: payload.attachments,
-      referenceUrl: payload.referenceUrl,
-      designSystem: cfg.designSystem ?? null,
-    });
-
-    logIpc.info('applyComment', {
-      provider: model.provider,
-      modelId: model.modelId,
-      selector: payload.selection.selector,
-      attachmentCount: payload.attachments.length,
-      hasReferenceUrl: payload.referenceUrl !== undefined,
-      hasDesignSystem: promptContext.designSystem !== null,
-      baseUrl: storedBaseUrl ?? '<default>',
-    });
-
-    const t0 = Date.now();
-    try {
-      const result = await applyComment({
-        html: payload.html,
-        comment: payload.comment,
-        selection: payload.selection,
-        model,
-        apiKey,
-        attachments: promptContext.attachments,
-        referenceUrl: promptContext.referenceUrl,
-        designSystem: promptContext.designSystem ?? null,
-        ...(storedBaseUrl !== undefined ? { baseUrl: storedBaseUrl } : {}),
-      });
-      logIpc.info('applyComment.ok', {
-        ms: Date.now() - t0,
-        artifacts: result.artifacts.length,
-        cost: result.costUsd,
-      });
-      return result;
-    } catch (err) {
-      logIpc.error('applyComment.fail', {
-        ms: Date.now() - t0,
-        provider: model.provider,
-        modelId: model.modelId,
-        selector: payload.selection.selector,
-        message: err instanceof Error ? err.message : String(err),
-        code: err instanceof CodesignError ? err.code : undefined,
-      });
-      throw err;
+  ipcMain.handle('codesign:cancel-generation', (_e, raw: unknown) => {
+    const id = typeof raw === 'string' ? raw : undefined;
+    if (id !== undefined) {
+      const controller = inFlight.get(id);
+      if (controller) {
+        controller.abort();
+        inFlight.delete(id);
+        logIpc.info('generate.cancelled', { id });
+      }
+    } else {
+      for (const [key, controller] of inFlight) {
+        controller.abort();
+        logIpc.info('generate.cancelled', { id: key });
+      }
+      inFlight.clear();
     }
   });
 
@@ -256,7 +167,6 @@ void app.whenReady().then(async () => {
   initLogger();
   await loadConfigOnBoot();
   registerIpcHandlers();
-  registerLocaleIpc();
   registerOnboardingIpc();
   registerExporterIpc(() => mainWindow);
   setupAutoUpdater();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import {
   BRAND,
   CancelGenerationPayloadV1,
   CodesignError,
+  GeneratePayload,
   GeneratePayloadV1,
 } from '@open-codesign/shared';
 import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
@@ -133,6 +134,75 @@ function registerIpcHandlers(): void {
     const payload = GeneratePayloadV1.parse(raw);
     const controller = new AbortController();
     const id = payload.generationId;
+    inFlight.set(id, controller);
+
+    const apiKey = getApiKeyForProvider(payload.model.provider);
+    const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
+    const baseUrl = payload.baseUrl ?? storedBaseUrl;
+    const cfg = getCachedConfig();
+    const promptContext = await preparePromptContext({
+      attachments: payload.attachments,
+      referenceUrl: payload.referenceUrl,
+      designSystem: cfg?.designSystem ?? null,
+    });
+
+    logIpc.info('generate', {
+      id,
+      provider: payload.model.provider,
+      modelId: payload.model.modelId,
+      promptLen: payload.prompt.length,
+      historyLen: payload.history.length,
+      attachmentCount: payload.attachments.length,
+      hasReferenceUrl: payload.referenceUrl !== undefined,
+      hasDesignSystem: promptContext.designSystem !== null,
+      baseUrl: baseUrl ?? '<default>',
+    });
+
+    const t0 = Date.now();
+    try {
+      const result = await generate({
+        prompt: payload.prompt,
+        history: payload.history,
+        model: payload.model,
+        apiKey,
+        attachments: promptContext.attachments,
+        referenceUrl: promptContext.referenceUrl,
+        designSystem: promptContext.designSystem ?? null,
+        ...(baseUrl !== undefined ? { baseUrl } : {}),
+        signal: controller.signal,
+      });
+      logIpc.info('generate.ok', {
+        id,
+        ms: Date.now() - t0,
+        artifacts: result.artifacts.length,
+        cost: result.costUsd,
+      });
+      return result;
+    } catch (err) {
+      logIpc.error('generate.fail', {
+        id,
+        ms: Date.now() - t0,
+        provider: payload.model.provider,
+        modelId: payload.model.modelId,
+        baseUrl: baseUrl ?? '<default>',
+        message: err instanceof Error ? err.message : String(err),
+        code: err instanceof CodesignError ? err.code : undefined,
+      });
+      throw err;
+    } finally {
+      inFlight.delete(id);
+    }
+  });
+
+  // Legacy shim — kept for one minor release while older renderer builds still
+  // send codesign:generate without schemaVersion. Remove after v0.3.
+  ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
+    logIpc.warn('legacy codesign:generate channel used, schedule removal next minor');
+    const legacy = GeneratePayload.parse(raw);
+    const id = legacy.generationId ?? `gen-${Date.now()}`;
+    const v1Raw = { schemaVersion: 1 as const, ...legacy, generationId: id };
+    const payload = GeneratePayloadV1.parse(v1Raw);
+    const controller = new AbortController();
     inFlight.set(id, controller);
 
     const apiKey = getApiKeyForProvider(payload.model.provider);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,12 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
-import { BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
+import {
+  BRAND,
+  CancelGenerationPayloadV1,
+  CodesignError,
+  GeneratePayload,
+} from '@open-codesign/shared';
 import { BrowserWindow, app, ipcMain, shell } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { registerExporterIpc } from './exporter-ipc';
@@ -127,8 +132,9 @@ function registerIpcHandlers(): void {
     }
   });
 
-  ipcMain.handle('codesign:cancel-generation', (_e, raw: unknown) => {
-    cancelGenerationRequest(raw, inFlight, logIpc);
+  ipcMain.handle('codesign:v1:cancel-generation', (_e, raw: unknown) => {
+    const { generationId } = CancelGenerationPayloadV1.parse(raw);
+    cancelGenerationRequest(generationId, inFlight, logIpc);
   });
 
   ipcMain.handle('codesign:open-log-folder', async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,7 +8,7 @@ import {
   BRAND,
   CancelGenerationPayloadV1,
   CodesignError,
-  GeneratePayload,
+  GeneratePayloadV1,
 } from '@open-codesign/shared';
 import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
@@ -129,10 +129,10 @@ function registerIpcHandlers(): void {
     return nextState;
   });
 
-  ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
-    const payload = GeneratePayload.parse(raw);
+  ipcMain.handle('codesign:v1:generate', async (_e, raw: unknown) => {
+    const payload = GeneratePayloadV1.parse(raw);
     const controller = new AbortController();
-    const id = payload.generationId ?? `gen-${Date.now()}`;
+    const id = payload.generationId;
     inFlight.set(id, controller);
 
     const apiKey = getApiKeyForProvider(payload.model.provider);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,5 @@
 import type {
+  CancelGenerationPayloadV1,
   ChatMessage,
   ModelRef,
   OnboardingState,
@@ -33,7 +34,11 @@ const api = {
     baseUrl?: string;
     generationId?: string;
   }) => ipcRenderer.invoke('codesign:generate', payload),
-  cancelGeneration: (id: string) => ipcRenderer.invoke('codesign:cancel-generation', id),
+  cancelGeneration: (generationId: string) =>
+    ipcRenderer.invoke('codesign:v1:cancel-generation', {
+      schemaVersion: 1,
+      generationId,
+    } satisfies CancelGenerationPayloadV1),
   export: (payload: { format: ExportFormat; htmlContent: string; defaultFilename?: string }) =>
     ipcRenderer.invoke('codesign:export', payload) as Promise<ExportInvokeResponse>,
   checkForUpdates: () => ipcRenderer.invoke('codesign:check-for-updates'),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,9 +1,7 @@
 import type {
   ChatMessage,
-  LocalInputFile,
   ModelRef,
   OnboardingState,
-  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { contextBridge, ipcRenderer } from 'electron';
@@ -33,30 +31,11 @@ const api = {
     history: ChatMessage[];
     model: ModelRef;
     baseUrl?: string;
-    referenceUrl?: string;
-    attachments?: LocalInputFile[];
+    generationId?: string;
   }) => ipcRenderer.invoke('codesign:generate', payload),
-  applyComment: (payload: {
-    html: string;
-    comment: string;
-    selection: SelectedElement;
-    model?: ModelRef;
-    referenceUrl?: string;
-    attachments?: LocalInputFile[];
-  }) => ipcRenderer.invoke('codesign:apply-comment', payload),
-  pickInputFiles: () =>
-    ipcRenderer.invoke('codesign:pick-input-files') as Promise<LocalInputFile[]>,
-  pickDesignSystemDirectory: () =>
-    ipcRenderer.invoke('codesign:pick-design-system-directory') as Promise<OnboardingState>,
-  clearDesignSystem: () =>
-    ipcRenderer.invoke('codesign:clear-design-system') as Promise<OnboardingState>,
+  cancelGeneration: (id: string) => ipcRenderer.invoke('codesign:cancel-generation', id),
   export: (payload: { format: ExportFormat; htmlContent: string; defaultFilename?: string }) =>
     ipcRenderer.invoke('codesign:export', payload) as Promise<ExportInvokeResponse>,
-  locale: {
-    getSystem: () => ipcRenderer.invoke('locale:get-system') as Promise<string>,
-    getCurrent: () => ipcRenderer.invoke('locale:get-current') as Promise<string>,
-    set: (locale: string) => ipcRenderer.invoke('locale:set', locale) as Promise<string>,
-  },
   checkForUpdates: () => ipcRenderer.invoke('codesign:check-for-updates'),
   downloadUpdate: () => ipcRenderer.invoke('codesign:download-update'),
   installUpdate: () => ipcRenderer.invoke('codesign:install-update'),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import type {
   CancelGenerationPayloadV1,
   ChatMessage,
+  GeneratePayloadV1,
   LocalInputFile,
   ModelRef,
   OnboardingState,
@@ -35,9 +36,13 @@ const api = {
     model: ModelRef;
     baseUrl?: string;
     referenceUrl?: string;
-    attachments?: LocalInputFile[];
-    generationId?: string;
-  }) => ipcRenderer.invoke('codesign:generate', payload),
+    attachments: LocalInputFile[];
+    generationId: string;
+  }) =>
+    ipcRenderer.invoke('codesign:v1:generate', {
+      schemaVersion: 1,
+      ...payload,
+    } satisfies GeneratePayloadV1),
   cancelGeneration: (generationId: string) =>
     ipcRenderer.invoke('codesign:v1:cancel-generation', {
       schemaVersion: 1,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,8 +1,10 @@
 import type {
   CancelGenerationPayloadV1,
   ChatMessage,
+  LocalInputFile,
   ModelRef,
   OnboardingState,
+  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { contextBridge, ipcRenderer } from 'electron';
@@ -32,6 +34,8 @@ const api = {
     history: ChatMessage[];
     model: ModelRef;
     baseUrl?: string;
+    referenceUrl?: string;
+    attachments?: LocalInputFile[];
     generationId?: string;
   }) => ipcRenderer.invoke('codesign:generate', payload),
   cancelGeneration: (generationId: string) =>
@@ -39,8 +43,27 @@ const api = {
       schemaVersion: 1,
       generationId,
     } satisfies CancelGenerationPayloadV1),
+  applyComment: (payload: {
+    html: string;
+    comment: string;
+    selection: SelectedElement;
+    model?: ModelRef;
+    referenceUrl?: string;
+    attachments?: LocalInputFile[];
+  }) => ipcRenderer.invoke('codesign:apply-comment', payload),
+  pickInputFiles: () =>
+    ipcRenderer.invoke('codesign:pick-input-files') as Promise<LocalInputFile[]>,
+  pickDesignSystemDirectory: () =>
+    ipcRenderer.invoke('codesign:pick-design-system-directory') as Promise<OnboardingState>,
+  clearDesignSystem: () =>
+    ipcRenderer.invoke('codesign:clear-design-system') as Promise<OnboardingState>,
   export: (payload: { format: ExportFormat; htmlContent: string; defaultFilename?: string }) =>
     ipcRenderer.invoke('codesign:export', payload) as Promise<ExportInvokeResponse>,
+  locale: {
+    getSystem: () => ipcRenderer.invoke('locale:get-system') as Promise<string>,
+    getCurrent: () => ipcRenderer.invoke('locale:get-current') as Promise<string>,
+    set: (locale: string) => ipcRenderer.invoke('locale:set', locale) as Promise<string>,
+  },
   checkForUpdates: () => ipcRenderer.invoke('codesign:check-for-updates'),
   downloadUpdate: () => ipcRenderer.invoke('codesign:download-update'),
   installUpdate: () => ipcRenderer.invoke('codesign:install-update'),

--- a/apps/desktop/src/renderer/src/components/Sidebar.test.ts
+++ b/apps/desktop/src/renderer/src/components/Sidebar.test.ts
@@ -15,7 +15,7 @@ describe('getTextareaLineHeight', () => {
     expect(getTextareaLineHeight({} as HTMLTextAreaElement)).toBe(24);
   });
 
-  it('falls back to font size and leading-body when line-height is not numeric', () => {
+  it('returns fontSize * leading when line-height is not numeric but tokens are present', () => {
     vi.stubGlobal(
       'getComputedStyle',
       vi.fn(
@@ -29,5 +29,21 @@ describe('getTextareaLineHeight', () => {
     );
 
     expect(getTextareaLineHeight({} as HTMLTextAreaElement)).toBeCloseTo(20.8);
+  });
+
+  it('throws when sizing tokens are missing or invalid', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(
+        () =>
+          ({
+            lineHeight: 'normal',
+            fontSize: 'normal',
+            getPropertyValue: vi.fn(() => ''),
+          }) as unknown as CSSStyleDeclaration,
+      ),
+    );
+
+    expect(() => getTextareaLineHeight({} as HTMLTextAreaElement)).toThrow(/missing or invalid/);
   });
 });

--- a/apps/desktop/src/renderer/src/components/Sidebar.test.ts
+++ b/apps/desktop/src/renderer/src/components/Sidebar.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getTextareaLineHeight } from './Sidebar';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getTextareaLineHeight', () => {
+  it('uses the computed line-height when available', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(() => ({ lineHeight: '24px', fontSize: '13px', getPropertyValue: vi.fn(() => '') })),
+    );
+
+    expect(getTextareaLineHeight({} as HTMLTextAreaElement)).toBe(24);
+  });
+
+  it('falls back to font size and leading-body when line-height is not numeric', () => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      vi.fn(
+        () =>
+          ({
+            lineHeight: 'normal',
+            fontSize: '13px',
+            getPropertyValue: vi.fn((name: string) => (name === '--leading-body' ? '1.6' : '')),
+          }) as unknown as CSSStyleDeclaration,
+      ),
+    );
+
+    expect(getTextareaLineHeight({} as HTMLTextAreaElement)).toBeCloseTo(20.8);
+  });
+});

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
-import { useT } from '@open-codesign/i18n';
-import { ArrowUp, FolderOpen, Link2, Paperclip, X } from 'lucide-react';
+import { ArrowUp, Square } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
 
@@ -9,36 +8,31 @@ export interface SidebarProps {
   onSubmit: () => void;
 }
 
+const MAX_TEXTAREA_HEIGHT = 144; // 6 lines × ~24px
+
+function resizeTextarea(el: HTMLTextAreaElement): void {
+  el.style.height = 'auto';
+  el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_HEIGHT)}px`;
+}
+
 export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
-  const t = useT();
-  const config = useCodesignStore((s) => s.config);
   const messages = useCodesignStore((s) => s.messages);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
-  const inputFiles = useCodesignStore((s) => s.inputFiles);
-  const referenceUrl = useCodesignStore((s) => s.referenceUrl);
-  const setReferenceUrl = useCodesignStore((s) => s.setReferenceUrl);
-  const pickInputFiles = useCodesignStore((s) => s.pickInputFiles);
-  const removeInputFile = useCodesignStore((s) => s.removeInputFile);
-  const pickDesignSystemDirectory = useCodesignStore((s) => s.pickDesignSystemDirectory);
-  const clearDesignSystem = useCodesignStore((s) => s.clearDesignSystem);
+  const cancelGeneration = useCodesignStore((s) => s.cancelGeneration);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
-  const designSystem = config?.designSystem ?? null;
-
   useEffect(() => {
-    const ta = taRef.current;
-    if (!ta) return;
-    ta.style.height = 'auto';
-    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+    // sync height on mount to match any pre-filled value
+    if (taRef.current) resizeTextarea(taRef.current);
   }, []);
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.FormEvent): void {
     e.preventDefault();
     if (!prompt.trim() || isGenerating) return;
     onSubmit();
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>): void {
     if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       e.preventDefault();
       handleSubmit(e);
@@ -49,109 +43,10 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
 
   return (
     <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)] min-h-0">
-      <div className="px-5 py-5 border-b border-[var(--color-border-muted)] space-y-3">
-        <div className="space-y-2">
-          <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
-            {t('sidebar.localContext')}
-          </div>
-          <div className="grid grid-cols-1 gap-2">
-            <button
-              type="button"
-              onClick={() => void pickInputFiles()}
-              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
-            >
-              <Paperclip className="w-4 h-4 text-[var(--color-text-secondary)]" />
-              {t('sidebar.attachLocalFiles')}
-            </button>
-            <button
-              type="button"
-              onClick={() => void pickDesignSystemDirectory()}
-              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
-            >
-              <FolderOpen className="w-4 h-4 text-[var(--color-text-secondary)]" />
-              {designSystem
-                ? t('sidebar.refreshDesignSystemRepo')
-                : t('sidebar.linkDesignSystemRepo')}
-            </button>
-          </div>
-        </div>
-
-        <label className="block space-y-2">
-          <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
-            <Link2 className="w-3.5 h-3.5" />
-            {t('sidebar.referenceUrl')}
-          </span>
-          <input
-            type="url"
-            value={referenceUrl}
-            onChange={(e) => setReferenceUrl(e.target.value)}
-            placeholder="https://example.com/reference"
-            className="w-full h-10 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150"
-          />
-        </label>
-
-        {inputFiles.length > 0 ? (
-          <div className="space-y-2">
-            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
-              {t('sidebar.attachedFiles')}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {inputFiles.map((file) => (
-                <span
-                  key={file.path}
-                  className="inline-flex items-center gap-1.5 max-w-full rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[11px] text-[var(--color-text-secondary)]"
-                >
-                  <span className="truncate max-w-[180px]" title={file.path}>
-                    {file.name}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => removeInputFile(file.path)}
-                    className="inline-flex items-center justify-center rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
-                    aria-label={t('sidebar.removeFile', { name: file.name })}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        {designSystem ? (
-          <div className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 space-y-2">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <div className="text-[12px] font-medium text-[var(--color-text-primary)]">
-                  {t('sidebar.activeDesignSystem')}
-                </div>
-                <div className="text-[11px] text-[var(--color-text-muted)] break-all">
-                  {designSystem.rootPath}
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => void clearDesignSystem()}
-                className="text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
-              >
-                {t('sidebar.clear')}
-              </button>
-            </div>
-            <p className="text-[12px] text-[var(--color-text-secondary)] leading-[1.5]">
-              {designSystem.summary}
-            </p>
-          </div>
-        ) : (
-          <p className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
-            {t('sidebar.designSystemHint')}
-          </p>
-        )}
-      </div>
-
       <div className="flex-1 overflow-y-auto px-5 py-6 space-y-3">
         {messages.length === 0 ? (
           <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
-            {t('sidebar.startHint')}
+            Start a conversation. Pick a starter from the preview pane, or type your brief.
           </p>
         ) : (
           messages.map((m, i) => (
@@ -170,53 +65,43 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
       </div>
 
       <form onSubmit={handleSubmit} className="border-t border-[var(--color-border-muted)] p-4">
-        <div className="relative flex items-end gap-2 p-2 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] focus-within:border-[var(--color-accent)] focus-within:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[var(--ease-out)]">
+        <div className="relative rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] focus-within:border-[var(--color-accent)] focus-within:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[var(--ease-out)]">
           <textarea
             ref={taRef}
             value={prompt}
             onChange={(e) => {
               setPrompt(e.target.value);
-              e.currentTarget.style.height = 'auto';
-              e.currentTarget.style.height = `${Math.min(e.currentTarget.scrollHeight, 160)}px`;
+              resizeTextarea(e.currentTarget);
             }}
             onKeyDown={handleKeyDown}
-            placeholder={t('chat.placeholder')}
+            placeholder="Describe what to design… (Enter to send, Shift+Enter for newline)"
             disabled={isGenerating}
             rows={1}
-            className="flex-1 resize-none bg-transparent px-2 py-1 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[160px]"
+            className="block w-full resize-none bg-transparent px-3 pt-3 pb-10 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[144px] overflow-y-auto"
           />
-          <button
-            type="submit"
-            disabled={!canSend}
-            aria-label={t('common.send')}
-            className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 disabled:pointer-events-none transition-[transform,background-color,opacity] duration-150 ease-[var(--ease-out)]"
-          >
-            <ArrowUp className="w-4 h-4" strokeWidth={2.4} />
-          </button>
-        </div>
-        <div className="mt-2 px-1 text-[11px] text-[var(--color-text-muted)] flex items-center justify-between">
-          <span>
-            <kbd
-              className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
-              style={{ fontFamily: 'var(--font-mono)' }}
-            >
-              Enter
-            </kbd>{' '}
-            {t('chat.sendAction')} /{' '}
-            <kbd
-              className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
-              style={{ fontFamily: 'var(--font-mono)' }}
-            >
-              Cmd/Ctrl+Enter
-            </kbd>{' '}
-            {t('chat.sendAnywhere')}
-          </span>
-          {isGenerating ? (
-            <span className="inline-flex items-center gap-1.5 text-[var(--color-accent)]">
-              <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-pulse" />
-              {t('common.working')}
-            </span>
-          ) : null}
+
+          {/* action button pinned to bottom-right inside the textarea container */}
+          <div className="absolute bottom-2 right-2">
+            {isGenerating ? (
+              <button
+                type="button"
+                onClick={cancelGeneration}
+                aria-label="Stop generation"
+                className="inline-flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color] duration-150 ease-[var(--ease-out)]"
+              >
+                <Square className="w-3.5 h-3.5" strokeWidth={0} fill="currentColor" />
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={!canSend}
+                aria-label="Send prompt"
+                className="inline-flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 disabled:pointer-events-none transition-[transform,background-color,opacity] duration-150 ease-[var(--ease-out)]"
+              >
+                <ArrowUp className="w-3.5 h-3.5" strokeWidth={2.4} />
+              </button>
+            )}
+          </div>
         </div>
       </form>
     </aside>

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -10,15 +10,26 @@ export interface SidebarProps {
 }
 
 const MAX_TEXTAREA_ROWS = 6;
-const FALLBACK_ROW_HEIGHT = 24;
+const FALLBACK_FONT_SIZE = 13;
+const FALLBACK_LINE_HEIGHT_MULTIPLIER = 1.6;
 
-function getTextareaRowHeight(el: HTMLTextAreaElement): number {
-  const rowHeight = Number.parseFloat(getComputedStyle(el).getPropertyValue('--space-6'));
-  return Number.isFinite(rowHeight) && rowHeight > 0 ? rowHeight : FALLBACK_ROW_HEIGHT;
+export function getTextareaLineHeight(el: HTMLTextAreaElement): number {
+  const styles = getComputedStyle(el);
+  const lineHeight = Number.parseFloat(styles.lineHeight);
+  if (Number.isFinite(lineHeight) && lineHeight > 0) return lineHeight;
+
+  const fontSize = Number.parseFloat(styles.fontSize);
+  const leading = Number.parseFloat(styles.getPropertyValue('--leading-body'));
+  const resolvedFontSize =
+    Number.isFinite(fontSize) && fontSize > 0 ? fontSize : FALLBACK_FONT_SIZE;
+  const resolvedLeading =
+    Number.isFinite(leading) && leading > 0 ? leading : FALLBACK_LINE_HEIGHT_MULTIPLIER;
+
+  return resolvedFontSize * resolvedLeading;
 }
 
 function resizeTextarea(el: HTMLTextAreaElement): void {
-  const rowHeight = getTextareaRowHeight(el);
+  const rowHeight = getTextareaLineHeight(el);
   el.style.height = 'auto';
   el.style.height = `${Math.min(el.scrollHeight, rowHeight * MAX_TEXTAREA_ROWS)}px`;
 }
@@ -84,7 +95,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
             placeholder="Describe what to design... (Enter to send, Shift+Enter for newline)"
             disabled={isGenerating}
             rows={1}
-            className="block w-full resize-none bg-transparent px-[var(--space-3)] pt-[var(--space-3)] pb-[calc(var(--space-6)+var(--space-4))] text-[var(--text-sm)] leading-[var(--leading-body)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[var(--space-6)] max-h-[calc(var(--space-6)*6)] overflow-y-auto"
+            className="block w-full resize-none bg-transparent px-[var(--space-3)] pt-[var(--space-3)] pb-[calc(var(--space-6)+var(--space-4))] text-[var(--text-sm)] leading-[var(--leading-body)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[var(--space-6)] overflow-y-auto"
           />
 
           <div className="absolute bottom-[var(--space-2)] right-[var(--space-2)]">

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -11,8 +11,6 @@ export interface SidebarProps {
 }
 
 const MAX_TEXTAREA_ROWS = 6;
-const FALLBACK_FONT_SIZE = 13;
-const FALLBACK_LINE_HEIGHT_MULTIPLIER = 1.6;
 
 export function getTextareaLineHeight(el: HTMLTextAreaElement): number {
   const styles = getComputedStyle(el);
@@ -21,12 +19,10 @@ export function getTextareaLineHeight(el: HTMLTextAreaElement): number {
 
   const fontSize = Number.parseFloat(styles.fontSize);
   const leading = Number.parseFloat(styles.getPropertyValue('--leading-body'));
-  const resolvedFontSize =
-    Number.isFinite(fontSize) && fontSize > 0 ? fontSize : FALLBACK_FONT_SIZE;
-  const resolvedLeading =
-    Number.isFinite(leading) && leading > 0 ? leading : FALLBACK_LINE_HEIGHT_MULTIPLIER;
-
-  return resolvedFontSize * resolvedLeading;
+  if (!Number.isFinite(fontSize) || fontSize <= 0 || !Number.isFinite(leading) || leading <= 0) {
+    throw new Error('Textarea sizing tokens (--leading-body / fontSize) are missing or invalid');
+  }
+  return fontSize * leading;
 }
 
 function resizeTextarea(el: HTMLTextAreaElement): void {

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -104,7 +104,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
                 size="sm"
                 label="Stop generation"
                 onClick={cancelGeneration}
-                className="bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] hover:text-white hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color,color] duration-150 ease-[var(--ease-out)]"
+                className="bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color,color] duration-150 ease-[var(--ease-out)]"
               >
                 <Square className="w-4 h-4" strokeWidth={0} fill="currentColor" />
               </IconButton>
@@ -114,7 +114,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
                 type="submit"
                 label="Send prompt"
                 disabled={!canSend}
-                className="bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-white hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-150 ease-[var(--ease-out)]"
+                className="bg-[var(--color-accent)] text-[var(--color-on-accent)] shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-150 ease-[var(--ease-out)]"
               >
                 <ArrowUp className="w-4 h-4" strokeWidth={2.4} />
               </IconButton>

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
+import { IconButton } from '@open-codesign/ui';
 import { ArrowUp, Square } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { type FormEvent, type KeyboardEvent, useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
 
 export interface SidebarProps {
@@ -8,11 +9,18 @@ export interface SidebarProps {
   onSubmit: () => void;
 }
 
-const MAX_TEXTAREA_HEIGHT = 144; // 6 lines × ~24px
+const MAX_TEXTAREA_ROWS = 6;
+const FALLBACK_ROW_HEIGHT = 24;
+
+function getTextareaRowHeight(el: HTMLTextAreaElement): number {
+  const rowHeight = Number.parseFloat(getComputedStyle(el).getPropertyValue('--space-6'));
+  return Number.isFinite(rowHeight) && rowHeight > 0 ? rowHeight : FALLBACK_ROW_HEIGHT;
+}
 
 function resizeTextarea(el: HTMLTextAreaElement): void {
+  const rowHeight = getTextareaRowHeight(el);
   el.style.height = 'auto';
-  el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_HEIGHT)}px`;
+  el.style.height = `${Math.min(el.scrollHeight, rowHeight * MAX_TEXTAREA_ROWS)}px`;
 }
 
 export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
@@ -22,17 +30,16 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    // sync height on mount to match any pre-filled value
     if (taRef.current) resizeTextarea(taRef.current);
   }, []);
 
-  function handleSubmit(e: React.FormEvent): void {
+  function handleSubmit(e: FormEvent): void {
     e.preventDefault();
     if (!prompt.trim() || isGenerating) return;
     onSubmit();
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>): void {
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
     if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       e.preventDefault();
       handleSubmit(e);
@@ -42,7 +49,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
   const canSend = prompt.trim().length > 0 && !isGenerating;
 
   return (
-    <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)] min-h-0">
+    <aside className="flex flex-col min-h-0 border-r border-[var(--color-border)] bg-[var(--color-background-secondary)]">
       <div className="flex-1 overflow-y-auto px-5 py-6 space-y-3">
         {messages.length === 0 ? (
           <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
@@ -52,7 +59,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
           messages.map((m, i) => (
             <div
               key={`${m.role}-${i}-${m.content.slice(0, 8)}`}
-              className={`px-4 py-3 rounded-[var(--radius-lg)] text-[var(--text-sm)] leading-[1.55] ${
+              className={`px-[var(--space-4)] py-[var(--space-3)] rounded-[var(--radius-lg)] text-[var(--text-sm)] leading-[var(--leading-body)] ${
                 m.role === 'user'
                   ? 'bg-[var(--color-accent-soft)] text-[var(--color-text-primary)] border border-[var(--color-accent-muted)]'
                   : 'bg-[var(--color-surface)] border border-[var(--color-border-muted)] text-[var(--color-text-primary)]'
@@ -74,32 +81,32 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
               resizeTextarea(e.currentTarget);
             }}
             onKeyDown={handleKeyDown}
-            placeholder="Describe what to design… (Enter to send, Shift+Enter for newline)"
+            placeholder="Describe what to design... (Enter to send, Shift+Enter for newline)"
             disabled={isGenerating}
             rows={1}
-            className="block w-full resize-none bg-transparent px-3 pt-3 pb-10 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[144px] overflow-y-auto"
+            className="block w-full resize-none bg-transparent px-[var(--space-3)] pt-[var(--space-3)] pb-[calc(var(--space-6)+var(--space-4))] text-[var(--text-sm)] leading-[var(--leading-body)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[var(--space-6)] max-h-[calc(var(--space-6)*6)] overflow-y-auto"
           />
 
-          {/* action button pinned to bottom-right inside the textarea container */}
-          <div className="absolute bottom-2 right-2">
+          <div className="absolute bottom-[var(--space-2)] right-[var(--space-2)]">
             {isGenerating ? (
-              <button
-                type="button"
+              <IconButton
+                size="sm"
+                label="Stop generation"
                 onClick={cancelGeneration}
-                aria-label="Stop generation"
-                className="inline-flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color] duration-150 ease-[var(--ease-out)]"
+                className="bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] hover:text-white hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color,color] duration-150 ease-[var(--ease-out)]"
               >
-                <Square className="w-3.5 h-3.5" strokeWidth={0} fill="currentColor" />
-              </button>
+                <Square className="w-4 h-4" strokeWidth={0} fill="currentColor" />
+              </IconButton>
             ) : (
-              <button
+              <IconButton
+                size="sm"
                 type="submit"
+                label="Send prompt"
                 disabled={!canSend}
-                aria-label="Send prompt"
-                className="inline-flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 disabled:pointer-events-none transition-[transform,background-color,opacity] duration-150 ease-[var(--ease-out)]"
+                className="bg-[var(--color-accent)] text-white shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-white hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-150 ease-[var(--ease-out)]"
               >
-                <ArrowUp className="w-3.5 h-3.5" strokeWidth={2.4} />
-              </button>
+                <ArrowUp className="w-4 h-4" strokeWidth={2.4} />
+              </IconButton>
             )}
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
+import { useT } from '@open-codesign/i18n';
 import { IconButton } from '@open-codesign/ui';
-import { ArrowUp, Square } from 'lucide-react';
+import { ArrowUp, FolderOpen, Link2, Paperclip, Square, X } from 'lucide-react';
 import { type FormEvent, type KeyboardEvent, useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
 
@@ -35,10 +36,21 @@ function resizeTextarea(el: HTMLTextAreaElement): void {
 }
 
 export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
+  const t = useT();
+  const config = useCodesignStore((s) => s.config);
   const messages = useCodesignStore((s) => s.messages);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const cancelGeneration = useCodesignStore((s) => s.cancelGeneration);
+  const inputFiles = useCodesignStore((s) => s.inputFiles);
+  const referenceUrl = useCodesignStore((s) => s.referenceUrl);
+  const setReferenceUrl = useCodesignStore((s) => s.setReferenceUrl);
+  const pickInputFiles = useCodesignStore((s) => s.pickInputFiles);
+  const removeInputFile = useCodesignStore((s) => s.removeInputFile);
+  const pickDesignSystemDirectory = useCodesignStore((s) => s.pickDesignSystemDirectory);
+  const clearDesignSystem = useCodesignStore((s) => s.clearDesignSystem);
   const taRef = useRef<HTMLTextAreaElement>(null);
+
+  const designSystem = config?.designSystem ?? null;
 
   useEffect(() => {
     if (taRef.current) resizeTextarea(taRef.current);
@@ -61,10 +73,109 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
 
   return (
     <aside className="flex flex-col min-h-0 border-r border-[var(--color-border)] bg-[var(--color-background-secondary)]">
+      <div className="px-5 py-5 border-b border-[var(--color-border-muted)] space-y-3">
+        <div className="space-y-2">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+            {t('sidebar.localContext')}
+          </div>
+          <div className="grid grid-cols-1 gap-2">
+            <button
+              type="button"
+              onClick={() => void pickInputFiles()}
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+            >
+              <Paperclip className="w-4 h-4 text-[var(--color-text-secondary)]" />
+              {t('sidebar.attachLocalFiles')}
+            </button>
+            <button
+              type="button"
+              onClick={() => void pickDesignSystemDirectory()}
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+            >
+              <FolderOpen className="w-4 h-4 text-[var(--color-text-secondary)]" />
+              {designSystem
+                ? t('sidebar.refreshDesignSystemRepo')
+                : t('sidebar.linkDesignSystemRepo')}
+            </button>
+          </div>
+        </div>
+
+        <label className="block space-y-2">
+          <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+            <Link2 className="w-3.5 h-3.5" />
+            {t('sidebar.referenceUrl')}
+          </span>
+          <input
+            type="url"
+            value={referenceUrl}
+            onChange={(e) => setReferenceUrl(e.target.value)}
+            placeholder="https://example.com/reference"
+            className="w-full h-10 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150"
+          />
+        </label>
+
+        {inputFiles.length > 0 ? (
+          <div className="space-y-2">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+              {t('sidebar.attachedFiles')}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {inputFiles.map((file) => (
+                <span
+                  key={file.path}
+                  className="inline-flex items-center gap-1.5 max-w-full rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[11px] text-[var(--color-text-secondary)]"
+                >
+                  <span className="truncate max-w-[180px]" title={file.path}>
+                    {file.name}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeInputFile(file.path)}
+                    className="inline-flex items-center justify-center rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+                    aria-label={t('sidebar.removeFile', { name: file.name })}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {designSystem ? (
+          <div className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 space-y-2">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[12px] font-medium text-[var(--color-text-primary)]">
+                  {t('sidebar.activeDesignSystem')}
+                </div>
+                <div className="text-[11px] text-[var(--color-text-muted)] break-all">
+                  {designSystem.rootPath}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void clearDesignSystem()}
+                className="text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+              >
+                {t('sidebar.clear')}
+              </button>
+            </div>
+            <p className="text-[12px] text-[var(--color-text-secondary)] leading-[1.5]">
+              {designSystem.summary}
+            </p>
+          </div>
+        ) : (
+          <p className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
+            {t('sidebar.designSystemHint')}
+          </p>
+        )}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-5 py-6 space-y-3">
         {messages.length === 0 ? (
           <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
-            Start a conversation. Pick a starter from the preview pane, or type your brief.
+            {t('sidebar.startHint')}
           </p>
         ) : (
           messages.map((m, i) => (
@@ -92,7 +203,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
               resizeTextarea(e.currentTarget);
             }}
             onKeyDown={handleKeyDown}
-            placeholder="Describe what to design... (Enter to send, Shift+Enter for newline)"
+            placeholder={t('chat.placeholder')}
             disabled={isGenerating}
             rows={1}
             className="block w-full resize-none bg-transparent px-[var(--space-3)] pt-[var(--space-3)] pb-[calc(var(--space-6)+var(--space-4))] text-[var(--text-sm)] leading-[var(--leading-body)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[var(--space-6)] overflow-y-auto"
@@ -102,7 +213,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
             {isGenerating ? (
               <IconButton
                 size="sm"
-                label="Stop generation"
+                label={t('chat.stop')}
                 onClick={cancelGeneration}
                 className="bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[1.04] active:scale-[0.96] transition-[transform,background-color,color] duration-150 ease-[var(--ease-out)]"
               >
@@ -112,7 +223,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
               <IconButton
                 size="sm"
                 type="submit"
-                label="Send prompt"
+                label={t('chat.send')}
                 disabled={!canSend}
                 className="bg-[var(--color-accent)] text-[var(--color-on-accent)] shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[1.04] active:scale-[0.96] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-150 ease-[var(--ease-out)]"
               >

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -113,7 +113,7 @@ describe('useCodesignStore generation cancellation', () => {
       string,
       ReturnType<typeof deferred<{ artifacts: Array<{ content: string }>; message: string }>>
     >();
-    const cancelGeneration = vi.fn();
+    const cancelGeneration = vi.fn(() => Promise.resolve());
     const generate = vi.fn((payload: { generationId?: string }) => {
       if (!payload.generationId) throw new Error('missing generationId');
       const task = deferred<{ artifacts: Array<{ content: string }>; message: string }>();
@@ -134,6 +134,9 @@ describe('useCodesignStore generation cancellation', () => {
     if (!firstId) throw new Error('expected first generation id');
 
     useCodesignStore.getState().cancelGeneration();
+
+    // Drain microtasks so the cancel IPC promise resolves and clears state
+    await Promise.resolve();
 
     const secondRun = useCodesignStore.getState().sendPrompt({ prompt: 'second prompt' });
     const secondId = useCodesignStore.getState().activeGenerationId;
@@ -179,7 +182,7 @@ describe('useCodesignStore generation cancellation', () => {
     vi.stubGlobal('window', {
       codesign: {
         generate,
-        cancelGeneration: vi.fn(),
+        cancelGeneration: vi.fn(() => Promise.resolve()),
       },
       setTimeout,
     });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -126,6 +126,7 @@ describe('useCodesignStore generation cancellation', () => {
         generate,
         cancelGeneration,
       },
+      setTimeout,
     });
 
     const firstRun = useCodesignStore.getState().sendPrompt('first prompt');
@@ -161,5 +162,48 @@ describe('useCodesignStore generation cancellation', () => {
     expect(cancelGeneration).toHaveBeenCalledWith(firstId);
     expect(useCodesignStore.getState().previewHtml).toBe('<html>fresh</html>');
     expect(useCodesignStore.getState().isGenerating).toBe(false);
+  });
+
+  it('surfaces current-generation failures even when the message contains abort wording', async () => {
+    const pendingById = new Map<
+      string,
+      ReturnType<typeof deferred<{ artifacts: Array<{ content: string }>; message: string }>>
+    >();
+    const generate = vi.fn((payload: { generationId?: string }) => {
+      if (!payload.generationId) throw new Error('missing generationId');
+      const task = deferred<{ artifacts: Array<{ content: string }>; message: string }>();
+      pendingById.set(payload.generationId, task);
+      return task.promise;
+    });
+
+    vi.stubGlobal('window', {
+      codesign: {
+        generate,
+        cancelGeneration: vi.fn(),
+      },
+      setTimeout,
+    });
+
+    const run = useCodesignStore.getState().sendPrompt('first prompt');
+    const generationId = useCodesignStore.getState().activeGenerationId;
+    if (!generationId) throw new Error('expected generation id');
+
+    pendingById.get(generationId)?.reject(new Error('Upstream proxy aborted the response'));
+    await run;
+
+    const state = useCodesignStore.getState();
+    expect(state.isGenerating).toBe(false);
+    expect(state.activeGenerationId).toBeNull();
+    expect(state.errorMessage).toBe('Upstream proxy aborted the response');
+    expect(state.lastError).toBe('Upstream proxy aborted the response');
+    expect(state.messages.at(-1)).toEqual({
+      role: 'assistant',
+      content: 'Error: Upstream proxy aborted the response',
+    });
+    expect(state.toasts.at(-1)).toMatchObject({
+      variant: 'error',
+      title: 'Generation failed',
+      description: 'Upstream proxy aborted the response',
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -13,12 +13,23 @@ const READY_CONFIG: OnboardingState = {
 
 const initialState = useCodesignStore.getState();
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function resetStore() {
   useCodesignStore.setState({
     ...initialState,
     messages: [],
     previewHtml: null,
     isGenerating: false,
+    activeGenerationId: null,
     errorMessage: null,
     lastError: null,
     config: READY_CONFIG,
@@ -93,5 +104,62 @@ describe('useCodesignStore iframe error handling', () => {
     // oldest (0-4) should have been shifted out; newest (5-54) remain
     expect(errors[0]).toBe('error-5');
     expect(errors[49]).toBe('error-54');
+  });
+});
+
+describe('useCodesignStore generation cancellation', () => {
+  it('ignores stale completions from a cancelled generation after a resubmit', async () => {
+    const pendingById = new Map<
+      string,
+      ReturnType<typeof deferred<{ artifacts: Array<{ content: string }>; message: string }>>
+    >();
+    const cancelGeneration = vi.fn();
+    const generate = vi.fn((payload: { generationId?: string }) => {
+      if (!payload.generationId) throw new Error('missing generationId');
+      const task = deferred<{ artifacts: Array<{ content: string }>; message: string }>();
+      pendingById.set(payload.generationId, task);
+      return task.promise;
+    });
+
+    vi.stubGlobal('window', {
+      codesign: {
+        generate,
+        cancelGeneration,
+      },
+    });
+
+    const firstRun = useCodesignStore.getState().sendPrompt('first prompt');
+    const firstId = useCodesignStore.getState().activeGenerationId;
+    if (!firstId) throw new Error('expected first generation id');
+
+    useCodesignStore.getState().cancelGeneration();
+
+    const secondRun = useCodesignStore.getState().sendPrompt('second prompt');
+    const secondId = useCodesignStore.getState().activeGenerationId;
+    if (!secondId) throw new Error('expected second generation id');
+    expect(secondId).not.toBe(firstId);
+
+    pendingById.get(firstId)?.resolve({
+      artifacts: [{ content: '<html>old</html>' }],
+      message: 'Old result',
+    });
+    await firstRun;
+
+    expect(useCodesignStore.getState().activeGenerationId).toBe(secondId);
+    expect(useCodesignStore.getState().isGenerating).toBe(true);
+    expect(useCodesignStore.getState().previewHtml).toBeNull();
+    expect(
+      useCodesignStore.getState().messages.some((m) => m.content === 'Old result'),
+    ).toBe(false);
+
+    pendingById.get(secondId)?.resolve({
+      artifacts: [{ content: '<html>fresh</html>' }],
+      message: 'Fresh result',
+    });
+    await secondRun;
+
+    expect(cancelGeneration).toHaveBeenCalledWith(firstId);
+    expect(useCodesignStore.getState().previewHtml).toBe('<html>fresh</html>');
+    expect(useCodesignStore.getState().isGenerating).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -129,13 +129,13 @@ describe('useCodesignStore generation cancellation', () => {
       setTimeout,
     });
 
-    const firstRun = useCodesignStore.getState().sendPrompt('first prompt');
+    const firstRun = useCodesignStore.getState().sendPrompt({ prompt: 'first prompt' });
     const firstId = useCodesignStore.getState().activeGenerationId;
     if (!firstId) throw new Error('expected first generation id');
 
     useCodesignStore.getState().cancelGeneration();
 
-    const secondRun = useCodesignStore.getState().sendPrompt('second prompt');
+    const secondRun = useCodesignStore.getState().sendPrompt({ prompt: 'second prompt' });
     const secondId = useCodesignStore.getState().activeGenerationId;
     if (!secondId) throw new Error('expected second generation id');
     expect(secondId).not.toBe(firstId);
@@ -184,7 +184,7 @@ describe('useCodesignStore generation cancellation', () => {
       setTimeout,
     });
 
-    const run = useCodesignStore.getState().sendPrompt('first prompt');
+    const run = useCodesignStore.getState().sendPrompt({ prompt: 'first prompt' });
     const generationId = useCodesignStore.getState().activeGenerationId;
     if (!generationId) throw new Error('expected generation id');
 
@@ -202,7 +202,6 @@ describe('useCodesignStore generation cancellation', () => {
     });
     expect(state.toasts.at(-1)).toMatchObject({
       variant: 'error',
-      title: 'Generation failed',
       description: 'Upstream proxy aborted the response',
     });
   });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1,5 +1,6 @@
 import type { OnboardingState } from '@open-codesign/shared';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initI18n } from '@open-codesign/i18n';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCodesignStore } from './store';
 
 const READY_CONFIG: OnboardingState = {
@@ -108,6 +109,10 @@ describe('useCodesignStore iframe error handling', () => {
 });
 
 describe('useCodesignStore generation cancellation', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
   it('ignores stale completions from a cancelled generation after a resubmit', async () => {
     const pendingById = new Map<
       string,
@@ -165,6 +170,21 @@ describe('useCodesignStore generation cancellation', () => {
     expect(cancelGeneration).toHaveBeenCalledWith(firstId);
     expect(useCodesignStore.getState().previewHtml).toBe('<html>fresh</html>');
     expect(useCodesignStore.getState().isGenerating).toBe(false);
+  });
+
+  it('sets errorMessage and pushes a toast when window.codesign is missing during cancel', () => {
+    vi.stubGlobal('window', { setTimeout });
+
+    useCodesignStore.setState({ activeGenerationId: 'gen-123' });
+
+    useCodesignStore.getState().cancelGeneration();
+
+    const state = useCodesignStore.getState();
+    expect(state.errorMessage).toBeTruthy();
+    expect(state.lastError).toBe(state.errorMessage);
+    expect(state.toasts.at(-1)).toMatchObject({
+      variant: 'error',
+    });
   });
 
   it('surfaces current-generation failures even when the message contains abort wording', async () => {

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -149,9 +149,9 @@ describe('useCodesignStore generation cancellation', () => {
     expect(useCodesignStore.getState().activeGenerationId).toBe(secondId);
     expect(useCodesignStore.getState().isGenerating).toBe(true);
     expect(useCodesignStore.getState().previewHtml).toBeNull();
-    expect(
-      useCodesignStore.getState().messages.some((m) => m.content === 'Old result'),
-    ).toBe(false);
+    expect(useCodesignStore.getState().messages.some((m) => m.content === 'Old result')).toBe(
+      false,
+    );
 
     pendingById.get(secondId)?.resolve({
       artifacts: [{ content: '<html>fresh</html>' }],

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1,5 +1,5 @@
-import type { OnboardingState } from '@open-codesign/shared';
 import { initI18n } from '@open-codesign/i18n';
+import type { OnboardingState } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCodesignStore } from './store';
 

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -235,7 +235,6 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     });
   },
 
-
   async loadConfig() {
     if (!window.codesign) {
       set({

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -103,30 +103,46 @@ function modelRef(provider: SupportedOnboardingProvider, modelId: string): Model
 type SetState = StoreApi<CodesignState>['setState'];
 type GetState = StoreApi<CodesignState>['getState'];
 
-function applyGenerateSuccess(set: SetState, result: unknown): void {
+function finishIfCurrent(
+  set: SetState,
+  generationId: string,
+  update: (state: CodesignState) => Partial<CodesignState>,
+): void {
+  set((state) => (state.activeGenerationId === generationId ? update(state) : {}));
+}
+
+function applyGenerateSuccess(set: SetState, generationId: string, result: unknown): void {
   const r = result as { artifacts: Array<{ content: string }>; message: string };
   const firstArtifact = r.artifacts[0];
   const message = r.message;
-  set((s) => ({
-    messages: [...s.messages, { role: 'assistant', content: message || 'Done.' }],
-    previewHtml: firstArtifact?.content ?? s.previewHtml,
+  finishIfCurrent(set, generationId, (state) => ({
+    messages: [...state.messages, { role: 'assistant', content: message || 'Done.' }],
+    previewHtml: firstArtifact?.content ?? state.previewHtml,
     isGenerating: false,
     activeGenerationId: null,
   }));
 }
 
-function applyGenerateError(get: GetState, set: SetState, err: unknown): void {
+function applyGenerateError(
+  get: GetState,
+  set: SetState,
+  generationId: string,
+  err: unknown,
+): void {
   const msg = err instanceof Error ? err.message : 'Unknown error';
   const lower = msg.toLowerCase();
   const isCancelled = lower.includes('abort') || lower.includes('cancel');
-  set((s) => ({
+  const isCurrentGeneration = get().activeGenerationId === generationId;
+  if (!isCurrentGeneration) return;
+
+  finishIfCurrent(set, generationId, (state) => ({
     messages: isCancelled
-      ? s.messages
-      : [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
+      ? state.messages
+      : [...state.messages, { role: 'assistant', content: `Error: ${msg}` }],
     isGenerating: false,
     activeGenerationId: null,
     errorMessage: isCancelled ? null : msg,
-    lastError: isCancelled ? s.lastError : msg,
+    lastError: isCancelled ? state.lastError : msg,
   }));
   if (!isCancelled) {
     get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
@@ -210,9 +226,9 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         model: modelRef(cfg.provider, cfg.modelPrimary),
         generationId,
       });
-      applyGenerateSuccess(set, result);
+      applyGenerateSuccess(set, generationId, result);
     } catch (err) {
-      applyGenerateError(get, set, err);
+      applyGenerateError(get, set, generationId, err);
     }
   },
 

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -369,8 +369,21 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   cancelGeneration() {
     const id = get().activeGenerationId;
     if (!id || !window.codesign) return;
-    window.codesign.cancelGeneration(id);
-    set({ isGenerating: false, activeGenerationId: null });
+
+    void window.codesign
+      .cancelGeneration(id)
+      .then(() => {
+        finishIfCurrent(set, id, () => ({ isGenerating: false, activeGenerationId: null }));
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : tr('errors.unknown');
+        set({ errorMessage: msg, lastError: msg });
+        get().pushToast({
+          variant: 'error',
+          title: tr('notifications.cancellationFailed'),
+          description: msg,
+        });
+      });
   },
 
   async retryLastPrompt() {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -368,7 +368,17 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   cancelGeneration() {
     const id = get().activeGenerationId;
-    if (!id || !window.codesign) return;
+    if (!id) return;
+    if (!window.codesign) {
+      const msg = tr('errors.rendererDisconnected');
+      set({ errorMessage: msg, lastError: msg });
+      get().pushToast({
+        variant: 'error',
+        title: tr('notifications.cancellationFailed'),
+        description: msg,
+      });
+      return;
+    }
 
     void window.codesign
       .cancelGeneration(id)

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,7 +1,10 @@
+import { i18n } from '@open-codesign/i18n';
 import type {
   ChatMessage,
+  LocalInputFile,
   ModelRef,
   OnboardingState,
+  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { create } from 'zustand';
@@ -25,6 +28,12 @@ export interface Toast {
 
 export type Theme = 'light' | 'dark';
 
+interface PromptRequest {
+  prompt: string;
+  attachments: LocalInputFile[];
+  referenceUrl?: string | undefined;
+}
+
 interface CodesignState {
   messages: ChatMessage[];
   previewHtml: string | null;
@@ -42,15 +51,35 @@ interface CodesignState {
   toasts: Toast[];
   iframeErrors: string[];
 
+  inputFiles: LocalInputFile[];
+  referenceUrl: string;
+  lastPromptInput: PromptRequest | null;
+  selectedElement: SelectedElement | null;
+
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
-  sendPrompt: (prompt: string) => Promise<void>;
+  sendPrompt: (input: {
+    prompt: string;
+    attachments?: LocalInputFile[] | undefined;
+    referenceUrl?: string | undefined;
+  }) => Promise<void>;
   cancelGeneration: () => void;
   retryLastPrompt: () => Promise<void>;
+  applyInlineComment: (comment: string) => Promise<void>;
   clearError: () => void;
   clearIframeErrors: () => void;
   pushIframeError: (message: string) => void;
   exportActive: (format: ExportFormat) => Promise<void>;
+
+  pickInputFiles: () => Promise<void>;
+  removeInputFile: (path: string) => void;
+  clearInputFiles: () => void;
+  setReferenceUrl: (value: string) => void;
+  pickDesignSystemDirectory: () => Promise<void>;
+  clearDesignSystem: () => Promise<void>;
+
+  selectCanvasElement: (selection: SelectedElement) => void;
+  clearCanvasElement: () => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -100,6 +129,26 @@ function modelRef(provider: SupportedOnboardingProvider, modelId: string): Model
   return { provider, modelId };
 }
 
+function normalizeReferenceUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function uniqueFiles(files: LocalInputFile[]): LocalInputFile[] {
+  const seen = new Set<string>();
+  const result: LocalInputFile[] = [];
+  for (const file of files) {
+    if (seen.has(file.path)) continue;
+    seen.add(file.path);
+    result.push(file);
+  }
+  return result;
+}
+
+function tr(key: string, options?: Record<string, unknown>): string {
+  return i18n.t(key, options ?? {}) as string;
+}
+
 type SetState = StoreApi<CodesignState>['setState'];
 type GetState = StoreApi<CodesignState>['getState'];
 
@@ -111,12 +160,17 @@ function finishIfCurrent(
   set((state) => (state.activeGenerationId === generationId ? update(state) : {}));
 }
 
-function applyGenerateSuccess(set: SetState, generationId: string, result: unknown): void {
-  const r = result as { artifacts: Array<{ content: string }>; message: string };
-  const firstArtifact = r.artifacts[0];
-  const message = r.message;
+function applyGenerateSuccess(
+  set: SetState,
+  generationId: string,
+  result: { artifacts: Array<{ content: string }>; message: string },
+): void {
+  const firstArtifact = result.artifacts[0];
   finishIfCurrent(set, generationId, (state) => ({
-    messages: [...state.messages, { role: 'assistant', content: message || 'Done.' }],
+    messages: [
+      ...state.messages,
+      { role: 'assistant', content: result.message || tr('common.done') },
+    ],
     previewHtml: firstArtifact?.content ?? state.previewHtml,
     isGenerating: false,
     activeGenerationId: null,
@@ -129,7 +183,7 @@ function applyGenerateError(
   generationId: string,
   err: unknown,
 ): void {
-  const msg = err instanceof Error ? err.message : 'Unknown error';
+  const msg = err instanceof Error ? err.message : tr('errors.unknown');
   if (get().activeGenerationId !== generationId) return;
 
   finishIfCurrent(set, generationId, (state) => ({
@@ -139,7 +193,11 @@ function applyGenerateError(
     errorMessage: msg,
     lastError: msg,
   }));
-  get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
+  get().pushToast({
+    variant: 'error',
+    title: tr('notifications.generationFailed'),
+    description: msg,
+  });
 }
 
 export const useCodesignStore = create<CodesignState>((set, get) => ({
@@ -159,6 +217,11 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   toasts: [],
   iframeErrors: [],
 
+  inputFiles: [],
+  referenceUrl: '',
+  lastPromptInput: null,
+  selectedElement: null,
+
   clearIframeErrors() {
     set({ iframeErrors: [] });
   },
@@ -177,7 +240,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     if (!window.codesign) {
       set({
         configLoaded: true,
-        errorMessage: 'Renderer is not connected to the main process.',
+        errorMessage: tr('errors.rendererDisconnected'),
       });
       return;
     }
@@ -189,37 +252,115 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     set({ config: next });
   },
 
-  async sendPrompt(prompt: string) {
+  async pickInputFiles() {
+    if (!window.codesign) return;
+    const files = await window.codesign.pickInputFiles();
+    if (files.length === 0) return;
+    set((s) => ({ inputFiles: uniqueFiles([...s.inputFiles, ...files]) }));
+  },
+
+  removeInputFile(path) {
+    set((s) => ({ inputFiles: s.inputFiles.filter((file) => file.path !== path) }));
+  },
+
+  clearInputFiles() {
+    set({ inputFiles: [] });
+  },
+
+  setReferenceUrl(value) {
+    set({ referenceUrl: value });
+  },
+
+  async pickDesignSystemDirectory() {
+    if (!window.codesign) return;
+    try {
+      const next = await window.codesign.pickDesignSystemDirectory();
+      set({ config: next });
+      if (next.designSystem) {
+        get().pushToast({
+          variant: 'success',
+          title: tr('notifications.designSystemLinked'),
+          description: next.designSystem.summary,
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : tr('errors.generic');
+      get().pushToast({
+        variant: 'error',
+        title: tr('notifications.designSystemScanFailed'),
+        description: message,
+      });
+    }
+  },
+
+  async clearDesignSystem() {
+    if (!window.codesign) return;
+    try {
+      const next = await window.codesign.clearDesignSystem();
+      set({ config: next });
+      get().pushToast({ variant: 'info', title: tr('notifications.designSystemCleared') });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : tr('errors.generic');
+      get().pushToast({
+        variant: 'error',
+        title: tr('notifications.clearDesignSystemFailed'),
+        description: message,
+      });
+    }
+  },
+
+  async sendPrompt(input) {
     if (get().isGenerating) return;
     if (!window.codesign) {
-      const msg = 'Renderer is not connected to the main process.';
+      const msg = tr('errors.rendererDisconnected');
       set({ errorMessage: msg, lastError: msg });
       return;
     }
     const cfg = get().config;
     if (cfg === null || !cfg.hasKey || cfg.provider === null || cfg.modelPrimary === null) {
-      const msg = 'Onboarding is not complete.';
+      const msg = tr('errors.onboardingIncomplete');
       set({ errorMessage: msg, lastError: msg });
       return;
     }
 
+    const prompt = input.prompt.trim();
+    if (!prompt) return;
+
+    const request: PromptRequest = {
+      prompt,
+      attachments: uniqueFiles(input.attachments ?? get().inputFiles),
+      ...(normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl)
+        ? { referenceUrl: normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl) }
+        : {}),
+    };
+
     const generationId = newId();
+    const history = get().messages;
     const userMessage: ChatMessage = { role: 'user', content: prompt };
     set((s) => ({
       messages: [...s.messages, userMessage],
       isGenerating: true,
       activeGenerationId: generationId,
       errorMessage: null,
+      lastPromptInput: request,
+      selectedElement: null,
+      iframeErrors: [],
     }));
 
     try {
       const result = await window.codesign.generate({
         prompt,
-        history: get().messages,
+        history,
         model: modelRef(cfg.provider, cfg.modelPrimary),
+        ...(request.referenceUrl ? { referenceUrl: request.referenceUrl } : {}),
+        attachments: request.attachments,
         generationId,
       });
-      applyGenerateSuccess(set, generationId, result);
+      applyGenerateSuccess(
+        set,
+        generationId,
+        result as { artifacts: Array<{ content: string }>; message: string },
+      );
     } catch (err) {
       applyGenerateError(get, set, generationId, err);
     }
@@ -233,15 +374,72 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   },
 
   async retryLastPrompt() {
-    const lastUser = [...get().messages].reverse().find((m) => m.role === 'user');
-    if (!lastUser) return;
+    const lastPromptInput = get().lastPromptInput;
+    if (!lastPromptInput) return;
+
+    const messages = [...get().messages];
+    const lastMessage = messages.at(-1);
+    if (lastMessage?.role === 'assistant' && lastMessage.content.startsWith('Error:'))
+      messages.pop();
+    const maybeUser = messages.at(-1);
+    if (maybeUser?.role === 'user' && maybeUser.content === lastPromptInput.prompt) messages.pop();
+
+    set({ messages, errorMessage: null });
+    await get().sendPrompt(lastPromptInput);
+  },
+
+  async applyInlineComment(comment) {
+    const trimmed = comment.trim();
+    if (!trimmed || get().isGenerating) return;
+    if (!window.codesign) return;
+    const cfg = get().config;
+    const html = get().previewHtml;
+    const selection = get().selectedElement;
+    if (cfg === null || !cfg.hasKey || html === null || selection === null) return;
+
+    const userMessage: ChatMessage = { role: 'user', content: `Edit ${selection.tag}: ${trimmed}` };
+    const referenceUrl = normalizeReferenceUrl(get().referenceUrl);
+    const attachments = uniqueFiles(get().inputFiles);
+
     set((s) => ({
-      messages: s.messages.filter(
-        (m) => m !== lastUser && !(m.role === 'assistant' && m.content.startsWith('Error:')),
-      ),
+      messages: [...s.messages, userMessage],
+      isGenerating: true,
       errorMessage: null,
+      iframeErrors: [],
     }));
-    await get().sendPrompt(lastUser.content);
+
+    try {
+      const result = await window.codesign.applyComment({
+        html,
+        comment: trimmed,
+        selection,
+        ...(referenceUrl ? { referenceUrl } : {}),
+        attachments,
+      });
+      const firstArtifact = result.artifacts[0];
+      set((s) => ({
+        messages: [
+          ...s.messages,
+          { role: 'assistant', content: result.message || tr('common.applied') },
+        ],
+        previewHtml: firstArtifact?.content ?? s.previewHtml,
+        isGenerating: false,
+        selectedElement: null,
+      }));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      set((s) => ({
+        messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
+        isGenerating: false,
+        errorMessage: msg,
+        lastError: msg,
+      }));
+      get().pushToast({
+        variant: 'error',
+        title: tr('notifications.inlineCommentFailed'),
+        description: msg,
+      });
+    }
   },
 
   clearError() {
@@ -251,11 +449,11 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   async exportActive(format: ExportFormat) {
     const html = get().previewHtml;
     if (!html) {
-      set({ toastMessage: 'No design to export yet.' });
+      set({ toastMessage: tr('notifications.noDesignToExport') });
       return;
     }
     if (!window.codesign) {
-      set({ errorMessage: 'Renderer is not connected to the main process.' });
+      set({ errorMessage: tr('errors.rendererDisconnected') });
       return;
     }
     try {
@@ -266,12 +464,20 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         defaultFilename: `codesign-${stamp}.${format}`,
       });
       if (res.status === 'saved' && res.path) {
-        set({ toastMessage: `Exported to ${res.path}` });
+        set({ toastMessage: tr('notifications.exportedTo', { path: res.path }) });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Unknown error';
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
       set({ toastMessage: msg, errorMessage: msg, lastError: msg });
     }
+  },
+
+  selectCanvasElement(selection) {
+    set({ selectedElement: selection });
+  },
+
+  clearCanvasElement() {
+    set({ selectedElement: null });
   },
 
   setTheme(theme) {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -130,23 +130,16 @@ function applyGenerateError(
   err: unknown,
 ): void {
   const msg = err instanceof Error ? err.message : 'Unknown error';
-  const lower = msg.toLowerCase();
-  const isCancelled = lower.includes('abort') || lower.includes('cancel');
-  const isCurrentGeneration = get().activeGenerationId === generationId;
-  if (!isCurrentGeneration) return;
+  if (get().activeGenerationId !== generationId) return;
 
   finishIfCurrent(set, generationId, (state) => ({
-    messages: isCancelled
-      ? state.messages
-      : [...state.messages, { role: 'assistant', content: `Error: ${msg}` }],
+    messages: [...state.messages, { role: 'assistant', content: `Error: ${msg}` }],
     isGenerating: false,
     activeGenerationId: null,
-    errorMessage: isCancelled ? null : msg,
-    lastError: isCancelled ? state.lastError : msg,
+    errorMessage: msg,
+    lastError: msg,
   }));
-  if (!isCancelled) {
-    get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
-  }
+  get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
 }
 
 export const useCodesignStore = create<CodesignState>((set, get) => ({

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,13 +1,11 @@
-import { i18n } from '@open-codesign/i18n';
 import type {
   ChatMessage,
-  LocalInputFile,
   ModelRef,
   OnboardingState,
-  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { create } from 'zustand';
+import type { StoreApi } from 'zustand';
 import type { CodesignApi, ExportFormat } from '../../preload/index';
 
 declare global {
@@ -27,16 +25,11 @@ export interface Toast {
 
 export type Theme = 'light' | 'dark';
 
-interface PromptRequest {
-  prompt: string;
-  attachments: LocalInputFile[];
-  referenceUrl?: string | undefined;
-}
-
 interface CodesignState {
   messages: ChatMessage[];
   previewHtml: string | null;
   isGenerating: boolean;
+  activeGenerationId: string | null;
   errorMessage: string | null;
   lastError: string | null;
   config: OnboardingState | null;
@@ -49,34 +42,15 @@ interface CodesignState {
   toasts: Toast[];
   iframeErrors: string[];
 
-  inputFiles: LocalInputFile[];
-  referenceUrl: string;
-  lastPromptInput: PromptRequest | null;
-  selectedElement: SelectedElement | null;
-
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
-  sendPrompt: (input: {
-    prompt: string;
-    attachments?: LocalInputFile[] | undefined;
-    referenceUrl?: string | undefined;
-  }) => Promise<void>;
+  sendPrompt: (prompt: string) => Promise<void>;
+  cancelGeneration: () => void;
   retryLastPrompt: () => Promise<void>;
-  applyInlineComment: (comment: string) => Promise<void>;
   clearError: () => void;
   clearIframeErrors: () => void;
   pushIframeError: (message: string) => void;
   exportActive: (format: ExportFormat) => Promise<void>;
-
-  pickInputFiles: () => Promise<void>;
-  removeInputFile: (path: string) => void;
-  clearInputFiles: () => void;
-  setReferenceUrl: (value: string) => void;
-  pickDesignSystemDirectory: () => Promise<void>;
-  clearDesignSystem: () => Promise<void>;
-
-  selectCanvasElement: (selection: SelectedElement) => void;
-  clearCanvasElement: () => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -126,30 +100,44 @@ function modelRef(provider: SupportedOnboardingProvider, modelId: string): Model
   return { provider, modelId };
 }
 
-function normalizeReferenceUrl(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+type SetState = StoreApi<CodesignState>['setState'];
+type GetState = StoreApi<CodesignState>['getState'];
+
+function applyGenerateSuccess(set: SetState, result: unknown): void {
+  const r = result as { artifacts: Array<{ content: string }>; message: string };
+  const firstArtifact = r.artifacts[0];
+  const message = r.message;
+  set((s) => ({
+    messages: [...s.messages, { role: 'assistant', content: message || 'Done.' }],
+    previewHtml: firstArtifact?.content ?? s.previewHtml,
+    isGenerating: false,
+    activeGenerationId: null,
+  }));
 }
 
-function uniqueFiles(files: LocalInputFile[]): LocalInputFile[] {
-  const seen = new Set<string>();
-  const result: LocalInputFile[] = [];
-  for (const file of files) {
-    if (seen.has(file.path)) continue;
-    seen.add(file.path);
-    result.push(file);
+function applyGenerateError(get: GetState, set: SetState, err: unknown): void {
+  const msg = err instanceof Error ? err.message : 'Unknown error';
+  const lower = msg.toLowerCase();
+  const isCancelled = lower.includes('abort') || lower.includes('cancel');
+  set((s) => ({
+    messages: isCancelled
+      ? s.messages
+      : [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
+    isGenerating: false,
+    activeGenerationId: null,
+    errorMessage: isCancelled ? null : msg,
+    lastError: isCancelled ? s.lastError : msg,
+  }));
+  if (!isCancelled) {
+    get().pushToast({ variant: 'error', title: 'Generation failed', description: msg });
   }
-  return result;
-}
-
-function tr(key: string, options?: Record<string, unknown>): string {
-  return i18n.t(key, options ?? {}) as string;
 }
 
 export const useCodesignStore = create<CodesignState>((set, get) => ({
   messages: [],
   previewHtml: null,
   isGenerating: false,
+  activeGenerationId: null,
   errorMessage: null,
   lastError: null,
   config: null,
@@ -161,11 +149,6 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   commandPaletteOpen: false,
   toasts: [],
   iframeErrors: [],
-
-  inputFiles: [],
-  referenceUrl: '',
-  lastPromptInput: null,
-  selectedElement: null,
 
   clearIframeErrors() {
     set({ iframeErrors: [] });
@@ -180,11 +163,12 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     });
   },
 
+
   async loadConfig() {
     if (!window.codesign) {
       set({
         configLoaded: true,
-        errorMessage: tr('errors.rendererDisconnected'),
+        errorMessage: 'Renderer is not connected to the main process.',
       });
       return;
     }
@@ -196,199 +180,59 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     set({ config: next });
   },
 
-  async pickInputFiles() {
-    if (!window.codesign) return;
-    const files = await window.codesign.pickInputFiles();
-    if (files.length === 0) return;
-    set((s) => ({ inputFiles: uniqueFiles([...s.inputFiles, ...files]) }));
-  },
-
-  removeInputFile(path) {
-    set((s) => ({ inputFiles: s.inputFiles.filter((file) => file.path !== path) }));
-  },
-
-  clearInputFiles() {
-    set({ inputFiles: [] });
-  },
-
-  setReferenceUrl(value) {
-    set({ referenceUrl: value });
-  },
-
-  async pickDesignSystemDirectory() {
-    if (!window.codesign) return;
-    try {
-      const next = await window.codesign.pickDesignSystemDirectory();
-      set({ config: next });
-      if (next.designSystem) {
-        get().pushToast({
-          variant: 'success',
-          title: tr('notifications.designSystemLinked'),
-          description: next.designSystem.summary,
-        });
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : tr('errors.generic');
-      get().pushToast({
-        variant: 'error',
-        title: tr('notifications.designSystemScanFailed'),
-        description: message,
-      });
-    }
-  },
-
-  async clearDesignSystem() {
-    if (!window.codesign) return;
-    try {
-      const next = await window.codesign.clearDesignSystem();
-      set({ config: next });
-      get().pushToast({ variant: 'info', title: tr('notifications.designSystemCleared') });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : tr('errors.generic');
-      get().pushToast({
-        variant: 'error',
-        title: tr('notifications.clearDesignSystemFailed'),
-        description: message,
-      });
-    }
-  },
-
-  async sendPrompt(input) {
+  async sendPrompt(prompt: string) {
     if (get().isGenerating) return;
     if (!window.codesign) {
-      const msg = tr('errors.rendererDisconnected');
+      const msg = 'Renderer is not connected to the main process.';
       set({ errorMessage: msg, lastError: msg });
       return;
     }
     const cfg = get().config;
     if (cfg === null || !cfg.hasKey || cfg.provider === null || cfg.modelPrimary === null) {
-      const msg = tr('errors.onboardingIncomplete');
+      const msg = 'Onboarding is not complete.';
       set({ errorMessage: msg, lastError: msg });
       return;
     }
 
-    const prompt = input.prompt.trim();
-    if (!prompt) return;
-
-    const request: PromptRequest = {
-      prompt,
-      attachments: uniqueFiles(input.attachments ?? get().inputFiles),
-      ...(normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl)
-        ? { referenceUrl: normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl) }
-        : {}),
-    };
-
-    const history = get().messages;
+    const generationId = newId();
     const userMessage: ChatMessage = { role: 'user', content: prompt };
     set((s) => ({
       messages: [...s.messages, userMessage],
       isGenerating: true,
+      activeGenerationId: generationId,
       errorMessage: null,
-      lastPromptInput: request,
-      selectedElement: null,
-      iframeErrors: [],
     }));
 
     try {
       const result = await window.codesign.generate({
         prompt,
-        history,
+        history: get().messages,
         model: modelRef(cfg.provider, cfg.modelPrimary),
-        ...(request.referenceUrl ? { referenceUrl: request.referenceUrl } : {}),
-        attachments: request.attachments,
+        generationId,
       });
-      const firstArtifact = result.artifacts[0];
-      set((s) => ({
-        messages: [
-          ...s.messages,
-          { role: 'assistant', content: result.message || tr('common.done') },
-        ],
-        previewHtml: firstArtifact?.content ?? s.previewHtml,
-        isGenerating: false,
-      }));
+      applyGenerateSuccess(set, result);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : tr('errors.unknown');
-      set((s) => ({
-        messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
-        isGenerating: false,
-        errorMessage: msg,
-        lastError: msg,
-      }));
-      get().pushToast({
-        variant: 'error',
-        title: tr('notifications.generationFailed'),
-        description: msg,
-      });
+      applyGenerateError(get, set, err);
     }
+  },
+
+  cancelGeneration() {
+    const id = get().activeGenerationId;
+    if (!id || !window.codesign) return;
+    window.codesign.cancelGeneration(id);
+    set({ isGenerating: false, activeGenerationId: null });
   },
 
   async retryLastPrompt() {
-    const lastPromptInput = get().lastPromptInput;
-    if (!lastPromptInput) return;
-
-    const messages = [...get().messages];
-    const lastMessage = messages.at(-1);
-    if (lastMessage?.role === 'assistant' && lastMessage.content.startsWith('Error:'))
-      messages.pop();
-    const maybeUser = messages.at(-1);
-    if (maybeUser?.role === 'user' && maybeUser.content === lastPromptInput.prompt) messages.pop();
-
-    set({ messages, errorMessage: null });
-    await get().sendPrompt(lastPromptInput);
-  },
-
-  async applyInlineComment(comment) {
-    const trimmed = comment.trim();
-    if (!trimmed || get().isGenerating) return;
-    if (!window.codesign) return;
-    const cfg = get().config;
-    const html = get().previewHtml;
-    const selection = get().selectedElement;
-    if (cfg === null || !cfg.hasKey || html === null || selection === null) return;
-
-    const userMessage: ChatMessage = { role: 'user', content: `Edit ${selection.tag}: ${trimmed}` };
-    const referenceUrl = normalizeReferenceUrl(get().referenceUrl);
-    const attachments = uniqueFiles(get().inputFiles);
-
+    const lastUser = [...get().messages].reverse().find((m) => m.role === 'user');
+    if (!lastUser) return;
     set((s) => ({
-      messages: [...s.messages, userMessage],
-      isGenerating: true,
+      messages: s.messages.filter(
+        (m) => m !== lastUser && !(m.role === 'assistant' && m.content.startsWith('Error:')),
+      ),
       errorMessage: null,
-      iframeErrors: [],
     }));
-
-    try {
-      const result = await window.codesign.applyComment({
-        html,
-        comment: trimmed,
-        selection,
-        ...(referenceUrl ? { referenceUrl } : {}),
-        attachments,
-      });
-      const firstArtifact = result.artifacts[0];
-      set((s) => ({
-        messages: [
-          ...s.messages,
-          { role: 'assistant', content: result.message || tr('common.applied') },
-        ],
-        previewHtml: firstArtifact?.content ?? s.previewHtml,
-        isGenerating: false,
-        selectedElement: null,
-      }));
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : tr('errors.unknown');
-      set((s) => ({
-        messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
-        isGenerating: false,
-        errorMessage: msg,
-        lastError: msg,
-      }));
-      get().pushToast({
-        variant: 'error',
-        title: tr('notifications.inlineCommentFailed'),
-        description: msg,
-      });
-    }
+    await get().sendPrompt(lastUser.content);
   },
 
   clearError() {
@@ -398,11 +242,11 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   async exportActive(format: ExportFormat) {
     const html = get().previewHtml;
     if (!html) {
-      set({ toastMessage: tr('notifications.noDesignToExport') });
+      set({ toastMessage: 'No design to export yet.' });
       return;
     }
     if (!window.codesign) {
-      set({ errorMessage: tr('errors.rendererDisconnected') });
+      set({ errorMessage: 'Renderer is not connected to the main process.' });
       return;
     }
     try {
@@ -413,20 +257,12 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         defaultFilename: `codesign-${stamp}.${format}`,
       });
       if (res.status === 'saved' && res.path) {
-        set({ toastMessage: tr('notifications.exportedTo', { path: res.path }) });
+        set({ toastMessage: `Exported to ${res.path}` });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      const msg = err instanceof Error ? err.message : 'Unknown error';
       set({ toastMessage: msg, errorMessage: msg, lastError: msg });
     }
-  },
-
-  selectCanvasElement(selection) {
-    set({ selectedElement: selection });
-  },
-
-  clearCanvasElement() {
-    set({ selectedElement: null });
   },
 
   setTheme(theme) {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -165,6 +165,7 @@
     "designSystemCleared": "Design system cleared",
     "clearDesignSystemFailed": "Unable to clear design system",
     "generationFailed": "Generation failed",
+    "cancellationFailed": "Cancellation failed",
     "inlineCommentFailed": "Inline comment failed",
     "noDesignToExport": "No design to export yet.",
     "exportedTo": "Exported to {{path}}"

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -45,7 +45,9 @@
     "sendShortcut": "Send (Enter)",
     "emptyHint": "Start with a starter prompt or your own idea.",
     "sendAction": "send",
-    "sendAnywhere": "anywhere"
+    "sendAnywhere": "anywhere",
+    "send": "Send prompt",
+    "stop": "Stop generation"
   },
   "sidebar": {
     "localContext": "Local context",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -165,6 +165,7 @@
     "designSystemCleared": "设计系统已清除",
     "clearDesignSystemFailed": "无法清除设计系统",
     "generationFailed": "生成失败",
+    "cancellationFailed": "取消失败",
     "inlineCommentFailed": "局部修改失败",
     "noDesignToExport": "当前还没有可导出的设计。",
     "exportedTo": "已导出到 {{path}}"

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -45,7 +45,9 @@
     "sendShortcut": "发送（回车）",
     "emptyHint": "可以从范例开始，也可以直接说出你的想法。",
     "sendAction": "发送",
-    "sendAnywhere": "任意位置发送"
+    "sendAnywhere": "任意位置发送",
+    "send": "发送提示词",
+    "stop": "停止生成"
   },
   "sidebar": {
     "localContext": "本地上下文",

--- a/packages/shared/src/generate-payload.test.ts
+++ b/packages/shared/src/generate-payload.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { GeneratePayloadV1 } from './index';
+
+const BASE_VALID = {
+  schemaVersion: 1 as const,
+  prompt: 'Design a landing page',
+  history: [],
+  model: { provider: 'anthropic' as const, modelId: 'claude-sonnet-4-6' },
+  generationId: 'gen-abc123',
+};
+
+describe('GeneratePayloadV1', () => {
+  it('accepts a valid v1 payload', () => {
+    const result = GeneratePayloadV1.parse(BASE_VALID);
+    expect(result.schemaVersion).toBe(1);
+    expect(result.generationId).toBe('gen-abc123');
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('rejects a payload missing schemaVersion', () => {
+    const { schemaVersion: _, ...noVersion } = BASE_VALID;
+    expect(() => GeneratePayloadV1.parse(noVersion)).toThrow();
+  });
+
+  it('rejects a payload with a future schemaVersion (forward incompat)', () => {
+    expect(() => GeneratePayloadV1.parse({ ...BASE_VALID, schemaVersion: 2 })).toThrow();
+  });
+
+  it('rejects a payload with an empty generationId', () => {
+    expect(() => GeneratePayloadV1.parse({ ...BASE_VALID, generationId: '' })).toThrow();
+  });
+
+  it('rejects a payload missing generationId', () => {
+    const { generationId: _, ...noId } = BASE_VALID;
+    expect(() => GeneratePayloadV1.parse(noId)).toThrow();
+  });
+});

--- a/packages/shared/src/generate-payload.test.ts
+++ b/packages/shared/src/generate-payload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { GeneratePayloadV1 } from './index';
+import { GeneratePayload, GeneratePayloadV1 } from './index';
 
 const BASE_VALID = {
   schemaVersion: 1 as const,
@@ -33,5 +33,41 @@ describe('GeneratePayloadV1', () => {
   it('rejects a payload missing generationId', () => {
     const { generationId: _, ...noId } = BASE_VALID;
     expect(() => GeneratePayloadV1.parse(noId)).toThrow();
+  });
+});
+
+describe('GeneratePayload (legacy — no schemaVersion)', () => {
+  it('accepts a legacy payload without schemaVersion and optional generationId', () => {
+    const raw = {
+      prompt: 'Design a landing page',
+      history: [],
+      model: { provider: 'anthropic' as const, modelId: 'claude-sonnet-4-6' },
+    };
+    const result = GeneratePayload.parse(raw);
+    expect(result.generationId).toBeUndefined();
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('accepts a legacy payload with generationId present', () => {
+    const raw = {
+      prompt: 'Design a landing page',
+      history: [],
+      model: { provider: 'anthropic' as const, modelId: 'claude-sonnet-4-6' },
+      generationId: 'gen-old-123',
+    };
+    const result = GeneratePayload.parse(raw);
+    expect(result.generationId).toBe('gen-old-123');
+  });
+
+  it('can be promoted to GeneratePayloadV1 by injecting schemaVersion and falling back generationId', () => {
+    const legacy = GeneratePayload.parse({
+      prompt: 'Design a landing page',
+      history: [],
+      model: { provider: 'anthropic' as const, modelId: 'claude-sonnet-4-6' },
+    });
+    const id = legacy.generationId ?? `gen-${Date.now()}`;
+    const v1 = GeneratePayloadV1.parse({ schemaVersion: 1, ...legacy, generationId: id });
+    expect(v1.schemaVersion).toBe(1);
+    expect(v1.generationId).toMatch(/^gen-/);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -114,6 +114,21 @@ export const GeneratePayload = z.object({
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
 
+/** @deprecated Use GeneratePayloadV1. */
+export type LegacyGeneratePayload = GeneratePayload;
+
+export const GeneratePayloadV1 = z.object({
+  schemaVersion: z.literal(1),
+  prompt: z.string().min(1).max(32_000),
+  history: z.array(ChatMessage).max(200),
+  model: ModelRef,
+  baseUrl: z.string().url().optional(),
+  referenceUrl: z.string().url().optional(),
+  attachments: z.array(LocalInputFile).max(12).default([]),
+  generationId: z.string().min(1),
+});
+export type GeneratePayloadV1 = z.infer<typeof GeneratePayloadV1>;
+
 export const ApplyCommentPayload = z.object({
   html: z.string().min(1).max(500_000),
   comment: z.string().min(1).max(4_000),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -80,14 +80,49 @@ export const ChatMessage = z.object({
 });
 export type ChatMessage = z.infer<typeof ChatMessage>;
 
+export const LocalInputFile = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  size: z.number().int().nonnegative(),
+});
+export type LocalInputFile = z.infer<typeof LocalInputFile>;
+
+export const ElementSelectionRect = z.object({
+  top: z.number(),
+  left: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+export type ElementSelectionRect = z.infer<typeof ElementSelectionRect>;
+
+export const SelectedElement = z.object({
+  selector: z.string().min(1),
+  tag: z.string().min(1),
+  outerHTML: z.string(),
+  rect: ElementSelectionRect,
+});
+export type SelectedElement = z.infer<typeof SelectedElement>;
+
 export const GeneratePayload = z.object({
   prompt: z.string().min(1).max(32_000),
   history: z.array(ChatMessage).max(200),
   model: ModelRef,
   baseUrl: z.string().url().optional(),
+  referenceUrl: z.string().url().optional(),
+  attachments: z.array(LocalInputFile).max(12).default([]),
   generationId: z.string().optional(),
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
+
+export const ApplyCommentPayload = z.object({
+  html: z.string().min(1).max(500_000),
+  comment: z.string().min(1).max(4_000),
+  selection: SelectedElement,
+  model: ModelRef.optional(),
+  referenceUrl: z.string().url().optional(),
+  attachments: z.array(LocalInputFile).max(12).default([]),
+});
+export type ApplyCommentPayload = z.infer<typeof ApplyCommentPayload>;
 
 export const CancelGenerationPayloadV1 = z.object({
   schemaVersion: z.literal(1),
@@ -133,6 +168,8 @@ export {
   PROVIDER_SHORTLIST,
   SUPPORTED_ONBOARDING_PROVIDERS,
   SecretRef,
+  STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
+  StoredDesignSystem,
   isSupportedOnboardingProvider,
 } from './config';
 export type {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -80,48 +80,14 @@ export const ChatMessage = z.object({
 });
 export type ChatMessage = z.infer<typeof ChatMessage>;
 
-export const LocalInputFile = z.object({
-  path: z.string().min(1),
-  name: z.string().min(1),
-  size: z.number().int().nonnegative(),
-});
-export type LocalInputFile = z.infer<typeof LocalInputFile>;
-
-export const ElementSelectionRect = z.object({
-  top: z.number(),
-  left: z.number(),
-  width: z.number(),
-  height: z.number(),
-});
-export type ElementSelectionRect = z.infer<typeof ElementSelectionRect>;
-
-export const SelectedElement = z.object({
-  selector: z.string().min(1),
-  tag: z.string().min(1),
-  outerHTML: z.string(),
-  rect: ElementSelectionRect,
-});
-export type SelectedElement = z.infer<typeof SelectedElement>;
-
 export const GeneratePayload = z.object({
   prompt: z.string().min(1).max(32_000),
   history: z.array(ChatMessage).max(200),
   model: ModelRef,
   baseUrl: z.string().url().optional(),
-  referenceUrl: z.string().url().optional(),
-  attachments: z.array(LocalInputFile).max(12).default([]),
+  generationId: z.string().optional(),
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
-
-export const ApplyCommentPayload = z.object({
-  html: z.string().min(1).max(500_000),
-  comment: z.string().min(1).max(4_000),
-  selection: SelectedElement,
-  model: ModelRef.optional(),
-  referenceUrl: z.string().url().optional(),
-  attachments: z.array(LocalInputFile).max(12).default([]),
-});
-export type ApplyCommentPayload = z.infer<typeof ApplyCommentPayload>;
 
 /**
  * Iframe runtime error event — schema for the postMessage payload sent by
@@ -161,8 +127,6 @@ export {
   PROVIDER_SHORTLIST,
   SUPPORTED_ONBOARDING_PROVIDERS,
   SecretRef,
-  STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
-  StoredDesignSystem,
   isSupportedOnboardingProvider,
 } from './config';
 export type {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -89,6 +89,12 @@ export const GeneratePayload = z.object({
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
 
+export const CancelGenerationPayloadV1 = z.object({
+  schemaVersion: z.literal(1),
+  generationId: z.string().min(1),
+});
+export type CancelGenerationPayloadV1 = z.infer<typeof CancelGenerationPayloadV1>;
+
 /**
  * Iframe runtime error event — schema for the postMessage payload sent by
  * the sandbox overlay (see packages/runtime/src/overlay.ts) when JS inside

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -25,6 +25,7 @@
   --color-accent-muted: #f3d9cf;
   --color-accent-soft: rgba(201, 100, 66, 0.08);
   --color-focus-ring: rgba(201, 100, 66, 0.3);
+  --color-on-accent: #ffffff;
 
   /* Text */
   --color-text-primary: #1f1d18;
@@ -118,6 +119,7 @@
   --color-accent-muted: #4a2b22;
   --color-accent-soft: rgba(217, 119, 87, 0.1);
   --color-focus-ring: rgba(217, 119, 87, 0.35);
+  --color-on-accent: #ffffff;
 
   --color-text-primary: #f5f1e8;
   --color-text-secondary: #b8b3a6;


### PR DESCRIPTION
## Summary
- Sidebar 单行 input → autosize textarea（1–6 行）；send 按钮内嵌右下角 28px icon-only
- 生成中切换 Square stop 按钮，点击触发 cancel
- Cancellation IPC：main 维护 `Map<generationId, AbortController>`；preload 暴露 `cancelGeneration`；store 跟踪 `activeGenerationId`，abort 错误静默处理
- `GeneratePayload` 新增可选 `generationId` 字段（向后兼容）

## Test plan
- [ ] `pnpm --filter @open-codesign/desktop typecheck` ✅
- [ ] `pnpm lint` ✅
- [ ] Enter 发送 / Shift+Enter 换行 / ⌘↵ 全局发送
- [ ] 生成中点 stop，验证请求被 abort 且不弹错

🤖 Generated with subagent