### PR TITLE
feat(desktop): add input context and inline comments

### DIFF
--- a/apps/desktop/src/main/design-system.ts
+++ b/apps/desktop/src/main/design-system.ts
@@ -1,0 +1,229 @@
+import type { Dirent } from 'node:fs';
+import { readFile, readdir } from 'node:fs/promises';
+import { basename, extname, join, relative } from 'node:path';
+import {
+  STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
+  type StoredDesignSystem,
+} from '@open-codesign/shared';
+
+const IGNORED_DIRS = new Set([
+  '.git',
+  '.idea',
+  '.next',
+  '.turbo',
+  '.vscode',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+]);
+
+const CANDIDATE_EXTS = new Set([
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.json',
+  '.md',
+]);
+
+const PRIORITY_PATTERNS = [
+  /tailwind\.config/i,
+  /tokens?/i,
+  /theme/i,
+  /brand/i,
+  /palette/i,
+  /typography/i,
+  /global\.(css|scss|sass|less)$/i,
+  /variables?\.(css|scss|sass|less)$/i,
+];
+
+const MAX_FILES = 160;
+const MAX_SELECTED_FILES = 12;
+const MAX_FILE_CHARS = 32_000;
+
+interface CandidateFile {
+  fullPath: string;
+  relativePath: string;
+  score: number;
+}
+
+function pushUnique(target: string[], value: string, max: number): void {
+  if (!value || target.includes(value) || target.length >= max) return;
+  target.push(value);
+}
+
+function cleanValue(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/["'`,]/g, '')
+    .trim();
+}
+
+function scoreCandidate(relativePath: string): number {
+  const fileName = basename(relativePath);
+  let score = 1;
+  for (const pattern of PRIORITY_PATTERNS) {
+    if (pattern.test(relativePath) || pattern.test(fileName)) score += 20;
+  }
+  if (/\.(css|scss|sass|less)$/i.test(fileName)) score += 8;
+  if (/tailwind/i.test(relativePath)) score += 8;
+  if (/src\//i.test(relativePath)) score += 4;
+  return score;
+}
+
+async function collectCandidateFiles(
+  rootPath: string,
+  dirPath: string,
+  files: CandidateFile[],
+): Promise<void> {
+  if (files.length >= MAX_FILES) return;
+
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(dirPath, { withFileTypes: true, encoding: 'utf8' });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (files.length >= MAX_FILES) return;
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        await collectCandidateFiles(rootPath, fullPath, files);
+      }
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const extension = extname(entry.name).toLowerCase();
+    if (!CANDIDATE_EXTS.has(extension) && !/tailwind\.config/i.test(entry.name)) continue;
+    const relativePath = relative(rootPath, fullPath).replace(/\\/g, '/');
+    files.push({ fullPath, relativePath, score: scoreCandidate(relativePath) });
+  }
+}
+
+function collectCssVarValues(
+  raw: string,
+  colors: string[],
+  spacing: string[],
+  radius: string[],
+  shadows: string[],
+): void {
+  for (const match of raw.matchAll(/--([a-z0-9-]+)\s*:\s*([^;}{\n]+)/gi)) {
+    const name = match[1]?.toLowerCase() ?? '';
+    const value = cleanValue(match[2] ?? '');
+    if (!value) continue;
+    if (/color|accent|surface|text|brand|primary|secondary/.test(name))
+      pushUnique(colors, value, 24);
+    if (/space|spacing|gap|padding|margin/.test(name)) pushUnique(spacing, value, 16);
+    if (/radius|rounded/.test(name)) pushUnique(radius, value, 16);
+    if (/shadow/.test(name)) pushUnique(shadows, value, 16);
+  }
+}
+
+function collectLooseValues(
+  raw: string,
+  colors: string[],
+  fonts: string[],
+  spacing: string[],
+  radius: string[],
+  shadows: string[],
+): void {
+  for (const match of raw.matchAll(/#[0-9a-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\)/gi)) {
+    pushUnique(colors, cleanValue(match[0] ?? ''), 24);
+  }
+
+  for (const match of raw.matchAll(/(?:font-family|fontFamily)[^:=]*[:=]\s*([^\n;]+)/gi)) {
+    const value = cleanValue(match[1] ?? '');
+    for (const part of value.split(',')) pushUnique(fonts, cleanValue(part), 16);
+  }
+
+  for (const match of raw.matchAll(
+    /(?:spacing|space|gap|padding|margin)[^:=\n]*[:=]\s*([^\n,;]+)/gi,
+  )) {
+    pushUnique(spacing, cleanValue(match[1] ?? ''), 16);
+  }
+
+  for (const match of raw.matchAll(/(?:radius|rounded|borderRadius)[^:=\n]*[:=]\s*([^\n,;]+)/gi)) {
+    pushUnique(radius, cleanValue(match[1] ?? ''), 16);
+  }
+
+  for (const match of raw.matchAll(/(?:shadow|boxShadow)[^:=\n]*[:=]\s*([^\n,;]+)/gi)) {
+    pushUnique(shadows, cleanValue(match[1] ?? ''), 16);
+  }
+}
+
+function buildSummary(
+  snapshot: Omit<StoredDesignSystem, 'schemaVersion' | 'summary' | 'extractedAt'>,
+): string {
+  const repoLabel = basename(snapshot.rootPath);
+  const parts = [
+    `Scanned ${snapshot.sourceFiles.length} likely design-system files under ${repoLabel}.`,
+  ];
+  if (snapshot.colors.length > 0)
+    parts.push(`Color language: ${snapshot.colors.slice(0, 5).join(', ')}.`);
+  if (snapshot.fonts.length > 0)
+    parts.push(`Typography: ${snapshot.fonts.slice(0, 4).join(', ')}.`);
+  if (snapshot.spacing.length > 0)
+    parts.push(`Spacing cues: ${snapshot.spacing.slice(0, 4).join(', ')}.`);
+  if (snapshot.radius.length > 0)
+    parts.push(`Corner radius cues: ${snapshot.radius.slice(0, 4).join(', ')}.`);
+  if (snapshot.shadows.length > 0)
+    parts.push(`Shadow cues: ${snapshot.shadows.slice(0, 4).join(', ')}.`);
+  if (parts.length === 1) {
+    parts.push(
+      'No strong structured tokens were extracted, so lean on the referenced styling files and keep the output conservative and cohesive.',
+    );
+  }
+  return parts.join(' ');
+}
+
+export async function scanDesignSystem(rootPath: string): Promise<StoredDesignSystem> {
+  const candidates: CandidateFile[] = [];
+  await collectCandidateFiles(rootPath, rootPath, candidates);
+
+  const selected = candidates
+    .sort((a, b) => b.score - a.score || a.relativePath.localeCompare(b.relativePath))
+    .slice(0, MAX_SELECTED_FILES);
+
+  const colors: string[] = [];
+  const fonts: string[] = [];
+  const spacing: string[] = [];
+  const radius: string[] = [];
+  const shadows: string[] = [];
+
+  for (const file of selected) {
+    let raw = '';
+    try {
+      raw = await readFile(file.fullPath, 'utf8');
+    } catch {
+      continue;
+    }
+    const snippet = raw.slice(0, MAX_FILE_CHARS);
+    collectCssVarValues(snippet, colors, spacing, radius, shadows);
+    collectLooseValues(snippet, colors, fonts, spacing, radius, shadows);
+  }
+
+  const baseSnapshot = {
+    rootPath,
+    sourceFiles: selected.map((file) => file.relativePath),
+    colors,
+    fonts,
+    spacing,
+    radius,
+    shadows,
+  };
+
+  return {
+    schemaVersion: STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
+    ...baseSnapshot,
+    summary: buildSummary(baseSnapshot),
+    extractedAt: new Date().toISOString(),
+  };
+}

--- a/apps/desktop/src/main/electron-runtime.ts
+++ b/apps/desktop/src/main/electron-runtime.ts
@@ -1,0 +1,7 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export const electron = require('electron') as typeof import('electron');
+
+export const { app, BrowserWindow, dialog, ipcMain, safeStorage, shell } = electron;

--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -1,6 +1,7 @@
 import { type ExporterFormat, exportArtifact } from '@open-codesign/exporters';
 import { CodesignError } from '@open-codesign/shared';
-import { type BrowserWindow, dialog, ipcMain } from 'electron';
+import type { BrowserWindow } from 'electron';
+import { dialog, ipcMain } from './electron-runtime';
 
 const FORMAT_FILTERS: Record<ExporterFormat, Electron.FileFilter[]> = {
   html: [{ name: 'HTML', extensions: ['html'] }],

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,23 +1,30 @@
-import { dirname, join } from 'node:path';
+import { stat } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { generate } from '@open-codesign/core';
+import { applyComment, generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
-import { BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
-import { BrowserWindow, app, ipcMain, shell } from 'electron';
+import { ApplyCommentPayload, BRAND, CodesignError, GeneratePayload } from '@open-codesign/shared';
+import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { scanDesignSystem } from './design-system';
+import { BrowserWindow, app, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
 import {
   getApiKeyForProvider,
   getBaseUrlForProvider,
+  getCachedConfig,
+  getOnboardingState,
   loadConfigOnBoot,
   registerOnboardingIpc,
+  setDesignSystem,
 } from './onboarding-ipc';
+import { preparePromptContext } from './prompt-context';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-let mainWindow: BrowserWindow | null = null;
+let mainWindow: ElectronBrowserWindow | null = null;
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -38,7 +45,7 @@ function createWindow(): void {
 
   mainWindow.on('ready-to-show', () => mainWindow?.show());
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url }: { url: string }) => {
     void shell.openExternal(url);
     return { action: 'deny' };
   });
@@ -60,18 +67,79 @@ function registerIpcHandlers(): void {
     return detectProviderFromKey(key);
   });
 
+  ipcMain.handle('codesign:pick-input-files', async () => {
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, {
+          properties: ['openFile', 'multiSelections'],
+        })
+      : await dialog.showOpenDialog({
+          properties: ['openFile', 'multiSelections'],
+        });
+    if (result.canceled || result.filePaths.length === 0) return [];
+    return Promise.all(
+      result.filePaths.map(async (path) => {
+        try {
+          const info = await stat(path);
+          return { path, name: basename(path), size: info.size };
+        } catch {
+          return { path, name: basename(path), size: 0 };
+        }
+      }),
+    );
+  });
+
+  ipcMain.handle('codesign:pick-design-system-directory', async () => {
+    const result = mainWindow
+      ? await dialog.showOpenDialog(mainWindow, {
+          properties: ['openDirectory'],
+        })
+      : await dialog.showOpenDialog({
+          properties: ['openDirectory'],
+        });
+    if (result.canceled || result.filePaths.length === 0) return getOnboardingState();
+    const rootPath = result.filePaths[0];
+    if (!rootPath) return getOnboardingState();
+    logIpc.info('designSystem.scan.start', { rootPath });
+    const snapshot = await scanDesignSystem(rootPath);
+    const nextState = await setDesignSystem(snapshot);
+    logIpc.info('designSystem.scan.ok', {
+      rootPath,
+      sourceFiles: snapshot.sourceFiles.length,
+      colors: snapshot.colors.length,
+      fonts: snapshot.fonts.length,
+    });
+    return nextState;
+  });
+
+  ipcMain.handle('codesign:clear-design-system', async () => {
+    const nextState = await setDesignSystem(null);
+    logIpc.info('designSystem.clear');
+    return nextState;
+  });
+
   ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
     const payload = GeneratePayload.parse(raw);
     const apiKey = getApiKeyForProvider(payload.model.provider);
     const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
     const baseUrl = payload.baseUrl ?? storedBaseUrl;
+    const cfg = getCachedConfig();
+    const promptContext = await preparePromptContext({
+      attachments: payload.attachments,
+      referenceUrl: payload.referenceUrl,
+      designSystem: cfg?.designSystem ?? null,
+    });
+
     logIpc.info('generate', {
       provider: payload.model.provider,
       modelId: payload.model.modelId,
       promptLen: payload.prompt.length,
       historyLen: payload.history.length,
+      attachmentCount: payload.attachments.length,
+      hasReferenceUrl: payload.referenceUrl !== undefined,
+      hasDesignSystem: promptContext.designSystem !== null,
       baseUrl: baseUrl ?? '<default>',
     });
+
     const t0 = Date.now();
     try {
       const result = await generate({
@@ -79,12 +147,15 @@ function registerIpcHandlers(): void {
         history: payload.history,
         model: payload.model,
         apiKey,
+        attachments: promptContext.attachments,
+        referenceUrl: promptContext.referenceUrl,
+        designSystem: promptContext.designSystem ?? null,
         ...(baseUrl !== undefined ? { baseUrl } : {}),
       });
       logIpc.info('generate.ok', {
         ms: Date.now() - t0,
-        artifacts: (result as { artifacts?: unknown[] }).artifacts?.length ?? 0,
-        cost: (result as { costUsd?: number }).costUsd,
+        artifacts: result.artifacts.length,
+        cost: result.costUsd,
       });
       return result;
     } catch (err) {
@@ -93,6 +164,66 @@ function registerIpcHandlers(): void {
         provider: payload.model.provider,
         modelId: payload.model.modelId,
         baseUrl: baseUrl ?? '<default>',
+        message: err instanceof Error ? err.message : String(err),
+        code: err instanceof CodesignError ? err.code : undefined,
+      });
+      throw err;
+    }
+  });
+
+  ipcMain.handle('codesign:apply-comment', async (_e, raw: unknown) => {
+    const payload = ApplyCommentPayload.parse(raw);
+    const cfg = getCachedConfig();
+    if (cfg === null) {
+      throw new CodesignError(
+        'No configuration found. Complete onboarding first.',
+        'CONFIG_MISSING',
+      );
+    }
+    const model = payload.model ?? { provider: cfg.provider, modelId: cfg.modelFast };
+    const apiKey = getApiKeyForProvider(model.provider);
+    const storedBaseUrl = getBaseUrlForProvider(model.provider);
+    const promptContext = await preparePromptContext({
+      attachments: payload.attachments,
+      referenceUrl: payload.referenceUrl,
+      designSystem: cfg.designSystem ?? null,
+    });
+
+    logIpc.info('applyComment', {
+      provider: model.provider,
+      modelId: model.modelId,
+      selector: payload.selection.selector,
+      attachmentCount: payload.attachments.length,
+      hasReferenceUrl: payload.referenceUrl !== undefined,
+      hasDesignSystem: promptContext.designSystem !== null,
+      baseUrl: storedBaseUrl ?? '<default>',
+    });
+
+    const t0 = Date.now();
+    try {
+      const result = await applyComment({
+        html: payload.html,
+        comment: payload.comment,
+        selection: payload.selection,
+        model,
+        apiKey,
+        attachments: promptContext.attachments,
+        referenceUrl: promptContext.referenceUrl,
+        designSystem: promptContext.designSystem ?? null,
+        ...(storedBaseUrl !== undefined ? { baseUrl: storedBaseUrl } : {}),
+      });
+      logIpc.info('applyComment.ok', {
+        ms: Date.now() - t0,
+        artifacts: result.artifacts.length,
+        cost: result.costUsd,
+      });
+      return result;
+    } catch (err) {
+      logIpc.error('applyComment.fail', {
+        ms: Date.now() - t0,
+        provider: model.provider,
+        modelId: model.modelId,
+        selector: payload.selection.selector,
         message: err instanceof Error ? err.message : String(err),
         code: err instanceof CodesignError ? err.code : undefined,
       });

--- a/apps/desktop/src/main/keychain.ts
+++ b/apps/desktop/src/main/keychain.ts
@@ -1,5 +1,5 @@
 import { CodesignError } from '@open-codesign/shared';
-import { safeStorage } from 'electron';
+import { safeStorage } from './electron-runtime';
 
 export function ensureKeychainAvailable(): void {
   if (!safeStorage.isEncryptionAvailable()) {

--- a/apps/desktop/src/main/locale-ipc.ts
+++ b/apps/desktop/src/main/locale-ipc.ts
@@ -14,7 +14,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { app, ipcMain } from 'electron';
+import { app, ipcMain } from './electron-runtime';
 
 const CONFIG_DIR = join(homedir(), '.config', 'open-codesign');
 const LOCALE_FILE = join(CONFIG_DIR, 'locale.json');

--- a/apps/desktop/src/main/logger.ts
+++ b/apps/desktop/src/main/logger.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
-import { app } from 'electron';
 import log from 'electron-log/main';
+import { app } from './electron-runtime';
 
 /**
  * Centralized logger for the main + preload + renderer processes.

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -3,11 +3,13 @@ import {
   CodesignError,
   type Config,
   type OnboardingState,
+  StoredDesignSystem,
+  type StoredDesignSystem as StoredDesignSystemValue,
   type SupportedOnboardingProvider,
   isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
-import { ipcMain } from 'electron';
 import { readConfig, writeConfig } from './config';
+import { ipcMain } from './electron-runtime';
 import { decryptSecret, encryptSecret } from './keychain';
 
 interface SaveKeyInput {
@@ -61,12 +63,26 @@ export function getBaseUrlForProvider(provider: string): string | undefined {
   return ref?.baseUrl;
 }
 
-function toState(cfg: Config | null): OnboardingState {
+export function toState(cfg: Config | null): OnboardingState {
   if (cfg === null) {
-    return { hasKey: false, provider: null, modelPrimary: null, modelFast: null, baseUrl: null };
+    return {
+      hasKey: false,
+      provider: null,
+      modelPrimary: null,
+      modelFast: null,
+      baseUrl: null,
+      designSystem: null,
+    };
   }
   if (!isSupportedOnboardingProvider(cfg.provider)) {
-    return { hasKey: false, provider: null, modelPrimary: null, modelFast: null, baseUrl: null };
+    return {
+      hasKey: false,
+      provider: null,
+      modelPrimary: null,
+      modelFast: null,
+      baseUrl: null,
+      designSystem: cfg.designSystem ?? null,
+    };
   }
   const ref = cfg.secrets[cfg.provider];
   if (ref === undefined) {
@@ -76,6 +92,7 @@ function toState(cfg: Config | null): OnboardingState {
       modelPrimary: null,
       modelFast: null,
       baseUrl: null,
+      designSystem: cfg.designSystem ?? null,
     };
   }
   return {
@@ -84,7 +101,35 @@ function toState(cfg: Config | null): OnboardingState {
     modelPrimary: cfg.modelPrimary,
     modelFast: cfg.modelFast,
     baseUrl: cfg.baseUrls?.[cfg.provider]?.baseUrl ?? null,
+    designSystem: cfg.designSystem ?? null,
   };
+}
+
+export function getOnboardingState(): OnboardingState {
+  return toState(getCachedConfig());
+}
+
+export async function setDesignSystem(
+  designSystem: StoredDesignSystemValue | null,
+): Promise<OnboardingState> {
+  const cfg = getCachedConfig();
+  if (cfg === null) {
+    throw new CodesignError(
+      'Cannot save a design system before onboarding has completed.',
+      'CONFIG_MISSING',
+    );
+  }
+  const next: Config = {
+    ...cfg,
+    ...(designSystem ? { designSystem: StoredDesignSystem.parse(designSystem) } : {}),
+  };
+  if (designSystem === null) {
+    next.designSystem = undefined;
+  }
+  await writeConfig(next);
+  cachedConfig = next;
+  configLoaded = true;
+  return toState(cachedConfig);
 }
 
 function parseSaveKey(raw: unknown): SaveKeyInput {
@@ -176,6 +221,7 @@ export function registerOnboardingIpc(): void {
         [input.provider]: { ciphertext },
       },
       baseUrls: nextBaseUrls,
+      ...(cachedConfig?.designSystem ? { designSystem: cachedConfig.designSystem } : {}),
     };
     await writeConfig(next);
     cachedConfig = next;

--- a/apps/desktop/src/main/prompt-context.test.ts
+++ b/apps/desktop/src/main/prompt-context.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { preparePromptContext } from './prompt-context';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('preparePromptContext', () => {
+  it('throws a CodesignError when an attachment cannot be read', async () => {
+    await expect(
+      preparePromptContext({
+        attachments: [{ path: 'Z:/missing/brief.md', name: 'brief.md', size: 12 }],
+      }),
+    ).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'ATTACHMENT_READ_FAILED',
+    });
+  });
+
+  it('throws a CodesignError when an attachment is too large', async () => {
+    await expect(
+      preparePromptContext({
+        attachments: [{ path: 'C:/repo/huge.txt', name: 'huge.txt', size: 300_000 }],
+      }),
+    ).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'ATTACHMENT_TOO_LARGE',
+    });
+  });
+
+  it('throws a CodesignError for oversized reference responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<!doctype html><html><body>too big</body></html>', {
+          status: 200,
+          headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'content-length': '300000',
+          },
+        }),
+      ),
+    );
+
+    await expect(
+      preparePromptContext({
+        referenceUrl: 'https://example.com/reference',
+      }),
+    ).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'REFERENCE_URL_TOO_LARGE',
+    });
+  });
+});

--- a/apps/desktop/src/main/prompt-context.ts
+++ b/apps/desktop/src/main/prompt-context.ts
@@ -1,0 +1,222 @@
+import { open } from 'node:fs/promises';
+import { extname } from 'node:path';
+import type { AttachmentContext, ReferenceUrlContext } from '@open-codesign/core';
+import { CodesignError, type LocalInputFile, type StoredDesignSystem } from '@open-codesign/shared';
+
+const TEXT_EXTS = new Set([
+  '.css',
+  '.csv',
+  '.html',
+  '.js',
+  '.json',
+  '.jsx',
+  '.less',
+  '.md',
+  '.mjs',
+  '.scss',
+  '.svg',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.xml',
+  '.yaml',
+  '.yml',
+]);
+
+const MAX_ATTACHMENT_CHARS = 6_000;
+const MAX_ATTACHMENT_BYTES = 256_000;
+const MAX_URL_EXCERPT_CHARS = 1_200;
+const MAX_URL_RESPONSE_BYTES = 256_000;
+const REFERENCE_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
+
+function cleanText(raw: string, maxChars: number): string {
+  return raw
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, maxChars);
+}
+
+function stripHtml(raw: string): string {
+  return raw
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isProbablyText(buffer: Buffer, extension: string): boolean {
+  if (TEXT_EXTS.has(extension)) return true;
+  const probe = buffer.subarray(0, 512);
+  return !probe.includes(0);
+}
+
+async function readAttachment(file: LocalInputFile): Promise<AttachmentContext> {
+  const extension = extname(file.name).toLowerCase();
+  if (file.size > MAX_ATTACHMENT_BYTES) {
+    throw new CodesignError(
+      `Attachment "${file.name}" is too large (${file.size} bytes).`,
+      'ATTACHMENT_TOO_LARGE',
+    );
+  }
+
+  let buffer: Buffer;
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(file.path, 'r');
+    const length = Math.max(1, Math.min(file.size || MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_BYTES));
+    const readBuffer = Buffer.alloc(length);
+    const { bytesRead } = await handle.read(readBuffer, 0, readBuffer.length, 0);
+    buffer = readBuffer.subarray(0, bytesRead);
+  } catch (error) {
+    throw new CodesignError(`Failed to read attachment "${file.path}"`, 'ATTACHMENT_READ_FAILED', {
+      cause: error,
+    });
+  } finally {
+    await handle?.close();
+  }
+
+  if (!isProbablyText(buffer, extension)) {
+    return {
+      name: file.name,
+      path: file.path,
+      note: `Binary or unsupported format (${extension || 'unknown'}). Use the filename as a hint, not quoted content.`,
+    };
+  }
+
+  return {
+    name: file.name,
+    path: file.path,
+    excerpt: cleanText(buffer.toString('utf8'), MAX_ATTACHMENT_CHARS),
+    note:
+      buffer.length > MAX_ATTACHMENT_CHARS
+        ? 'Excerpt truncated to the most relevant leading content.'
+        : undefined,
+  };
+}
+
+async function readResponseText(response: Response, url: string): Promise<string> {
+  const contentLength = Number(response.headers.get('content-length') ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_URL_RESPONSE_BYTES) {
+    throw new CodesignError(
+      `Reference URL response is too large (${contentLength} bytes) for ${url}`,
+      'REFERENCE_URL_TOO_LARGE',
+    );
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text, 'utf8') > MAX_URL_RESPONSE_BYTES) {
+      throw new CodesignError(
+        `Reference URL response is too large for ${url}`,
+        'REFERENCE_URL_TOO_LARGE',
+      );
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_URL_RESPONSE_BYTES) {
+        throw new CodesignError(
+          `Reference URL response is too large for ${url}`,
+          'REFERENCE_URL_TOO_LARGE',
+        );
+      }
+
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function inspectReferenceUrl(url: string): Promise<ReferenceUrlContext> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 4_000);
+  try {
+    const response = await fetch(url, {
+      headers: { 'user-agent': 'open-codesign/0.0.0 (+local desktop app)' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new CodesignError(
+        `Reference URL fetch failed (${response.status}) for ${url}`,
+        'REFERENCE_URL_FETCH_FAILED',
+      );
+    }
+
+    const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+    if (!REFERENCE_CONTENT_TYPES.some((type) => contentType.includes(type))) {
+      throw new CodesignError(
+        `Unsupported reference URL content type "${contentType || 'unknown'}" for ${url}`,
+        'REFERENCE_URL_UNSUPPORTED',
+      );
+    }
+
+    const html = await readResponseText(response, url);
+    const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]?.trim();
+    const description =
+      html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i)?.[1] ??
+      html.match(/<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i)?.[1];
+
+    return {
+      url,
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
+      excerpt: cleanText(stripHtml(html), MAX_URL_EXCERPT_CHARS),
+    };
+  } catch (error) {
+    if (error instanceof CodesignError) throw error;
+    const code =
+      error instanceof Error && error.name === 'AbortError'
+        ? 'REFERENCE_URL_FETCH_TIMEOUT'
+        : 'REFERENCE_URL_FETCH_FAILED';
+    const message =
+      code === 'REFERENCE_URL_FETCH_TIMEOUT'
+        ? `Reference URL request timed out for ${url}`
+        : `Failed to fetch reference URL ${url}`;
+    throw new CodesignError(message, code, { cause: error });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface PreparedPromptContext {
+  designSystem: StoredDesignSystem | null;
+  attachments: AttachmentContext[];
+  referenceUrl: ReferenceUrlContext | null;
+}
+
+export async function preparePromptContext(input: {
+  attachments?: LocalInputFile[] | undefined;
+  referenceUrl?: string | undefined;
+  designSystem?: StoredDesignSystem | null | undefined;
+}): Promise<PreparedPromptContext> {
+  const attachments = await Promise.all(
+    (input.attachments ?? []).map((file) => readAttachment(file)),
+  );
+  const referenceUrl =
+    typeof input.referenceUrl === 'string' && input.referenceUrl.trim().length > 0
+      ? await inspectReferenceUrl(input.referenceUrl.trim())
+      : null;
+
+  return {
+    designSystem: input.designSystem ?? null,
+    attachments,
+    referenceUrl,
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,7 +1,9 @@
 import type {
   ChatMessage,
+  LocalInputFile,
   ModelRef,
   OnboardingState,
+  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { contextBridge, ipcRenderer } from 'electron';
@@ -31,7 +33,23 @@ const api = {
     history: ChatMessage[];
     model: ModelRef;
     baseUrl?: string;
+    referenceUrl?: string;
+    attachments?: LocalInputFile[];
   }) => ipcRenderer.invoke('codesign:generate', payload),
+  applyComment: (payload: {
+    html: string;
+    comment: string;
+    selection: SelectedElement;
+    model?: ModelRef;
+    referenceUrl?: string;
+    attachments?: LocalInputFile[];
+  }) => ipcRenderer.invoke('codesign:apply-comment', payload),
+  pickInputFiles: () =>
+    ipcRenderer.invoke('codesign:pick-input-files') as Promise<LocalInputFile[]>,
+  pickDesignSystemDirectory: () =>
+    ipcRenderer.invoke('codesign:pick-design-system-directory') as Promise<OnboardingState>,
+  clearDesignSystem: () =>
+    ipcRenderer.invoke('codesign:clear-design-system') as Promise<OnboardingState>,
   export: (payload: { format: ExportFormat; htmlContent: string; defaultFilename?: string }) =>
     ipcRenderer.invoke('codesign:export', payload) as Promise<ExportInvokeResponse>,
   checkForUpdates: () => ipcRenderer.invoke('codesign:check-for-updates'),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -31,7 +31,7 @@ export function App() {
   function submit(): void {
     const trimmed = prompt.trim();
     if (!trimmed || isGenerating) return;
-    void sendPrompt(trimmed);
+    void sendPrompt({ prompt: trimmed });
     setPrompt('');
   }
 
@@ -45,7 +45,7 @@ export function App() {
           if (!ready) return;
           const trimmed = prompt.trim();
           if (!trimmed || isGenerating) return;
-          void sendPrompt(trimmed);
+          void sendPrompt({ prompt: trimmed });
           setPrompt('');
         },
       },

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -32,6 +32,8 @@ export function CommandPalette() {
             messages: [],
             previewHtml: null,
             errorMessage: null,
+            iframeErrors: [],
+            selectedElement: null,
           });
           pushToast({ variant: 'info', title: 'Workspace cleared' });
         },

--- a/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
@@ -1,0 +1,82 @@
+import type { SelectedElement } from '@open-codesign/shared';
+import { MessageSquareText, X } from 'lucide-react';
+import { useState } from 'react';
+import { useCodesignStore } from '../store';
+
+export function InlineCommentComposer() {
+  const selectedElement = useCodesignStore((s) => s.selectedElement);
+  if (!selectedElement) return null;
+  return (
+    <InlineCommentComposerCard key={selectedElement.selector} selectedElement={selectedElement} />
+  );
+}
+
+interface InlineCommentComposerCardProps {
+  selectedElement: SelectedElement;
+}
+
+function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCardProps) {
+  const clearCanvasElement = useCodesignStore((s) => s.clearCanvasElement);
+  const applyInlineComment = useCodesignStore((s) => s.applyInlineComment);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const [draft, setDraft] = useState('');
+
+  return (
+    <div className="absolute bottom-10 right-10 z-10 w-[min(420px,calc(100%-3rem))] overflow-hidden rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
+      <div className="flex items-start justify-between gap-3 border-b border-[var(--color-border-muted)] px-4 py-3">
+        <div className="min-w-0">
+          <div className="inline-flex items-center gap-2 text-[12px] font-medium text-[var(--color-text-primary)]">
+            <MessageSquareText className="h-4 w-4 text-[var(--color-accent)]" />
+            Comment on <code className="text-[11px]">{selectedElement.tag}</code>
+          </div>
+          <p
+            className="mt-1 truncate text-[11px] text-[var(--color-text-muted)]"
+            title={selectedElement.selector}
+          >
+            {selectedElement.selector}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={clearCanvasElement}
+          className="rounded-[var(--radius-md)] p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]"
+          aria-label="Close inline comment composer"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="space-y-3 p-4">
+        <p className="text-[12px] leading-[1.5] text-[var(--color-text-secondary)]">
+          Clicked elements stay selected in the canvas. Describe the visual or content change you
+          want, and open-codesign will rewrite the artifact around that target.
+        </p>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Make this section more compact, sharpen the headline, and align it with the linked design system..."
+          rows={4}
+          disabled={isGenerating}
+          className="w-full resize-none rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[13px] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] transition-[box-shadow,border-color] duration-150 focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] focus:outline-none"
+        />
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={clearCanvasElement}
+            className="text-[12px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!draft.trim() || isGenerating}
+            onClick={() => void applyInlineComment(draft)}
+            className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent)] px-3 py-2 text-[12px] font-medium text-white shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:pointer-events-none disabled:opacity-40"
+          >
+            {isGenerating ? 'Applying...' : 'Apply change'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isTrustedPreviewMessageSource } from './PreviewPane';
+
+describe('isTrustedPreviewMessageSource', () => {
+  it('accepts only messages from the active preview iframe window', () => {
+    const previewWindow = {} as Window;
+    const otherWindow = {} as Window;
+
+    expect(isTrustedPreviewMessageSource(previewWindow, previewWindow)).toBe(true);
+    expect(isTrustedPreviewMessageSource(otherWindow, previewWindow)).toBe(false);
+    expect(isTrustedPreviewMessageSource(null, previewWindow)).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -1,12 +1,22 @@
-import { buildSrcdoc } from '@open-codesign/runtime';
+import { buildSrcdoc, isIframeErrorMessage, isOverlayMessage } from '@open-codesign/runtime';
+import { useEffect, useRef } from 'react';
 import { EmptyState } from '../preview/EmptyState';
 import { ErrorState } from '../preview/ErrorState';
 import { LoadingState } from '../preview/LoadingState';
 import { useCodesignStore } from '../store';
+import { CanvasErrorBar } from './CanvasErrorBar';
+import { InlineCommentComposer } from './InlineCommentComposer';
 import { PreviewToolbar } from './PreviewToolbar';
 
 export interface PreviewPaneProps {
   onPickStarter: (prompt: string) => void;
+}
+
+export function isTrustedPreviewMessageSource(
+  source: MessageEventSource | null,
+  previewWindow: Window | null | undefined,
+): boolean {
+  return source !== null && source === previewWindow;
 }
 
 export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
@@ -15,6 +25,36 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const errorMessage = useCodesignStore((s) => s.errorMessage);
   const retry = useCodesignStore((s) => s.retryLastPrompt);
   const clearError = useCodesignStore((s) => s.clearError);
+  const pushIframeError = useCodesignStore((s) => s.pushIframeError);
+  const selectCanvasElement = useCodesignStore((s) => s.selectCanvasElement);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    function onMessage(event: MessageEvent): void {
+      if (!isTrustedPreviewMessageSource(event.source, iframeRef.current?.contentWindow)) return;
+
+      if (isOverlayMessage(event.data)) {
+        selectCanvasElement({
+          selector: event.data.selector,
+          tag: event.data.tag,
+          outerHTML: event.data.outerHTML,
+          rect: event.data.rect,
+        });
+        return;
+      }
+
+      if (isIframeErrorMessage(event.data)) {
+        const location =
+          event.data.source && event.data.lineno
+            ? ` (${event.data.source}:${event.data.lineno})`
+            : '';
+        pushIframeError(`${event.data.kind}: ${event.data.message}${location}`);
+      }
+    }
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [pushIframeError, selectCanvasElement]);
 
   let body: React.ReactNode;
   if (errorMessage) {
@@ -32,13 +72,20 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   } else if (previewHtml) {
     body = (
       <div className="h-full p-6">
-        <iframe
-          key={previewHtml.length}
-          title="design-preview"
-          sandbox="allow-scripts"
-          srcDoc={buildSrcdoc(previewHtml)}
-          className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
-        />
+        <div className="relative h-full">
+          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
+            Click any element in the preview to leave an inline comment.
+          </div>
+          <iframe
+            ref={iframeRef}
+            key={previewHtml.length}
+            title="design-preview"
+            sandbox="allow-scripts"
+            srcDoc={buildSrcdoc(previewHtml)}
+            className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
+          />
+          <InlineCommentComposer />
+        </div>
       </div>
     );
   } else {
@@ -48,6 +95,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   return (
     <div className="flex flex-col min-h-0 flex-1">
       <PreviewToolbar />
+      <CanvasErrorBar />
       <div className="flex-1 overflow-auto">{body}</div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp } from 'lucide-react';
+import { ArrowUp, FolderOpen, Link2, Paperclip, X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
 
@@ -9,9 +9,19 @@ export interface SidebarProps {
 }
 
 export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
+  const config = useCodesignStore((s) => s.config);
   const messages = useCodesignStore((s) => s.messages);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const inputFiles = useCodesignStore((s) => s.inputFiles);
+  const referenceUrl = useCodesignStore((s) => s.referenceUrl);
+  const setReferenceUrl = useCodesignStore((s) => s.setReferenceUrl);
+  const pickInputFiles = useCodesignStore((s) => s.pickInputFiles);
+  const removeInputFile = useCodesignStore((s) => s.removeInputFile);
+  const pickDesignSystemDirectory = useCodesignStore((s) => s.pickDesignSystemDirectory);
+  const clearDesignSystem = useCodesignStore((s) => s.clearDesignSystem);
   const taRef = useRef<HTMLTextAreaElement>(null);
+
+  const designSystem = config?.designSystem ?? null;
 
   useEffect(() => {
     const ta = taRef.current;
@@ -37,10 +47,108 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
 
   return (
     <aside className="flex flex-col border-r border-[var(--color-border)] bg-[var(--color-background-secondary)] min-h-0">
+      <div className="px-5 py-5 border-b border-[var(--color-border-muted)] space-y-3">
+        <div className="space-y-2">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+            Local Context
+          </div>
+          <div className="grid grid-cols-1 gap-2">
+            <button
+              type="button"
+              onClick={() => void pickInputFiles()}
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+            >
+              <Paperclip className="w-4 h-4 text-[var(--color-text-secondary)]" />
+              Attach local files
+            </button>
+            <button
+              type="button"
+              onClick={() => void pickDesignSystemDirectory()}
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+            >
+              <FolderOpen className="w-4 h-4 text-[var(--color-text-secondary)]" />
+              {designSystem ? 'Refresh design system repo' : 'Link design system repo'}
+            </button>
+          </div>
+        </div>
+
+        <label className="block space-y-2">
+          <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+            <Link2 className="w-3.5 h-3.5" />
+            Reference URL
+          </span>
+          <input
+            type="url"
+            value={referenceUrl}
+            onChange={(e) => setReferenceUrl(e.target.value)}
+            placeholder="https://example.com/reference"
+            className="w-full h-10 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150"
+          />
+        </label>
+
+        {inputFiles.length > 0 ? (
+          <div className="space-y-2">
+            <div className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium">
+              Attached Files
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {inputFiles.map((file) => (
+                <span
+                  key={file.path}
+                  className="inline-flex items-center gap-1.5 max-w-full rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1 text-[11px] text-[var(--color-text-secondary)]"
+                >
+                  <span className="truncate max-w-[180px]" title={file.path}>
+                    {file.name}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeInputFile(file.path)}
+                    className="inline-flex items-center justify-center rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+                    aria-label={`Remove ${file.name}`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {designSystem ? (
+          <div className="rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 space-y-2">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[12px] font-medium text-[var(--color-text-primary)]">
+                  Active design system
+                </div>
+                <div className="text-[11px] text-[var(--color-text-muted)] break-all">
+                  {designSystem.rootPath}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => void clearDesignSystem()}
+                className="text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+              >
+                Clear
+              </button>
+            </div>
+            <p className="text-[12px] text-[var(--color-text-secondary)] leading-[1.5]">
+              {designSystem.summary}
+            </p>
+          </div>
+        ) : (
+          <p className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
+            Link a repo to extract colors, typography, spacing, and other styling cues for future
+            generations.
+          </p>
+        )}
+      </div>
+
       <div className="flex-1 overflow-y-auto px-5 py-6 space-y-3">
         {messages.length === 0 ? (
           <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
-            Start a conversation. Pick a starter from the preview pane, or type your brief.
+            Start with a brief, then add files, a URL, or a local repo to ground the result.
           </p>
         ) : (
           messages.map((m, i) => (
@@ -69,7 +177,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
               e.currentTarget.style.height = `${Math.min(e.currentTarget.scrollHeight, 160)}px`;
             }}
             onKeyDown={handleKeyDown}
-            placeholder="Describe what to design…"
+            placeholder="Describe what to design..."
             disabled={isGenerating}
             rows={1}
             className="flex-1 resize-none bg-transparent px-2 py-1 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none min-h-[24px] max-h-[160px]"
@@ -96,14 +204,14 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
               className="px-[5px] py-[1px] rounded-[4px] bg-[var(--color-surface-active)] text-[10px] text-[var(--color-text-secondary)]"
               style={{ fontFamily: 'var(--font-mono)' }}
             >
-              ⌘↵
+              Cmd/Ctrl+Enter
             </kbd>{' '}
             anywhere
           </span>
           {isGenerating ? (
             <span className="inline-flex items-center gap-1.5 text-[var(--color-accent)]">
               <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-pulse" />
-              Generating
+              Working
             </span>
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,7 +1,9 @@
 import type {
   ChatMessage,
+  LocalInputFile,
   ModelRef,
   OnboardingState,
+  SelectedElement,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { create } from 'zustand';
@@ -24,6 +26,12 @@ export interface Toast {
 
 export type Theme = 'light' | 'dark';
 
+interface PromptRequest {
+  prompt: string;
+  attachments: LocalInputFile[];
+  referenceUrl?: string | undefined;
+}
+
 interface CodesignState {
   messages: ChatMessage[];
   previewHtml: string | null;
@@ -40,13 +48,34 @@ interface CodesignState {
   toasts: Toast[];
   iframeErrors: string[];
 
+  inputFiles: LocalInputFile[];
+  referenceUrl: string;
+  lastPromptInput: PromptRequest | null;
+  selectedElement: SelectedElement | null;
+
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
-  sendPrompt: (prompt: string) => Promise<void>;
+  sendPrompt: (input: {
+    prompt: string;
+    attachments?: LocalInputFile[] | undefined;
+    referenceUrl?: string | undefined;
+  }) => Promise<void>;
   retryLastPrompt: () => Promise<void>;
+  applyInlineComment: (comment: string) => Promise<void>;
   clearError: () => void;
   clearIframeErrors: () => void;
+  pushIframeError: (message: string) => void;
   exportActive: (format: ExportFormat) => Promise<void>;
+
+  pickInputFiles: () => Promise<void>;
+  removeInputFile: (path: string) => void;
+  clearInputFiles: () => void;
+  setReferenceUrl: (value: string) => void;
+  pickDesignSystemDirectory: () => Promise<void>;
+  clearDesignSystem: () => Promise<void>;
+
+  selectCanvasElement: (selection: SelectedElement) => void;
+  clearCanvasElement: () => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -96,6 +125,22 @@ function modelRef(provider: SupportedOnboardingProvider, modelId: string): Model
   return { provider, modelId };
 }
 
+function normalizeReferenceUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function uniqueFiles(files: LocalInputFile[]): LocalInputFile[] {
+  const seen = new Set<string>();
+  const result: LocalInputFile[] = [];
+  for (const file of files) {
+    if (seen.has(file.path)) continue;
+    seen.add(file.path);
+    result.push(file);
+  }
+  return result;
+}
+
 export const useCodesignStore = create<CodesignState>((set, get) => ({
   messages: [],
   previewHtml: null,
@@ -112,8 +157,19 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   toasts: [],
   iframeErrors: [],
 
+  inputFiles: [],
+  referenceUrl: '',
+  lastPromptInput: null,
+  selectedElement: null,
+
   clearIframeErrors() {
     set({ iframeErrors: [] });
+  },
+
+  pushIframeError(message) {
+    set((s) => ({
+      iframeErrors: [...s.iframeErrors.slice(-9), message],
+    }));
   },
 
   async loadConfig() {
@@ -132,7 +188,64 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     set({ config: next });
   },
 
-  async sendPrompt(prompt: string) {
+  async pickInputFiles() {
+    if (!window.codesign) return;
+    const files = await window.codesign.pickInputFiles();
+    if (files.length === 0) return;
+    set((s) => ({ inputFiles: uniqueFiles([...s.inputFiles, ...files]) }));
+  },
+
+  removeInputFile(path) {
+    set((s) => ({ inputFiles: s.inputFiles.filter((file) => file.path !== path) }));
+  },
+
+  clearInputFiles() {
+    set({ inputFiles: [] });
+  },
+
+  setReferenceUrl(value) {
+    set({ referenceUrl: value });
+  },
+
+  async pickDesignSystemDirectory() {
+    if (!window.codesign) return;
+    try {
+      const next = await window.codesign.pickDesignSystemDirectory();
+      set({ config: next });
+      if (next.designSystem) {
+        get().pushToast({
+          variant: 'success',
+          title: 'Design system linked',
+          description: next.designSystem.summary,
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to scan design system.';
+      get().pushToast({
+        variant: 'error',
+        title: 'Design system scan failed',
+        description: message,
+      });
+    }
+  },
+
+  async clearDesignSystem() {
+    if (!window.codesign) return;
+    try {
+      const next = await window.codesign.clearDesignSystem();
+      set({ config: next });
+      get().pushToast({ variant: 'info', title: 'Design system cleared' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to clear design system.';
+      get().pushToast({
+        variant: 'error',
+        title: 'Unable to clear design system',
+        description: message,
+      });
+    }
+  },
+
+  async sendPrompt(input) {
     if (get().isGenerating) return;
     if (!window.codesign) {
       const msg = 'Renderer is not connected to the main process.';
@@ -146,23 +259,39 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       return;
     }
 
+    const prompt = input.prompt.trim();
+    if (!prompt) return;
+
+    const request: PromptRequest = {
+      prompt,
+      attachments: uniqueFiles(input.attachments ?? get().inputFiles),
+      ...(normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl)
+        ? { referenceUrl: normalizeReferenceUrl(input.referenceUrl ?? get().referenceUrl) }
+        : {}),
+    };
+
+    const history = get().messages;
     const userMessage: ChatMessage = { role: 'user', content: prompt };
     set((s) => ({
       messages: [...s.messages, userMessage],
       isGenerating: true,
       errorMessage: null,
+      lastPromptInput: request,
+      selectedElement: null,
+      iframeErrors: [],
     }));
 
     try {
       const result = await window.codesign.generate({
         prompt,
-        history: get().messages,
+        history,
         model: modelRef(cfg.provider, cfg.modelPrimary),
+        ...(request.referenceUrl ? { referenceUrl: request.referenceUrl } : {}),
+        attachments: request.attachments,
       });
-      const firstArtifact = (result as { artifacts: Array<{ content: string }> }).artifacts[0];
-      const message = (result as { message: string }).message;
+      const firstArtifact = result.artifacts[0];
       set((s) => ({
-        messages: [...s.messages, { role: 'assistant', content: message || 'Done.' }],
+        messages: [...s.messages, { role: 'assistant', content: result.message || 'Done.' }],
         previewHtml: firstArtifact?.content ?? s.previewHtml,
         isGenerating: false,
       }));
@@ -179,15 +308,65 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   },
 
   async retryLastPrompt() {
-    const lastUser = [...get().messages].reverse().find((m) => m.role === 'user');
-    if (!lastUser) return;
+    const lastPromptInput = get().lastPromptInput;
+    if (!lastPromptInput) return;
+
+    const messages = [...get().messages];
+    const lastMessage = messages.at(-1);
+    if (lastMessage?.role === 'assistant' && lastMessage.content.startsWith('Error:'))
+      messages.pop();
+    const maybeUser = messages.at(-1);
+    if (maybeUser?.role === 'user' && maybeUser.content === lastPromptInput.prompt) messages.pop();
+
+    set({ messages, errorMessage: null });
+    await get().sendPrompt(lastPromptInput);
+  },
+
+  async applyInlineComment(comment) {
+    const trimmed = comment.trim();
+    if (!trimmed || get().isGenerating) return;
+    if (!window.codesign) return;
+    const cfg = get().config;
+    const html = get().previewHtml;
+    const selection = get().selectedElement;
+    if (cfg === null || !cfg.hasKey || html === null || selection === null) return;
+
+    const userMessage: ChatMessage = { role: 'user', content: `Edit ${selection.tag}: ${trimmed}` };
+    const referenceUrl = normalizeReferenceUrl(get().referenceUrl);
+    const attachments = uniqueFiles(get().inputFiles);
+
     set((s) => ({
-      messages: s.messages.filter(
-        (m) => m !== lastUser && !(m.role === 'assistant' && m.content.startsWith('Error:')),
-      ),
+      messages: [...s.messages, userMessage],
+      isGenerating: true,
       errorMessage: null,
+      iframeErrors: [],
     }));
-    await get().sendPrompt(lastUser.content);
+
+    try {
+      const result = await window.codesign.applyComment({
+        html,
+        comment: trimmed,
+        selection,
+        ...(referenceUrl ? { referenceUrl } : {}),
+        attachments,
+      });
+      const firstArtifact = result.artifacts[0];
+      set((s) => ({
+        messages: [...s.messages, { role: 'assistant', content: result.message || 'Applied.' }],
+        previewHtml: firstArtifact?.content ?? s.previewHtml,
+        isGenerating: false,
+        selectedElement: null,
+      }));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      set((s) => ({
+        messages: [...s.messages, { role: 'assistant', content: `Error: ${msg}` }],
+        isGenerating: false,
+        errorMessage: msg,
+        lastError: msg,
+      }));
+      get().pushToast({ variant: 'error', title: 'Inline comment failed', description: msg });
+    }
   },
 
   clearError() {
@@ -218,6 +397,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       const msg = err instanceof Error ? err.message : 'Unknown error';
       set({ toastMessage: msg, errorMessage: msg, lastError: msg });
     }
+  },
+
+  selectCanvasElement(selection) {
+    set({ selectedElement: selection });
+  },
+
+  clearCanvasElement() {
+    set({ selectedElement: null });
   },
 
   setTheme(theme) {

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ModelRef } from '@open-codesign/shared';
+import type { ChatMessage, ModelRef, StoredDesignSystem } from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,7 +15,7 @@ vi.mock('@open-codesign/providers', () => ({
   ) => impl(_model, _messages, _opts),
 }));
 
-import { generate } from './index';
+import { applyComment, generate } from './index';
 
 const MODEL: ModelRef = { provider: 'anthropic', modelId: 'claude-sonnet-4-6' };
 
@@ -26,6 +26,19 @@ const RESPONSE = `Here is your design.
 <artifact identifier="design-1" type="html" title="Hello world">
 ${SAMPLE_HTML}
 </artifact>`;
+
+const DESIGN_SYSTEM: StoredDesignSystem = {
+  schemaVersion: 1,
+  rootPath: '/repo',
+  summary: 'Muted neutrals with warm copper accents.',
+  extractedAt: '2026-04-18T00:00:00.000Z',
+  sourceFiles: ['tailwind.config.ts'],
+  colors: ['#f4efe8', '#b45f3d'],
+  fonts: ['IBM Plex Sans'],
+  spacing: ['0.75rem', '1rem'],
+  radius: ['18px'],
+  shadows: ['0 12px 40px rgba(0,0,0,0.12)'],
+};
 
 afterEach(() => {
   completeMock.mockReset();
@@ -87,5 +100,98 @@ describe('generate()', () => {
     expect(system.role).toBe('system');
     expect(system.content).toContain('open-codesign');
     expect(system.content).toContain('artifact');
+  });
+
+  it('injects design system, file context, and reference URL into the user prompt', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a warm landing page',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+      designSystem: DESIGN_SYSTEM,
+      attachments: [
+        {
+          name: 'brief.md',
+          path: '/tmp/brief.md',
+          excerpt: 'Audience: climate founders. Tone: premium and calm.',
+        },
+      ],
+      referenceUrl: {
+        url: 'https://example.com',
+        title: 'Example',
+        description: 'A warm editorial layout',
+      },
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const user = messages[messages.length - 1];
+    if (!user) throw new Error('expected user message');
+    expect(user.content).toContain('design a warm landing page');
+    expect(user.content).toContain('Design system to follow');
+    expect(user.content).toContain('Repository: repo');
+    expect(user.content).toContain('Muted neutrals with warm copper accents.');
+    expect(user.content).toContain('brief.md');
+    expect(user.content).toContain('https://example.com');
+    expect(user.content).not.toContain('/repo');
+    expect(user.content).not.toContain('/tmp/brief.md');
+  });
+});
+
+describe('applyComment()', () => {
+  it('throws on empty comment', async () => {
+    await expect(
+      applyComment({
+        html: SAMPLE_HTML,
+        comment: '   ',
+        selection: {
+          selector: '#hero',
+          tag: 'section',
+          outerHTML: '<section id="hero">Hi</section>',
+          rect: { top: 0, left: 0, width: 100, height: 100 },
+        },
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).rejects.toBeInstanceOf(CodesignError);
+  });
+
+  it('builds a revision prompt around the selected element', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await applyComment({
+      html: SAMPLE_HTML,
+      comment: 'Make this hero tighter and more premium.',
+      selection: {
+        selector: '#hero',
+        tag: 'section',
+        outerHTML: '<section id="hero">Hi</section>',
+        rect: { top: 0, left: 0, width: 100, height: 100 },
+      },
+      model: MODEL,
+      apiKey: 'sk-test',
+      designSystem: DESIGN_SYSTEM,
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    const user = messages[1];
+    if (!system || !user) throw new Error('expected revision messages');
+    expect(system.content).toContain('revise an existing artifact');
+    expect(user.content).toContain('Make this hero tighter and more premium.');
+    expect(user.content).toContain('#hero');
+    expect(user.content).toContain(SAMPLE_HTML);
+    expect(user.content).toContain('Muted neutrals with warm copper accents.');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,20 +1,56 @@
+import { basename } from 'node:path';
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
 import { type RetryReason, complete, completeWithRetry } from '@open-codesign/providers';
-import type { Artifact, ChatMessage, ModelRef } from '@open-codesign/shared';
+import type {
+  Artifact,
+  ChatMessage,
+  ModelRef,
+  SelectedElement,
+  StoredDesignSystem,
+} from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 import { SYSTEM_PROMPTS } from '@open-codesign/templates';
+
+export interface AttachmentContext {
+  name: string;
+  path: string;
+  excerpt?: string | undefined;
+  note?: string | undefined;
+}
+
+export interface ReferenceUrlContext {
+  url: string;
+  title?: string | undefined;
+  description?: string | undefined;
+  excerpt?: string | undefined;
+}
 
 export interface GenerateInput {
   prompt: string;
   history: ChatMessage[];
   model: ModelRef;
   apiKey: string;
-  baseUrl?: string;
-  systemPrompt?: string;
-  /** Optional cancellation. Threaded through to pi-ai. */
-  signal?: AbortSignal;
-  /** Surfaced for every retry attempt — never silent (PRINCIPLES §10). */
-  onRetry?: (info: RetryReason) => void;
+  baseUrl?: string | undefined;
+  designSystem?: StoredDesignSystem | null | undefined;
+  attachments?: AttachmentContext[] | undefined;
+  referenceUrl?: ReferenceUrlContext | null | undefined;
+  systemPrompt?: string | undefined;
+  signal?: AbortSignal | undefined;
+  onRetry?: ((info: RetryReason) => void) | undefined;
+}
+
+export interface ApplyCommentInput {
+  html: string;
+  comment: string;
+  selection: SelectedElement;
+  model: ModelRef;
+  apiKey: string;
+  baseUrl?: string | undefined;
+  designSystem?: StoredDesignSystem | null | undefined;
+  attachments?: AttachmentContext[] | undefined;
+  referenceUrl?: ReferenceUrlContext | null | undefined;
+  signal?: AbortSignal | undefined;
+  onRetry?: ((info: RetryReason) => void) | undefined;
 }
 
 export interface GenerateOutput {
@@ -28,6 +64,15 @@ export interface GenerateOutput {
 interface Collected {
   text: string;
   artifacts: Artifact[];
+}
+
+interface ModelRunInput {
+  model: ModelRef;
+  apiKey: string;
+  baseUrl?: string | undefined;
+  signal?: AbortSignal | undefined;
+  onRetry?: ((info: RetryReason) => void) | undefined;
+  messages: ChatMessage[];
 }
 
 function collect(events: Iterable<ArtifactEvent>, into: Collected): void {
@@ -47,27 +92,95 @@ function collect(events: Iterable<ArtifactEvent>, into: Collected): void {
   }
 }
 
-/**
- * Generate one design artifact in response to a user prompt.
- * Tier 1: blocking call, returns the parsed artifact list at the end.
- * Wraps the provider call in `completeWithRetry` so transient 5xx/429/network
- * failures retry with backoff. Caller passes `signal` to cancel and `onRetry`
- * to surface retry attempts in the UI.
- */
-export async function generate(input: GenerateInput): Promise<GenerateOutput> {
-  if (!input.prompt.trim()) {
-    throw new CodesignError('Prompt cannot be empty', 'INPUT_EMPTY_PROMPT');
-  }
-
-  const messages: ChatMessage[] = [
-    { role: 'system', content: input.systemPrompt ?? SYSTEM_PROMPTS.designGenerator },
-    ...input.history,
-    { role: 'user', content: input.prompt },
+function formatDesignSystem(designSystem: StoredDesignSystem): string {
+  const repoLabel = basename(designSystem.rootPath);
+  const lines = [
+    '## Design system to follow',
+    `Repository: ${repoLabel}`,
+    `Summary: ${designSystem.summary}`,
   ];
+  if (designSystem.colors.length > 0) lines.push(`Colors: ${designSystem.colors.join(', ')}`);
+  if (designSystem.fonts.length > 0) lines.push(`Fonts: ${designSystem.fonts.join(', ')}`);
+  if (designSystem.spacing.length > 0) lines.push(`Spacing: ${designSystem.spacing.join(', ')}`);
+  if (designSystem.radius.length > 0) lines.push(`Radius: ${designSystem.radius.join(', ')}`);
+  if (designSystem.shadows.length > 0) lines.push(`Shadows: ${designSystem.shadows.join(', ')}`);
+  if (designSystem.sourceFiles.length > 0) {
+    lines.push(`Source files: ${designSystem.sourceFiles.join(', ')}`);
+  }
+  return lines.join('\n');
+}
 
+function formatAttachments(attachments: AttachmentContext[]): string | null {
+  if (attachments.length === 0) return null;
+  const body = attachments
+    .map((file, index) => {
+      const lines = [`${index + 1}. ${file.name}`];
+      if (file.note) lines.push(`Note: ${file.note}`);
+      if (file.excerpt) lines.push(`Excerpt:\n${file.excerpt}`);
+      return lines.join('\n');
+    })
+    .join('\n\n');
+  return `## Attached local references\n${body}`;
+}
+
+function formatReferenceUrl(referenceUrl: ReferenceUrlContext | null | undefined): string | null {
+  if (!referenceUrl) return null;
+  const lines = ['## Reference URL', `URL: ${referenceUrl.url}`];
+  if (referenceUrl.title) lines.push(`Title: ${referenceUrl.title}`);
+  if (referenceUrl.description) lines.push(`Description: ${referenceUrl.description}`);
+  if (referenceUrl.excerpt) lines.push(`Excerpt:\n${referenceUrl.excerpt}`);
+  return lines.join('\n');
+}
+
+function buildContextSections(input: {
+  designSystem?: StoredDesignSystem | null | undefined;
+  attachments?: AttachmentContext[] | undefined;
+  referenceUrl?: ReferenceUrlContext | null | undefined;
+}): string[] {
+  const sections: string[] = [];
+  if (input.designSystem) sections.push(formatDesignSystem(input.designSystem));
+  const attachmentSection = formatAttachments(input.attachments ?? []);
+  if (attachmentSection) sections.push(attachmentSection);
+  const referenceSection = formatReferenceUrl(input.referenceUrl);
+  if (referenceSection) sections.push(referenceSection);
+  return sections;
+}
+
+function buildPrompt(prompt: string, contextSections: string[]): string {
+  if (contextSections.length === 0) return prompt.trim();
+  return [
+    prompt.trim(),
+    'Use the following local context and references when making design decisions. Follow the design system closely when one is provided.',
+    contextSections.join('\n\n'),
+  ].join('\n\n');
+}
+
+function buildRevisionPrompt(input: ApplyCommentInput, contextSections: string[]): string {
+  const parts = [
+    'Revise the existing HTML artifact below.',
+    'Keep the overall structure, copy, and layout intact unless the user request requires a broader change.',
+    `User request: ${input.comment.trim()}`,
+    `Selected element tag: <${input.selection.tag}>`,
+    `Selected element selector: ${input.selection.selector}`,
+    `Selected element snippet:\n${input.selection.outerHTML || '(empty)'}`,
+    `Current full HTML:\n${input.html}`,
+  ];
+  if (contextSections.length > 0) {
+    parts.push(
+      'You also have the following supporting context. Use it to preserve brand consistency while applying the requested change.',
+    );
+    parts.push(contextSections.join('\n\n'));
+  }
+  parts.push(
+    'Return the full updated HTML artifact. Do not explain the diff line by line; a short summary outside the artifact is enough.',
+  );
+  return parts.join('\n\n');
+}
+
+async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
   const result = await completeWithRetry(
     input.model,
-    messages,
+    input.messages,
     {
       apiKey: input.apiKey,
       ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
@@ -91,4 +204,54 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     outputTokens: result.outputTokens,
     costUsd: result.costUsd,
   };
+}
+
+export async function generate(input: GenerateInput): Promise<GenerateOutput> {
+  if (!input.prompt.trim()) {
+    throw new CodesignError('Prompt cannot be empty', 'INPUT_EMPTY_PROMPT');
+  }
+
+  const messages: ChatMessage[] = [
+    { role: 'system', content: input.systemPrompt ?? SYSTEM_PROMPTS.designGenerator },
+    ...input.history,
+    { role: 'user', content: buildPrompt(input.prompt, buildContextSections(input)) },
+  ];
+
+  return runModel({
+    model: input.model,
+    apiKey: input.apiKey,
+    baseUrl: input.baseUrl,
+    signal: input.signal,
+    onRetry: input.onRetry,
+    messages,
+  });
+}
+
+export async function applyComment(input: ApplyCommentInput): Promise<GenerateOutput> {
+  if (!input.comment.trim()) {
+    throw new CodesignError('Comment cannot be empty', 'INPUT_EMPTY_COMMENT');
+  }
+  if (!input.html.trim()) {
+    throw new CodesignError('Existing HTML cannot be empty', 'INPUT_EMPTY_HTML');
+  }
+
+  const messages: ChatMessage[] = [
+    {
+      role: 'system',
+      content: [
+        SYSTEM_PROMPTS.designGenerator,
+        'You may also be asked to revise an existing artifact. In that case, preserve the design intent and make the smallest coherent change that satisfies the request.',
+      ].join('\n\n'),
+    },
+    { role: 'user', content: buildRevisionPrompt(input, buildContextSections(input)) },
+  ];
+
+  return runModel({
+    model: input.model,
+    apiKey: input.apiKey,
+    baseUrl: input.baseUrl,
+    signal: input.signal,
+    onRetry: input.onRetry,
+    messages,
+  });
 }

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigSchema, STORED_DESIGN_SYSTEM_SCHEMA_VERSION } from './config';
+
+describe('ConfigSchema', () => {
+  it('upgrades legacy designSystem snapshots to the versioned format', () => {
+    const parsed = ConfigSchema.parse({
+      version: 1,
+      provider: 'openai',
+      modelPrimary: 'gpt-4o',
+      modelFast: 'gpt-4o-mini',
+      secrets: {},
+      baseUrls: {},
+      designSystem: {
+        rootPath: '/repo',
+        summary: 'Warm neutral tokens',
+        extractedAt: '2026-04-18T00:00:00.000Z',
+        sourceFiles: ['tailwind.config.ts'],
+        colors: ['#f4efe8'],
+        fonts: ['IBM Plex Sans'],
+        spacing: ['1rem'],
+        radius: ['18px'],
+        shadows: ['0 12px 40px rgba(0,0,0,0.12)'],
+      },
+    });
+
+    expect(parsed.designSystem?.schemaVersion).toBe(STORED_DESIGN_SYSTEM_SCHEMA_VERSION);
+    expect(parsed.designSystem?.rootPath).toBe('/repo');
+  });
+});

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -27,6 +27,29 @@ export const BaseUrlRef = z.object({
 });
 export type BaseUrlRef = z.infer<typeof BaseUrlRef>;
 
+export const STORED_DESIGN_SYSTEM_SCHEMA_VERSION = 1 as const;
+
+const StoredDesignSystemShape = z.object({
+  schemaVersion: z.literal(STORED_DESIGN_SYSTEM_SCHEMA_VERSION),
+  rootPath: z.string().min(1),
+  summary: z.string().min(1),
+  extractedAt: z.string().min(1),
+  sourceFiles: z.array(z.string().min(1)).max(24).default([]),
+  colors: z.array(z.string().min(1)).max(24).default([]),
+  fonts: z.array(z.string().min(1)).max(16).default([]),
+  spacing: z.array(z.string().min(1)).max(16).default([]),
+  radius: z.array(z.string().min(1)).max(16).default([]),
+  shadows: z.array(z.string().min(1)).max(16).default([]),
+});
+
+export const StoredDesignSystem = z.preprocess((raw) => {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return raw;
+  const record = raw as Record<string, unknown>;
+  if ('schemaVersion' in record) return record;
+  return { schemaVersion: STORED_DESIGN_SYSTEM_SCHEMA_VERSION, ...record };
+}, StoredDesignSystemShape);
+export type StoredDesignSystem = z.infer<typeof StoredDesignSystem>;
+
 export const ConfigSchema = z.object({
   version: z.literal(1).default(1),
   provider: ProviderIdEnum,
@@ -34,6 +57,7 @@ export const ConfigSchema = z.object({
   modelFast: z.string().min(1),
   secrets: z.record(ProviderIdEnum, SecretRef).default({}),
   baseUrls: z.record(ProviderIdEnum, BaseUrlRef).default({}),
+  designSystem: StoredDesignSystem.optional(),
 });
 export type Config = z.infer<typeof ConfigSchema>;
 
@@ -43,6 +67,7 @@ export interface OnboardingState {
   modelPrimary: string | null;
   modelFast: string | null;
   baseUrl: string | null;
+  designSystem: StoredDesignSystem | null;
 }
 
 export interface ProviderShortlist {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -80,13 +80,48 @@ export const ChatMessage = z.object({
 });
 export type ChatMessage = z.infer<typeof ChatMessage>;
 
+export const LocalInputFile = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  size: z.number().int().nonnegative(),
+});
+export type LocalInputFile = z.infer<typeof LocalInputFile>;
+
+export const ElementSelectionRect = z.object({
+  top: z.number(),
+  left: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+export type ElementSelectionRect = z.infer<typeof ElementSelectionRect>;
+
+export const SelectedElement = z.object({
+  selector: z.string().min(1),
+  tag: z.string().min(1),
+  outerHTML: z.string(),
+  rect: ElementSelectionRect,
+});
+export type SelectedElement = z.infer<typeof SelectedElement>;
+
 export const GeneratePayload = z.object({
   prompt: z.string().min(1).max(32_000),
   history: z.array(ChatMessage).max(200),
   model: ModelRef,
   baseUrl: z.string().url().optional(),
+  referenceUrl: z.string().url().optional(),
+  attachments: z.array(LocalInputFile).max(12).default([]),
 });
 export type GeneratePayload = z.infer<typeof GeneratePayload>;
+
+export const ApplyCommentPayload = z.object({
+  html: z.string().min(1).max(500_000),
+  comment: z.string().min(1).max(4_000),
+  selection: SelectedElement,
+  model: ModelRef.optional(),
+  referenceUrl: z.string().url().optional(),
+  attachments: z.array(LocalInputFile).max(12).default([]),
+});
+export type ApplyCommentPayload = z.infer<typeof ApplyCommentPayload>;
 
 /**
  * Iframe runtime error event — schema for the postMessage payload sent by
@@ -126,6 +161,8 @@ export {
   PROVIDER_SHORTLIST,
   SUPPORTED_ONBOARDING_PROVIDERS,
   SecretRef,
+  STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
+  StoredDesignSystem,
   isSupportedOnboardingProvider,
 } from './config';
 export type {

--- a/packages/templates/src/system/design-generator.md
+++ b/packages/templates/src/system/design-generator.md
@@ -2,15 +2,14 @@
 
 Canonical, human-readable copy of the system prompt used by `@open-codesign/core`
 to drive `designGenerator`. The TypeScript constant in `./index.ts` MUST stay
-byte-for-byte in sync with the prose below; tests assert this. Keeping the prompt
-in Markdown lets reviewers diff prompt changes without scanning a quoted string.
+in sync with the prose below.
 
 ---
 
-You are **open-codesign**, an AI design partner. The user describes a thing they
-want to look at — a landing page, a mobile screen, a one-page case study, a slide
-deck — and you respond with a single, self-contained, production-quality HTML
-artifact they can export and ship.
+You are open-codesign, an AI design partner. The user describes a thing they
+want to look at - a landing page, a mobile screen, a one-page case study, a
+slide deck - and you respond with a single, self-contained, production-quality
+HTML artifact they can export and ship.
 
 ## Output contract
 
@@ -26,42 +25,45 @@ appear inside the tag, and no second artifact may follow.
 </artifact>
 ```
 
-Outside the artifact tag you may write at most one short paragraph (≤ 2
-sentences) describing what you produced. Never narrate the HTML — the user can
+Outside the artifact tag you may write at most one short paragraph (<= 2
+sentences) describing what you produced. Never narrate the HTML - the user can
 see it.
 
 ## Construction rules
 
-1. **Single shot, single file.** No external CSS, no external JS, no `<link>` to
+1. Single shot, single file. No external CSS, no external JS, no `<link>` to
    custom stylesheets. The only permitted external script is Tailwind from the
-   official CDN: `<script src="https://cdn.tailwindcss.com"></script>`. The only
-   permitted external font source is `fonts.googleapis.com`.
-2. **Tailwind is the styling engine.** Compose with utility classes; reach for
+   official CDN: `<script src="https://cdn.tailwindcss.com"></script>`. The
+   only permitted external font source is `fonts.googleapis.com`.
+2. Tailwind is the styling engine. Compose with utility classes; reach for
    inline `<style>` only for `:root` custom properties and the handful of rules
    Tailwind utilities cannot express cleanly (keyframes, complex selectors).
-3. **Tunable design tokens.** Every load-bearing value — primary color, accent
-   color, surface, text, base radius, base font size, spacing scale — MUST be a
+3. Tunable design tokens. Every load-bearing value - primary color, accent
+   color, surface, text, base radius, base font size, spacing scale - MUST be a
    CSS custom property declared on `:root`. Use these variables inside Tailwind
    via the arbitrary-value syntax (`bg-[var(--color-accent)]`). This is what
    makes the slider tier work later; bake it in from day one.
-4. **Semantic HTML.** `<header>`, `<main>`, `<section>`, `<article>`, `<nav>`,
-   `<footer>` where appropriate. Headings in correct order. Images have `alt`
+4. Semantic HTML. `<header>`, `<main>`, `<section>`, `<article>`, `<nav>`,
+   `<footer>` where appropriate. Headings in correct order. Images have alt
    text. Buttons are `<button>`, links are `<a>`.
-5. **Responsive by default.** Mobile-first; layout adapts at `sm`, `md`, `lg`.
-   Use CSS grid or flex — never absolute positioning for layout.
-6. **Modern aesthetic.** Generous whitespace, restrained color palette
-   (neutrals + one or two accents), confident typography hierarchy, soft
-   shadows, subtle motion only where it earns its keep. Never use the default
-   Tailwind blue. Pick a palette that fits the brief.
-7. **Real content.** No `lorem ipsum`. Write copy that fits the product the
-   user described — short, specific, on-brand. Use realistic names, numbers,
-   and dates.
-8. **Accessibility.** Color contrast meets WCAG AA. Interactive elements are
+5. Responsive by default. Mobile-first; layout adapts at `sm`, `md`, `lg`. Use
+   CSS grid or flex - never absolute positioning for layout.
+6. Modern aesthetic. Generous whitespace, restrained color palette (neutrals +
+   one or two accents), confident typography hierarchy, soft shadows, subtle
+   motion only where it earns its keep. Never use the default Tailwind blue.
+   Pick a palette that fits the brief.
+7. Real content. No lorem ipsum. Write copy that fits the product the user
+   described - short, specific, on-brand. Use realistic names, numbers, and
+   dates.
+8. Accessibility. Color contrast meets WCAG AA. Interactive elements are
    reachable by keyboard. Decorative SVGs get `aria-hidden="true"`.
-9. **No external assets you can't guarantee.** Inline SVGs for icons; never
-   `<img src="https://…/photo.jpg">`. If you need a hero image, render an
-   abstract SVG composition or a CSS gradient block.
-10. **Self-contained mockup.** The artifact is a finished design surface, not a
+9. Respect provided context. If the user supplies a design system, local files,
+   or a reference URL, use them as authoritative style/context inputs instead
+   of ignoring them or inventing a conflicting visual language.
+10. No external assets you can't guarantee. Inline SVGs for icons; never
+    `<img src="https://example.com/photo.jpg">`. If you need a hero image,
+    render an abstract SVG composition or a CSS gradient block.
+11. Self-contained mockup. The artifact is a finished design surface, not a
     working app. Don't wire up routes, fetch data, or include build tooling.
 
 ## Failure modes to avoid
@@ -74,5 +76,5 @@ see it.
 - Emitting more than one artifact.
 - Referencing files or images that don't exist.
 
-When the user follows up to tweak the design, regenerate the full artifact —
+When the user follows up to tweak the design, regenerate the full artifact -
 the artifact is the canonical state.

--- a/packages/templates/src/system/index.ts
+++ b/packages/templates/src/system/index.ts
@@ -9,7 +9,7 @@
  * Tier 1 packages don't depend on Vite's raw loader.
  */
 
-const designGenerator = `You are open-codesign, an AI design partner. The user describes a thing they want to look at — a landing page, a mobile screen, a one-page case study, a slide deck — and you respond with a single, self-contained, production-quality HTML artifact they can export and ship.
+const designGenerator = `You are open-codesign, an AI design partner. The user describes a thing they want to look at - a landing page, a mobile screen, a one-page case study, a slide deck - and you respond with a single, self-contained, production-quality HTML artifact they can export and ship.
 
 # Output contract
 
@@ -22,20 +22,21 @@ Wrap the entire HTML document in exactly one artifact tag. Nothing else may appe
 </html>
 </artifact>
 
-Outside the artifact tag you may write at most one short paragraph (≤ 2 sentences) describing what you produced. Never narrate the HTML — the user can see it.
+Outside the artifact tag you may write at most one short paragraph (<= 2 sentences) describing what you produced. Never narrate the HTML - the user can see it.
 
 # Construction rules
 
 1. Single shot, single file. No external CSS, no external JS, no <link> to custom stylesheets. The only permitted external script is Tailwind from the official CDN: <script src="https://cdn.tailwindcss.com"></script>. The only permitted external font source is fonts.googleapis.com.
 2. Tailwind is the styling engine. Compose with utility classes; reach for inline <style> only for :root custom properties and the handful of rules Tailwind utilities cannot express cleanly (keyframes, complex selectors).
-3. Tunable design tokens. Every load-bearing value — primary color, accent color, surface, text, base radius, base font size, spacing scale — MUST be a CSS custom property declared on :root. Use these variables inside Tailwind via the arbitrary-value syntax (bg-[var(--color-accent)]). This is what makes the slider tier work later; bake it in from day one.
+3. Tunable design tokens. Every load-bearing value - primary color, accent color, surface, text, base radius, base font size, spacing scale - MUST be a CSS custom property declared on :root. Use these variables inside Tailwind via the arbitrary-value syntax (bg-[var(--color-accent)]). This is what makes the slider tier work later; bake it in from day one.
 4. Semantic HTML. <header>, <main>, <section>, <article>, <nav>, <footer> where appropriate. Headings in correct order. Images have alt text. Buttons are <button>, links are <a>.
-5. Responsive by default. Mobile-first; layout adapts at sm, md, lg. Use CSS grid or flex — never absolute positioning for layout.
+5. Responsive by default. Mobile-first; layout adapts at sm, md, lg. Use CSS grid or flex - never absolute positioning for layout.
 6. Modern aesthetic. Generous whitespace, restrained color palette (neutrals + one or two accents), confident typography hierarchy, soft shadows, subtle motion only where it earns its keep. Never use the default Tailwind blue. Pick a palette that fits the brief.
-7. Real content. No lorem ipsum. Write copy that fits the product the user described — short, specific, on-brand. Use realistic names, numbers, and dates.
+7. Real content. No lorem ipsum. Write copy that fits the product the user described - short, specific, on-brand. Use realistic names, numbers, and dates.
 8. Accessibility. Color contrast meets WCAG AA. Interactive elements are reachable by keyboard. Decorative SVGs get aria-hidden="true".
-9. No external assets you can't guarantee. Inline SVGs for icons; never <img src="https://…/photo.jpg">. If you need a hero image, render an abstract SVG composition or a CSS gradient block.
-10. Self-contained mockup. The artifact is a finished design surface, not a working app. Don't wire up routes, fetch data, or include build tooling.
+9. Respect provided context. If the user supplies a design system, local files, or a reference URL, use them as authoritative style/context inputs instead of ignoring them or inventing a conflicting visual language.
+10. No external assets you can't guarantee. Inline SVGs for icons; never <img src="https://example.com/photo.jpg">. If you need a hero image, render an abstract SVG composition or a CSS gradient block.
+11. Self-contained mockup. The artifact is a finished design surface, not a working app. Don't wire up routes, fetch data, or include build tooling.
 
 # Failure modes to avoid
 
@@ -45,7 +46,7 @@ Outside the artifact tag you may write at most one short paragraph (≤ 2 senten
 - Emitting more than one artifact.
 - Referencing files or images that don't exist.
 
-When the user follows up to tweak the design, regenerate the full artifact — the artifact is the canonical state.`;
+When the user follows up to tweak the design, regenerate the full artifact - the artifact is the canonical state.`;
 
 export const SYSTEM_PROMPTS = {
   designGenerator,


### PR DESCRIPTION
## Summary
- add sidebar support for local files, reference URLs, and design system repos
- scan design system repos into prompt context and pass them into generate/apply-comment flows
- add preview selection + inline comment editing MVP in the desktop app

## Validation
- corepack pnpm --filter @open-codesign/shared typecheck
- corepack pnpm --filter @open-codesign/desktop typecheck
- corepack pnpm --filter @open-codesign/core test