### PR TITLE
fix(providers): adapt assistant history for pi-ai

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,0 +1,107 @@
+import type { ChatMessage, ModelRef } from '@open-codesign/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const getModelMock = vi.fn();
+const completeSimpleMock = vi.fn();
+
+vi.mock('@mariozechner/pi-ai', () => ({
+  getModel: (...args: unknown[]) => getModelMock(...args),
+  completeSimple: (...args: unknown[]) => completeSimpleMock(...args),
+}));
+
+import { complete } from './index';
+
+const MODEL: ModelRef = { provider: 'openai', modelId: 'gpt-4o' };
+
+afterEach(() => {
+  getModelMock.mockReset();
+  completeSimpleMock.mockReset();
+});
+
+describe('complete', () => {
+  it('adapts shared chat history into pi-ai context for follow-up turns', async () => {
+    getModelMock.mockReturnValue({
+      id: 'gpt-4o',
+      api: 'openai-completions',
+      provider: 'openai',
+    });
+    completeSimpleMock.mockImplementationOnce(async (_model, context) => {
+      expect(context.systemPrompt).toBe('You are open-codesign.');
+      expect(context.messages).toEqual([
+        {
+          role: 'user',
+          content: '介绍一下你自己',
+          timestamp: 2,
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '我是一个设计助手。' }],
+          api: 'openai-completions',
+          provider: 'openai',
+          model: 'gpt-4o',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: 'stop',
+          timestamp: 3,
+        },
+        {
+          role: 'user',
+          content: '你可以干什么',
+          timestamp: 4,
+        },
+      ]);
+
+      return {
+        role: 'assistant',
+        content: [{ type: 'text', text: '我可以帮你生成设计稿。' }],
+        api: 'openai-completions',
+        provider: 'openai',
+        model: 'gpt-4o',
+        usage: {
+          input: 12,
+          output: 34,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 46,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0.01,
+          },
+        },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      };
+    });
+
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are open-codesign.' },
+      { role: 'user', content: '介绍一下你自己' },
+      { role: 'assistant', content: '我是一个设计助手。' },
+      { role: 'user', content: '你可以干什么' },
+    ];
+
+    const result = await complete(MODEL, messages, { apiKey: 'sk-test' });
+
+    expect(result).toEqual({
+      content: '我可以帮你生成设计稿。',
+      inputTokens: 12,
+      outputTokens: 34,
+      costUsd: 0.01,
+    });
+  });
+});

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Wrappers around @mariozechner/pi-ai that fill capability gaps documented
  * in docs/research/05-pi-ai-boundary.md. App code MUST go through this
- * package — never import a provider SDK directly.
+ * package - never import a provider SDK directly.
  *
  * Tier 1 implementations: minimum viable. Tier 2 features tracked separately.
  */
@@ -21,6 +21,70 @@ export interface GenerateResult {
   costUsd: number;
 }
 
+interface PiTextContent {
+  type: 'text';
+  text: string;
+}
+
+interface PiUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+}
+
+interface PiUserMessage {
+  role: 'user';
+  content: string | PiTextContent[];
+  timestamp: number;
+}
+
+interface PiAssistantMessage {
+  role: 'assistant';
+  content: Array<{ type: string; text?: string }>;
+  api: string;
+  provider: string;
+  model: string;
+  usage: PiUsage;
+  stopReason: 'stop' | 'length' | 'toolUse' | 'error' | 'aborted';
+  errorMessage?: string;
+  timestamp: number;
+}
+
+interface PiContext {
+  systemPrompt?: string;
+  messages: Array<PiUserMessage | PiAssistantMessage>;
+}
+
+interface PiModel {
+  id: string;
+  api: string;
+  provider: string;
+}
+
+const EMPTY_USAGE: PiUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
 /**
  * Single non-streaming completion. Tier 1: thin shim, no caching, no retry.
  * Tier 2 will swap to pi-ai's streaming API and emit ArtifactEvents directly.
@@ -37,17 +101,12 @@ export async function complete(
   }
 
   const pi = (await import('@mariozechner/pi-ai')) as unknown as {
-    getModel: (provider: string, modelId: string) => unknown;
+    getModel: (provider: string, modelId: string) => PiModel | undefined;
     completeSimple: (
-      model: unknown,
-      context: { messages: ChatMessage[] },
+      model: PiModel,
+      context: PiContext,
       opts: { apiKey: string; baseUrl?: string; signal?: AbortSignal },
-    ) => Promise<{
-      stopReason?: string;
-      errorMessage?: string;
-      content: Array<{ type: string; text?: string }>;
-      usage?: { input?: number; output?: number; cost?: { total?: number } };
-    }>;
+    ) => Promise<PiAssistantMessage>;
   };
 
   const piModel = pi.getModel(model.provider, model.modelId);
@@ -64,7 +123,7 @@ export async function complete(
   if (opts.baseUrl !== undefined) piOpts.baseUrl = opts.baseUrl;
   if (opts.signal !== undefined) piOpts.signal = opts.signal;
 
-  const result = await pi.completeSimple(piModel, { messages }, piOpts);
+  const result = await pi.completeSimple(piModel, toPiContext(messages, piModel), piOpts);
 
   if (result.stopReason === 'error') {
     throw new CodesignError(result.errorMessage ?? 'Provider returned an error', 'PROVIDER_ERROR');
@@ -80,6 +139,45 @@ export async function complete(
     inputTokens: result.usage?.input ?? 0,
     outputTokens: result.usage?.output ?? 0,
     costUsd: result.usage?.cost?.total ?? 0,
+  };
+}
+
+function toPiContext(messages: ChatMessage[], model: PiModel): PiContext {
+  const systemPrompt = messages
+    .filter((message) => message.role === 'system')
+    .map((message) => message.content.trim())
+    .filter((content) => content.length > 0)
+    .join('\n\n');
+
+  return {
+    ...(systemPrompt.length > 0 ? { systemPrompt } : {}),
+    messages: messages.flatMap((message, index) => {
+      const timestamp = index + 1;
+
+      if (message.role === 'system') {
+        return [];
+      }
+
+      if (message.role === 'user') {
+        return {
+          role: 'user',
+          content: message.content,
+          timestamp,
+        };
+      }
+
+      return {
+        role: 'assistant',
+        content:
+          message.content.trim().length === 0 ? [] : [{ type: 'text', text: message.content }],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: EMPTY_USAGE,
+        stopReason: 'stop',
+        timestamp,
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- adapt shared chat history into pi-ai's expected context/message shape before calling completeSimple
- convert assistant string history into text blocks so follow-up turns no longer crash on ssistantMsg.content.flatMap
- add a regression test covering a multi-turn conversation with prior assistant history

## Validation
- corepack pnpm --filter @open-codesign/providers test
- corepack pnpm --filter @open-codesign/desktop typecheck