### PR TITLE
feat(desktop): proxy presets + connection test + real model list

### DIFF
--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure logic extracted from connection-ipc.ts
+// These tests do NOT import connection-ipc directly because that file imports
+// ./electron-runtime which requires('electron') — unavailable in vitest.
+// Instead we test the pure helpers inline.
+// ---------------------------------------------------------------------------
+
+// ----- Cache logic (mirrors the implementation in connection-ipc.ts) --------
+
+interface CacheEntry {
+  models: string[];
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cache: Map<string, CacheEntry>;
+
+function getCacheKey(provider: string, baseUrl: string): string {
+  return `${provider}::${baseUrl}`;
+}
+
+function getCachedModels(provider: string, baseUrl: string): string[] | null {
+  const key = getCacheKey(provider, baseUrl);
+  const entry = cache.get(key);
+  if (entry === undefined) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.models;
+}
+
+function setCachedModels(provider: string, baseUrl: string, models: string[]): void {
+  const key = getCacheKey(provider, baseUrl);
+  cache.set(key, { models, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// ----- Error classification (mirrors connection-ipc.ts) --------------------
+
+type ErrorCode = '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
+
+function classifyHttpError(status: number): { code: ErrorCode; hint: string } {
+  if (status === 401 || status === 403) {
+    return { code: '401', hint: 'API key 错误或权限不足' };
+  }
+  if (status === 404) {
+    return {
+      code: '404',
+      hint: 'baseUrl 路径错误。OpenAI 兼容代理通常需要 /v1 后缀（试试 https://your-host/v1）',
+    };
+  }
+  return { code: 'NETWORK', hint: `服务器返回 HTTP ${status}` };
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  cache = new Map();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// connection:v1:test — 401 hint contains "API key"
+// ---------------------------------------------------------------------------
+
+describe('classifyHttpError', () => {
+  it('returns hint containing "API key" on 401', () => {
+    const { hint } = classifyHttpError(401);
+    expect(hint).toContain('API key');
+  });
+
+  it('returns 401 code for status 403 as well', () => {
+    const { code } = classifyHttpError(403);
+    expect(code).toBe('401');
+  });
+
+  it('returns 404 code and /v1 hint on 404', () => {
+    const result = classifyHttpError(404);
+    expect(result.code).toBe('404');
+    expect(result.hint).toContain('/v1');
+  });
+
+  it('returns NETWORK code for unexpected status', () => {
+    const { code } = classifyHttpError(500);
+    expect(code).toBe('NETWORK');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// models:v1:list — 5-minute cache TTL
+// ---------------------------------------------------------------------------
+
+describe('models cache (5-min TTL)', () => {
+  it('returns cached models within TTL', () => {
+    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o', 'gpt-4o-mini']);
+    const result = getCachedModels('openai', 'https://api.openai.com/v1');
+    expect(result).toEqual(['gpt-4o', 'gpt-4o-mini']);
+  });
+
+  it('returns null after TTL expires', () => {
+    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o']);
+
+    // Advance past the 5-minute TTL
+    vi.advanceTimersByTime(CACHE_TTL_MS + 1);
+
+    const result = getCachedModels('openai', 'https://api.openai.com/v1');
+    expect(result).toBeNull();
+  });
+
+  it('different provider+baseUrl combinations are cached independently', () => {
+    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o']);
+    setCachedModels('openai', 'https://relay.example.com/v1', ['custom-model']);
+
+    expect(getCachedModels('openai', 'https://api.openai.com/v1')).toEqual(['gpt-4o']);
+    expect(getCachedModels('openai', 'https://relay.example.com/v1')).toEqual(['custom-model']);
+  });
+
+  it('returns null for keys not yet in cache', () => {
+    expect(getCachedModels('anthropic', 'https://api.anthropic.com')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -54,6 +54,111 @@ function classifyHttpError(status: number): { code: ErrorCode; hint: string } {
   return { code: 'NETWORK', hint: `服务器返回 HTTP ${status}` };
 }
 
+// ----- ModelsListResponse error union (mirrors connection-ipc.ts) -----------
+
+type ModelsListResponse =
+  | { ok: true; models: string[] }
+  | {
+      ok: false;
+      code: 'IPC_BAD_INPUT' | 'NETWORK' | 'HTTP' | 'PARSE';
+      message: string;
+      hint: string;
+    };
+
+// Minimal inline handler exercising the same logic as the real ipcMain handler.
+async function handleModelsList(
+  raw: unknown,
+  fetchImpl: (
+    url: string,
+  ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>,
+): Promise<ModelsListResponse> {
+  // Validate payload
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'payload must be an object',
+      hint: 'Invalid models:v1:list payload',
+    };
+  }
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r['provider'] !== 'string' ||
+    !['anthropic', 'openai', 'openrouter'].includes(r['provider'])
+  ) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: `Unsupported provider: ${String(r['provider'])}`,
+      hint: 'Invalid models:v1:list payload',
+    };
+  }
+  if (typeof r['apiKey'] !== 'string' || (r['apiKey'] as string).trim().length === 0) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'apiKey must be a non-empty string',
+      hint: 'Invalid models:v1:list payload',
+    };
+  }
+  if (typeof r['baseUrl'] !== 'string' || (r['baseUrl'] as string).trim().length === 0) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'baseUrl must be a non-empty string',
+      hint: 'Invalid models:v1:list payload',
+    };
+  }
+
+  const provider = r['provider'] as string;
+  const baseUrl = (r['baseUrl'] as string).trim();
+
+  const cached = getCachedModels(provider, baseUrl);
+  if (cached !== null) return { ok: true, models: cached };
+
+  let res: { ok: boolean; status: number; json: () => Promise<unknown> };
+  try {
+    res = await fetchImpl(`${baseUrl}/models`);
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'NETWORK',
+      message: err instanceof Error ? err.message : String(err),
+      hint: 'Cannot reach provider /models endpoint',
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      code: 'HTTP',
+      message: `HTTP ${res.status}`,
+      hint: 'Model list request failed',
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return {
+      ok: false,
+      code: 'PARSE',
+      message: 'Invalid JSON in response',
+      hint: 'Provider returned non-JSON',
+    };
+  }
+
+  const data = (body as { data?: unknown }).data;
+  const models = Array.isArray(data)
+    ? data
+        .filter((i) => typeof i === 'object' && i !== null && 'id' in i)
+        .map((i) => String((i as { id: unknown }).id))
+    : [];
+  setCachedModels(provider, baseUrl, models);
+  return { ok: true, models };
+}
+
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
@@ -123,5 +228,65 @@ describe('models cache (5-min TTL)', () => {
 
   it('returns null for keys not yet in cache', () => {
     expect(getCachedModels('anthropic', 'https://api.anthropic.com')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// models:v1:list — error union (no more silent [] fallback)
+// ---------------------------------------------------------------------------
+
+describe('models:v1:list error union', () => {
+  it('bad payload (missing provider) → ok=false, code=IPC_BAD_INPUT', async () => {
+    const result = await handleModelsList(
+      { apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => {
+        throw new Error('should not be called');
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('HTTP 500 from provider → ok=false, code=HTTP', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('HTTP');
+      expect(result.message).toBe('HTTP 500');
+    }
+  });
+
+  it('network error (fetch throws) → ok=false, code=NETWORK', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('NETWORK');
+      expect(result.message).toContain('ECONNREFUSED');
+    }
+  });
+
+  it('successful fetch → ok=true with model ids', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ id: 'gpt-4o' }, { id: 'gpt-4o-mini' }] }),
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
+    }
   });
 });

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -149,29 +149,25 @@ async function handleModelsList(
     };
   }
 
-  // mirrors extractModelIds: returns null when shape is unrecognised
+  // mirrors extractIds/extractModelIds: any item missing a string id rejects entirely
+  function extractIds(items: unknown[]): string[] | null {
+    const ids: string[] = [];
+    for (const item of items) {
+      if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
+        ids.push((item as { id: string }).id);
+      } else {
+        return null;
+      }
+    }
+    return ids;
+  }
+
   function extractModelIds(b: unknown): string[] | null {
     if (b === null || typeof b !== 'object') return null;
     const data = (b as { data?: unknown }).data;
-    if (Array.isArray(data)) {
-      return data
-        .map((i) =>
-          i && typeof i === 'object' && typeof (i as { id?: unknown }).id === 'string'
-            ? (i as { id: string }).id
-            : null,
-        )
-        .filter((id): id is string => id !== null);
-    }
+    if (Array.isArray(data)) return extractIds(data);
     const models = (b as { models?: unknown }).models;
-    if (Array.isArray(models)) {
-      return models
-        .map((i) =>
-          i && typeof i === 'object' && typeof (i as { id?: unknown }).id === 'string'
-            ? (i as { id: string }).id
-            : null,
-        )
-        .filter((id): id is string => id !== null);
-    }
+    if (Array.isArray(models)) return extractIds(models);
     return null;
   }
 
@@ -335,7 +331,7 @@ describe('models:v1:list error union', () => {
     }
   });
 
-  it('mixed data array (one valid, one without id) → ok=true, only valid id returned', async () => {
+  it('mixed data array (one valid, one without id) → ok=false, code=PARSE', async () => {
     const result = await handleModelsList(
       { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
       async () => ({
@@ -344,9 +340,24 @@ describe('models:v1:list error union', () => {
         json: async () => ({ data: [{ id: 'gpt-4o' }, { foo: 'bar' }] }),
       }),
     );
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.models).toEqual(['gpt-4o']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('PARSE');
+    }
+  });
+
+  it('data array with non-string id (number) → ok=false, code=PARSE', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ id: 'gpt-4o' }, { id: 123 }] }),
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('PARSE');
     }
   });
 

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -21,7 +21,76 @@ import {
 // network responses without hitting the network.
 // ---------------------------------------------------------------------------
 
-import type { ModelsListResponse } from './connection-ipc';
+import type { ConnectionTestResponse, ModelsListResponse } from './connection-ipc';
+
+// ---------------------------------------------------------------------------
+// connection:v1:test test helper
+// ---------------------------------------------------------------------------
+
+async function handleConnectionTest(
+  raw: unknown,
+  fetchImpl: (url: string) => Promise<{ ok: boolean; status: number }>,
+): Promise<ConnectionTestResponse> {
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'connection:v1:test expects an object payload',
+      hint: 'Invalid connection test payload',
+    };
+  }
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r['provider'] !== 'string' ||
+    !['anthropic', 'openai', 'openrouter'].includes(r['provider'])
+  ) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: `Unsupported provider: ${String(r['provider'])}`,
+      hint: 'Invalid connection test payload',
+    };
+  }
+  if (typeof r['apiKey'] !== 'string' || (r['apiKey'] as string).trim().length === 0) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'apiKey must be a non-empty string',
+      hint: 'Invalid connection test payload',
+    };
+  }
+  if (typeof r['baseUrl'] !== 'string' || (r['baseUrl'] as string).trim().length === 0) {
+    return {
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+      message: 'baseUrl must be a non-empty string',
+      hint: 'Invalid connection test payload',
+    };
+  }
+
+  const baseUrl = (r['baseUrl'] as string).trim();
+
+  let res: { ok: boolean; status: number };
+  try {
+    res = await fetchImpl(`${baseUrl}/v1/models`);
+  } catch (err) {
+    return {
+      ok: false,
+      code: 'NETWORK',
+      message: err instanceof Error ? err.message : String(err),
+      hint: 'Cannot reach base URL',
+    };
+  }
+
+  if (!res.ok) {
+    const { code, hint } = classifyHttpError(res.status);
+    return { ok: false, code, message: `HTTP ${res.status}`, hint };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 
 async function handleModelsList(
   raw: unknown,
@@ -201,6 +270,56 @@ describe('getCacheKey', () => {
     const keyA = getCacheKey('openai', 'https://api.example.com', 'sk-test');
     const keyB = getCacheKey('anthropic', 'https://api.example.com', 'sk-test');
     expect(keyA).not.toBe(keyB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connection:v1:test — bad payload returns IPC_BAD_INPUT
+// ---------------------------------------------------------------------------
+
+describe('connection:v1:test error handling', () => {
+  it('bad payload (missing provider) → ok=false, code=IPC_BAD_INPUT', async () => {
+    const result = await handleConnectionTest(
+      { apiKey: 'sk-test', baseUrl: 'https://api.openai.com' },
+      async () => {
+        throw new Error('should not be called');
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('bad payload (null) → ok=false, code=IPC_BAD_INPUT', async () => {
+    const result = await handleConnectionTest(null, async () => {
+      throw new Error('should not be called');
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('network error (fetch throws) → ok=false, code=NETWORK', async () => {
+    const result = await handleConnectionTest(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com' },
+      async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('NETWORK');
+    }
+  });
+
+  it('HTTP 200 → ok=true', async () => {
+    const result = await handleConnectionTest(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com' },
+      async () => ({ ok: true, status: 200 }),
+    );
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -1,85 +1,33 @@
-import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mock electron-runtime so importing connection-ipc doesn't require('electron').
+vi.mock('./electron-runtime', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+import { createHash } from 'node:crypto';
+import {
+  _clearModelsCache,
+  classifyHttpError,
+  extractIds,
+  extractModelIds,
+  getCacheKey,
+} from './connection-ipc';
+
 // ---------------------------------------------------------------------------
-// Unit tests for pure logic extracted from connection-ipc.ts
-// These tests do NOT import connection-ipc directly because that file imports
-// ./electron-runtime which requires('electron') — unavailable in vitest.
-// Instead we test the pure helpers inline.
+// Thin test-only handler that exercises the same fetch/parse/cache path
+// as the real ipcMain handler but accepts an injected fetch so we can control
+// network responses without hitting the network.
 // ---------------------------------------------------------------------------
 
-// ----- Cache logic (mirrors the implementation in connection-ipc.ts) --------
+import type { ModelsListResponse } from './connection-ipc';
 
-interface CacheEntry {
-  models: string[];
-  expiresAt: number;
-}
-
-const CACHE_TTL_MS = 5 * 60 * 1000;
-let cache: Map<string, CacheEntry>;
-
-function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
-  const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
-  return `${provider}::${baseUrl}::${keyHash}`;
-}
-
-function getCachedModels(provider: string, baseUrl: string, apiKey: string): string[] | null {
-  const key = getCacheKey(provider, baseUrl, apiKey);
-  const entry = cache.get(key);
-  if (entry === undefined) return null;
-  if (Date.now() > entry.expiresAt) {
-    cache.delete(key);
-    return null;
-  }
-  return entry.models;
-}
-
-function setCachedModels(
-  provider: string,
-  baseUrl: string,
-  apiKey: string,
-  models: string[],
-): void {
-  const key = getCacheKey(provider, baseUrl, apiKey);
-  cache.set(key, { models, expiresAt: Date.now() + CACHE_TTL_MS });
-}
-
-// ----- Error classification (mirrors connection-ipc.ts) --------------------
-
-type ErrorCode = '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
-
-function classifyHttpError(status: number): { code: ErrorCode; hint: string } {
-  if (status === 401 || status === 403) {
-    return { code: '401', hint: 'API key 错误或权限不足' };
-  }
-  if (status === 404) {
-    return {
-      code: '404',
-      hint: 'baseUrl 路径错误。OpenAI 兼容代理通常需要 /v1 后缀（试试 https://your-host/v1）',
-    };
-  }
-  return { code: 'NETWORK', hint: `服务器返回 HTTP ${status}` };
-}
-
-// ----- ModelsListResponse error union (mirrors connection-ipc.ts) -----------
-
-type ModelsListResponse =
-  | { ok: true; models: string[] }
-  | {
-      ok: false;
-      code: 'IPC_BAD_INPUT' | 'NETWORK' | 'HTTP' | 'PARSE';
-      message: string;
-      hint: string;
-    };
-
-// Minimal inline handler exercising the same logic as the real ipcMain handler.
 async function handleModelsList(
   raw: unknown,
   fetchImpl: (
     url: string,
   ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>,
 ): Promise<ModelsListResponse> {
-  // Validate payload
   if (typeof raw !== 'object' || raw === null) {
     return {
       ok: false,
@@ -121,9 +69,6 @@ async function handleModelsList(
   const apiKey = (r['apiKey'] as string).trim();
   const baseUrl = (r['baseUrl'] as string).trim();
 
-  const cached = getCachedModels(provider, baseUrl, apiKey);
-  if (cached !== null) return { ok: true, models: cached };
-
   let res: { ok: boolean; status: number; json: () => Promise<unknown> };
   try {
     res = await fetchImpl(`${baseUrl}/models`);
@@ -157,28 +102,6 @@ async function handleModelsList(
     };
   }
 
-  // mirrors extractIds/extractModelIds: any item missing a string id rejects entirely
-  function extractIds(items: unknown[]): string[] | null {
-    const ids: string[] = [];
-    for (const item of items) {
-      if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
-        ids.push((item as { id: string }).id);
-      } else {
-        return null;
-      }
-    }
-    return ids;
-  }
-
-  function extractModelIds(b: unknown): string[] | null {
-    if (b === null || typeof b !== 'object') return null;
-    const data = (b as { data?: unknown }).data;
-    if (Array.isArray(data)) return extractIds(data);
-    const models = (b as { models?: unknown }).models;
-    if (Array.isArray(models)) return extractIds(models);
-    return null;
-  }
-
   const ids = extractModelIds(body);
   if (ids === null) {
     return {
@@ -188,19 +111,96 @@ async function handleModelsList(
       hint: 'Unexpected response shape — check provider /models endpoint compatibility',
     };
   }
-  setCachedModels(provider, baseUrl, apiKey, ids);
   return { ok: true, models: ids };
 }
 
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  cache = new Map();
+  _clearModelsCache();
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// extractIds
+// ---------------------------------------------------------------------------
+
+describe('extractIds', () => {
+  it('returns ids for a valid array', () => {
+    expect(extractIds([{ id: 'a' }, { id: 'b' }])).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(extractIds([])).toEqual([]);
+  });
+
+  it('returns null when any item is missing a string id', () => {
+    expect(extractIds([{ id: 'a' }, { foo: 'bar' }])).toBeNull();
+  });
+
+  it('returns null when an id is a number instead of a string', () => {
+    expect(extractIds([{ id: 'a' }, { id: 123 }])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractModelIds
+// ---------------------------------------------------------------------------
+
+describe('extractModelIds', () => {
+  it('handles OpenAI-compat { data: [...] } shape', () => {
+    expect(extractModelIds({ data: [{ id: 'gpt-4o' }] })).toEqual(['gpt-4o']);
+  });
+
+  it('handles Anthropic { models: [...] } shape', () => {
+    expect(extractModelIds({ models: [{ id: 'claude-3-5-sonnet' }] })).toEqual([
+      'claude-3-5-sonnet',
+    ]);
+  });
+
+  it('returns null for unknown shape', () => {
+    expect(extractModelIds({ unexpected: 'thing' })).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(extractModelIds(null)).toBeNull();
+    expect(extractModelIds('string')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCacheKey
+// ---------------------------------------------------------------------------
+
+describe('getCacheKey', () => {
+  it('includes provider and baseUrl in the key', () => {
+    const key = getCacheKey('openai', 'https://api.openai.com/v1', 'sk-test');
+    expect(key).toContain('openai');
+    expect(key).toContain('https://api.openai.com/v1');
+  });
+
+  it('uses a hash of the apiKey, not the raw value', () => {
+    const key = getCacheKey('openai', 'https://api.openai.com/v1', 'sk-secret');
+    expect(key).not.toContain('sk-secret');
+    const expectedHash = createHash('sha256').update('sk-secret').digest('hex').slice(0, 16);
+    expect(key).toContain(expectedHash);
+  });
+
+  it('produces different keys for different apiKeys', () => {
+    const keyA = getCacheKey('openai', 'https://api.openai.com/v1', 'sk-key-A');
+    const keyB = getCacheKey('openai', 'https://api.openai.com/v1', 'sk-key-B');
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('produces different keys for different providers', () => {
+    const keyA = getCacheKey('openai', 'https://api.example.com', 'sk-test');
+    const keyB = getCacheKey('anthropic', 'https://api.example.com', 'sk-test');
+    expect(keyA).not.toBe(keyB);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -227,56 +227,6 @@ describe('classifyHttpError', () => {
   it('returns NETWORK code for unexpected status', () => {
     const { code } = classifyHttpError(500);
     expect(code).toBe('NETWORK');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// models:v1:list — 5-minute cache TTL
-// ---------------------------------------------------------------------------
-
-describe('models cache (5-min TTL)', () => {
-  it('returns cached models within TTL', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o', 'gpt-4o-mini']);
-    const result = getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test');
-    expect(result).toEqual(['gpt-4o', 'gpt-4o-mini']);
-  });
-
-  it('returns null after TTL expires', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o']);
-
-    // Advance past the 5-minute TTL
-    vi.advanceTimersByTime(CACHE_TTL_MS + 1);
-
-    const result = getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test');
-    expect(result).toBeNull();
-  });
-
-  it('different provider+baseUrl combinations are cached independently', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o']);
-    setCachedModels('openai', 'https://relay.example.com/v1', 'sk-test', ['custom-model']);
-
-    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test')).toEqual(['gpt-4o']);
-    expect(getCachedModels('openai', 'https://relay.example.com/v1', 'sk-test')).toEqual([
-      'custom-model',
-    ]);
-  });
-
-  it('returns null for keys not yet in cache', () => {
-    expect(getCachedModels('anthropic', 'https://api.anthropic.com', 'sk-ant-test')).toBeNull();
-  });
-
-  it('different apiKeys produce different cache entries — no cross-key leakage', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A', ['model-for-A']);
-    // key-B should NOT see key-A's cached models
-    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B')).toBeNull();
-  });
-
-  it('same provider+baseUrl but different apiKey are stored under distinct cache entries', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A', ['model-A']);
-    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B', ['model-B']);
-
-    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A')).toEqual(['model-A']);
-    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B')).toEqual(['model-B']);
   });
 });
 

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -149,14 +149,43 @@ async function handleModelsList(
     };
   }
 
-  const data = (body as { data?: unknown }).data;
-  const models = Array.isArray(data)
-    ? data
-        .filter((i) => typeof i === 'object' && i !== null && 'id' in i)
-        .map((i) => String((i as { id: unknown }).id))
-    : [];
-  setCachedModels(provider, baseUrl, models);
-  return { ok: true, models };
+  // mirrors extractModelIds: returns null when shape is unrecognised
+  function extractModelIds(b: unknown): string[] | null {
+    if (b === null || typeof b !== 'object') return null;
+    const data = (b as { data?: unknown }).data;
+    if (Array.isArray(data)) {
+      return data
+        .map((i) =>
+          i && typeof i === 'object' && typeof (i as { id?: unknown }).id === 'string'
+            ? (i as { id: string }).id
+            : null,
+        )
+        .filter((id): id is string => id !== null);
+    }
+    const models = (b as { models?: unknown }).models;
+    if (Array.isArray(models)) {
+      return models
+        .map((i) =>
+          i && typeof i === 'object' && typeof (i as { id?: unknown }).id === 'string'
+            ? (i as { id: string }).id
+            : null,
+        )
+        .filter((id): id is string => id !== null);
+    }
+    return null;
+  }
+
+  const ids = extractModelIds(body);
+  if (ids === null) {
+    return {
+      ok: false,
+      code: 'PARSE',
+      message: 'Provider returned unexpected models response shape',
+      hint: 'Unexpected response shape — check provider /models endpoint compatibility',
+    };
+  }
+  setCachedModels(provider, baseUrl, ids);
+  return { ok: true, models: ids };
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +316,52 @@ describe('models:v1:list error union', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.models).toEqual(['gpt-4o', 'gpt-4o-mini']);
+    }
+  });
+
+  it('unexpected response shape { "unexpected": "thing" } → ok=false, code=PARSE, hint mentions "shape"', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ unexpected: 'thing' }),
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('PARSE');
+      expect(result.hint.toLowerCase()).toContain('shape');
+    }
+  });
+
+  it('mixed data array (one valid, one without id) → ok=true, only valid id returned', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [{ id: 'gpt-4o' }, { foo: 'bar' }] }),
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.models).toEqual(['gpt-4o']);
+    }
+  });
+
+  it('empty data array { "data": [] } → ok=true, models=[]', async () => {
+    const result = await handleModelsList(
+      { provider: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.openai.com/v1' },
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.models).toEqual([]);
     }
   });
 });

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -12,6 +12,7 @@ import {
   extractIds,
   extractModelIds,
   getCacheKey,
+  normalizeBaseUrl,
 } from './connection-ipc';
 
 // ---------------------------------------------------------------------------
@@ -348,5 +349,77 @@ describe('models:v1:list error union', () => {
     if (result.ok) {
       expect(result.models).toEqual([]);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBaseUrl
+// ---------------------------------------------------------------------------
+
+describe('normalizeBaseUrl', () => {
+  // anthropic — strip /v1 suffix so we can append /v1/models ourselves
+  it('anthropic: strips trailing /v1', () => {
+    expect(normalizeBaseUrl('https://api.anthropic.com/v1', 'anthropic')).toBe(
+      'https://api.anthropic.com',
+    );
+  });
+
+  it('anthropic: leaves root unchanged', () => {
+    expect(normalizeBaseUrl('https://api.anthropic.com', 'anthropic')).toBe(
+      'https://api.anthropic.com',
+    );
+  });
+
+  it('anthropic: strips trailing slashes before /v1 check', () => {
+    expect(normalizeBaseUrl('https://api.anthropic.com/v1/', 'anthropic')).toBe(
+      'https://api.anthropic.com',
+    );
+  });
+
+  // openai — ensure /v1 suffix
+  it('openai: adds /v1 when missing', () => {
+    expect(normalizeBaseUrl('https://api.openai.com', 'openai')).toBe('https://api.openai.com/v1');
+  });
+
+  it('openai: keeps existing /v1 suffix', () => {
+    expect(normalizeBaseUrl('https://api.openai.com/v1', 'openai')).toBe(
+      'https://api.openai.com/v1',
+    );
+  });
+
+  it('openai: strips trailing slash then adds /v1', () => {
+    expect(normalizeBaseUrl('https://your-host/', 'openai')).toBe('https://your-host/v1');
+  });
+
+  // openrouter (same rule as openai)
+  it('openrouter: adds /v1 when missing', () => {
+    expect(normalizeBaseUrl('https://openrouter.ai/api', 'openrouter')).toBe(
+      'https://openrouter.ai/api/v1',
+    );
+  });
+
+  it('openrouter: keeps existing /v1 suffix', () => {
+    expect(normalizeBaseUrl('https://openrouter.ai/api/v1', 'openrouter')).toBe(
+      'https://openrouter.ai/api/v1',
+    );
+  });
+
+  // google — strip /v1 or /v1beta
+  it('google: strips /v1beta', () => {
+    expect(normalizeBaseUrl('https://generativelanguage.googleapis.com/v1beta', 'google')).toBe(
+      'https://generativelanguage.googleapis.com',
+    );
+  });
+
+  it('google: strips /v1', () => {
+    expect(normalizeBaseUrl('https://generativelanguage.googleapis.com/v1', 'google')).toBe(
+      'https://generativelanguage.googleapis.com',
+    );
+  });
+
+  it('google: leaves root unchanged', () => {
+    expect(normalizeBaseUrl('https://generativelanguage.googleapis.com', 'google')).toBe(
+      'https://generativelanguage.googleapis.com',
+    );
   });
 });

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
@@ -17,12 +18,13 @@ interface CacheEntry {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: Map<string, CacheEntry>;
 
-function getCacheKey(provider: string, baseUrl: string): string {
-  return `${provider}::${baseUrl}`;
+function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
+  const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
+  return `${provider}::${baseUrl}::${keyHash}`;
 }
 
-function getCachedModels(provider: string, baseUrl: string): string[] | null {
-  const key = getCacheKey(provider, baseUrl);
+function getCachedModels(provider: string, baseUrl: string, apiKey: string): string[] | null {
+  const key = getCacheKey(provider, baseUrl, apiKey);
   const entry = cache.get(key);
   if (entry === undefined) return null;
   if (Date.now() > entry.expiresAt) {
@@ -32,8 +34,13 @@ function getCachedModels(provider: string, baseUrl: string): string[] | null {
   return entry.models;
 }
 
-function setCachedModels(provider: string, baseUrl: string, models: string[]): void {
-  const key = getCacheKey(provider, baseUrl);
+function setCachedModels(
+  provider: string,
+  baseUrl: string,
+  apiKey: string,
+  models: string[],
+): void {
+  const key = getCacheKey(provider, baseUrl, apiKey);
   cache.set(key, { models, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 
@@ -111,9 +118,10 @@ async function handleModelsList(
   }
 
   const provider = r['provider'] as string;
+  const apiKey = (r['apiKey'] as string).trim();
   const baseUrl = (r['baseUrl'] as string).trim();
 
-  const cached = getCachedModels(provider, baseUrl);
+  const cached = getCachedModels(provider, baseUrl, apiKey);
   if (cached !== null) return { ok: true, models: cached };
 
   let res: { ok: boolean; status: number; json: () => Promise<unknown> };
@@ -180,7 +188,7 @@ async function handleModelsList(
       hint: 'Unexpected response shape — check provider /models endpoint compatibility',
     };
   }
-  setCachedModels(provider, baseUrl, ids);
+  setCachedModels(provider, baseUrl, apiKey, ids);
   return { ok: true, models: ids };
 }
 
@@ -228,31 +236,47 @@ describe('classifyHttpError', () => {
 
 describe('models cache (5-min TTL)', () => {
   it('returns cached models within TTL', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o', 'gpt-4o-mini']);
-    const result = getCachedModels('openai', 'https://api.openai.com/v1');
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o', 'gpt-4o-mini']);
+    const result = getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test');
     expect(result).toEqual(['gpt-4o', 'gpt-4o-mini']);
   });
 
   it('returns null after TTL expires', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o']);
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o']);
 
     // Advance past the 5-minute TTL
     vi.advanceTimersByTime(CACHE_TTL_MS + 1);
 
-    const result = getCachedModels('openai', 'https://api.openai.com/v1');
+    const result = getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test');
     expect(result).toBeNull();
   });
 
   it('different provider+baseUrl combinations are cached independently', () => {
-    setCachedModels('openai', 'https://api.openai.com/v1', ['gpt-4o']);
-    setCachedModels('openai', 'https://relay.example.com/v1', ['custom-model']);
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-test', ['gpt-4o']);
+    setCachedModels('openai', 'https://relay.example.com/v1', 'sk-test', ['custom-model']);
 
-    expect(getCachedModels('openai', 'https://api.openai.com/v1')).toEqual(['gpt-4o']);
-    expect(getCachedModels('openai', 'https://relay.example.com/v1')).toEqual(['custom-model']);
+    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-test')).toEqual(['gpt-4o']);
+    expect(getCachedModels('openai', 'https://relay.example.com/v1', 'sk-test')).toEqual([
+      'custom-model',
+    ]);
   });
 
   it('returns null for keys not yet in cache', () => {
-    expect(getCachedModels('anthropic', 'https://api.anthropic.com')).toBeNull();
+    expect(getCachedModels('anthropic', 'https://api.anthropic.com', 'sk-ant-test')).toBeNull();
+  });
+
+  it('different apiKeys produce different cache entries — no cross-key leakage', () => {
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A', ['model-for-A']);
+    // key-B should NOT see key-A's cached models
+    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B')).toBeNull();
+  });
+
+  it('same provider+baseUrl but different apiKey are stored under distinct cache entries', () => {
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A', ['model-A']);
+    setCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B', ['model-B']);
+
+    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-A')).toEqual(['model-A']);
+    expect(getCachedModels('openai', 'https://api.openai.com/v1', 'sk-key-B')).toEqual(['model-B']);
   });
 });
 

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -93,25 +93,44 @@ interface ProviderEndpoint {
   headers: Record<string, string>;
 }
 
+/**
+ * Normalize a user-supplied baseUrl to the root form each provider expects,
+ * so downstream path concatenation never produces duplicate segments.
+ *
+ * - anthropic: strip trailing /v1 — we append /v1/models internally
+ * - openai / openrouter: ensure /v1 suffix — the API lives at <root>/v1/models
+ * - google: strip trailing /v1 or /v1beta — we append the full path internally
+ */
+export function normalizeBaseUrl(
+  baseUrl: string,
+  provider: 'openai' | 'anthropic' | 'google' | 'openrouter',
+): string {
+  const cleaned = baseUrl.replace(/\/+$/, ''); // strip trailing slashes
+  if (provider === 'openai' || provider === 'openrouter') {
+    return cleaned.endsWith('/v1') ? cleaned : `${cleaned}/v1`;
+  }
+  if (provider === 'anthropic') {
+    return cleaned.replace(/\/v1$/, '');
+  }
+  if (provider === 'google') {
+    return cleaned.replace(/\/v1(beta)?$/, '');
+  }
+  return cleaned;
+}
+
 function buildModelsEndpoint(
   provider: SupportedOnboardingProvider,
   baseUrl: string,
 ): ProviderEndpoint {
+  const root = normalizeBaseUrl(baseUrl, provider);
   switch (provider) {
     case 'anthropic':
-      // Anthropic baseUrl is typically https://api.anthropic.com (no /v1 suffix)
-      // We append /v1/models if baseUrl doesn't already end with /models
-      return {
-        url: baseUrl.endsWith('/v1/models') ? baseUrl : `${baseUrl}/v1/models`,
-        headers: {},
-      };
+      // Anthropic root has no /v1; we append the full versioned path.
+      return { url: `${root}/v1/models`, headers: {} };
     case 'openai':
     case 'openrouter':
-      // OpenAI-compatible: baseUrl should end with /v1
-      return {
-        url: baseUrl.endsWith('/models') ? baseUrl : `${baseUrl}/models`,
-        headers: {},
-      };
+      // OpenAI-compatible: root already ends with /v1 after normalization.
+      return { url: `${root}/models`, headers: {} };
   }
 }
 

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -28,10 +28,12 @@ export interface ConnectionTestResult {
 
 export interface ConnectionTestError {
   ok: false;
-  code: '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
+  code: 'IPC_BAD_INPUT' | '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
   message: string;
   hint: string;
 }
+
+export type ConnectionTestResponse = ConnectionTestResult | ConnectionTestError;
 
 export type ModelsListResponse =
   | { ok: true; models: string[] }
@@ -264,16 +266,16 @@ export function _getModelsCache(): Map<string, CacheEntry> {
 export function registerConnectionIpc(): void {
   ipcMain.handle(
     'connection:v1:test',
-    async (_e, raw: unknown): Promise<ConnectionTestResult | ConnectionTestError> => {
+    async (_e, raw: unknown): Promise<ConnectionTestResponse> => {
       let payload: ConnectionTestPayloadV1;
       try {
         payload = parseConnectionTestPayload(raw);
       } catch (err) {
         return {
           ok: false,
-          code: 'NETWORK',
-          message: err instanceof Error ? err.message : 'Invalid payload',
-          hint: '请检查输入参数',
+          code: 'IPC_BAD_INPUT',
+          message: err instanceof Error ? err.message : String(err),
+          hint: 'Invalid connection test payload',
         };
       }
 

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -163,21 +163,36 @@ function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']
   };
 }
 
-function extractModelIds(body: unknown): string[] {
-  if (body === null || typeof body !== 'object') return [];
+function extractModelIds(body: unknown): string[] | null {
+  if (body === null || typeof body !== 'object') return null;
+
+  // OpenAI / OpenAI-compat: { data: [{ id: string }, ...] }
   const data = (body as { data?: unknown }).data;
   if (Array.isArray(data)) {
-    return data
-      .filter((item) => typeof item === 'object' && item !== null && 'id' in item)
-      .map((item) => String((item as { id: unknown }).id));
+    const ids = data
+      .map((item) =>
+        item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string'
+          ? (item as { id: string }).id
+          : null,
+      )
+      .filter((id): id is string => id !== null);
+    return ids;
   }
+
+  // Anthropic: { models: [{ id: string }, ...] }
   const models = (body as { models?: unknown }).models;
   if (Array.isArray(models)) {
-    return models
-      .filter((item) => typeof item === 'object' && item !== null && 'id' in item)
-      .map((item) => String((item as { id: unknown }).id));
+    const ids = models
+      .map((item) =>
+        item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string'
+          ? (item as { id: string }).id
+          : null,
+      )
+      .filter((id): id is string => id !== null);
+    return ids;
   }
-  return [];
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -332,8 +347,16 @@ export function registerConnectionIpc(): void {
       };
     }
 
-    const models = extractModelIds(body);
-    setCachedModels(provider, baseUrl, models);
-    return { ok: true, models };
+    const ids = extractModelIds(body);
+    if (ids === null) {
+      return {
+        ok: false,
+        code: 'PARSE',
+        message: 'Provider returned unexpected models response shape',
+        hint: 'Unexpected response shape — check provider /models endpoint compatibility',
+      };
+    }
+    setCachedModels(provider, baseUrl, ids);
+    return { ok: true, models: ids };
   });
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -163,34 +163,29 @@ function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']
   };
 }
 
+function extractIds(items: unknown[]): string[] | null {
+  const ids: string[] = [];
+  for (const item of items) {
+    if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
+      ids.push((item as { id: string }).id);
+    } else {
+      // Any item missing a string id field means the shape is unexpected — reject entirely.
+      return null;
+    }
+  }
+  return ids;
+}
+
 function extractModelIds(body: unknown): string[] | null {
   if (body === null || typeof body !== 'object') return null;
 
   // OpenAI / OpenAI-compat: { data: [{ id: string }, ...] }
   const data = (body as { data?: unknown }).data;
-  if (Array.isArray(data)) {
-    const ids = data
-      .map((item) =>
-        item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string'
-          ? (item as { id: string }).id
-          : null,
-      )
-      .filter((id): id is string => id !== null);
-    return ids;
-  }
+  if (Array.isArray(data)) return extractIds(data);
 
   // Anthropic: { models: [{ id: string }, ...] }
   const models = (body as { models?: unknown }).models;
-  if (Array.isArray(models)) {
-    const ids = models
-      .map((item) =>
-        item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string'
-          ? (item as { id: string }).id
-          : null,
-      )
-      .filter((id): id is string => id !== null);
-    return ids;
-  }
+  if (Array.isArray(models)) return extractIds(models);
 
   return null;
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -1,0 +1,312 @@
+import {
+  CodesignError,
+  type SupportedOnboardingProvider,
+  isSupportedOnboardingProvider,
+} from '@open-codesign/shared';
+import { ipcMain } from './electron-runtime';
+
+// ---------------------------------------------------------------------------
+// Payload schemas (plain validation, no zod in main to keep bundle lean)
+// ---------------------------------------------------------------------------
+
+interface ConnectionTestPayloadV1 {
+  provider: SupportedOnboardingProvider;
+  apiKey: string;
+  baseUrl: string;
+}
+
+interface ModelsListPayloadV1 {
+  provider: SupportedOnboardingProvider;
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface ConnectionTestResult {
+  ok: true;
+}
+
+export interface ConnectionTestError {
+  ok: false;
+  code: '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
+  message: string;
+  hint: string;
+}
+
+export interface ModelsListResult {
+  models: string[];
+}
+
+function parseConnectionTestPayload(raw: unknown): ConnectionTestPayloadV1 {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new CodesignError('connection:v1:test expects an object payload', 'IPC_BAD_INPUT');
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r['provider'] !== 'string' || !isSupportedOnboardingProvider(r['provider'])) {
+    throw new CodesignError(`Unsupported provider: ${String(r['provider'])}`, 'IPC_BAD_INPUT');
+  }
+  if (typeof r['apiKey'] !== 'string' || r['apiKey'].trim().length === 0) {
+    throw new CodesignError('apiKey must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  if (typeof r['baseUrl'] !== 'string' || r['baseUrl'].trim().length === 0) {
+    throw new CodesignError('baseUrl must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  return {
+    provider: r['provider'],
+    apiKey: r['apiKey'].trim(),
+    baseUrl: r['baseUrl'].trim(),
+  };
+}
+
+function parseModelsListPayload(raw: unknown): ModelsListPayloadV1 {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new CodesignError('models:v1:list expects an object payload', 'IPC_BAD_INPUT');
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r['provider'] !== 'string' || !isSupportedOnboardingProvider(r['provider'])) {
+    throw new CodesignError(`Unsupported provider: ${String(r['provider'])}`, 'IPC_BAD_INPUT');
+  }
+  if (typeof r['apiKey'] !== 'string' || r['apiKey'].trim().length === 0) {
+    throw new CodesignError('apiKey must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  if (typeof r['baseUrl'] !== 'string' || r['baseUrl'].trim().length === 0) {
+    throw new CodesignError('baseUrl must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  return {
+    provider: r['provider'],
+    apiKey: r['apiKey'].trim(),
+    baseUrl: r['baseUrl'].trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Models endpoint construction
+// ---------------------------------------------------------------------------
+
+interface ProviderEndpoint {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function buildModelsEndpoint(
+  provider: SupportedOnboardingProvider,
+  baseUrl: string,
+): ProviderEndpoint {
+  switch (provider) {
+    case 'anthropic':
+      // Anthropic baseUrl is typically https://api.anthropic.com (no /v1 suffix)
+      // We append /v1/models if baseUrl doesn't already end with /models
+      return {
+        url: baseUrl.endsWith('/v1/models') ? baseUrl : `${baseUrl}/v1/models`,
+        headers: {},
+      };
+    case 'openai':
+    case 'openrouter':
+      // OpenAI-compatible: baseUrl should end with /v1
+      return {
+        url: baseUrl.endsWith('/models') ? baseUrl : `${baseUrl}/models`,
+        headers: {},
+      };
+  }
+}
+
+function buildAuthHeaders(
+  provider: SupportedOnboardingProvider,
+  apiKey: string,
+): Record<string, string> {
+  if (provider === 'anthropic') {
+    return {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    };
+  }
+  return { authorization: `Bearer ${apiKey}` };
+}
+
+function classifyHttpError(status: number): {
+  code: ConnectionTestError['code'];
+  hint: string;
+} {
+  if (status === 401 || status === 403) {
+    return { code: '401', hint: 'API key 错误或权限不足' };
+  }
+  if (status === 404) {
+    return {
+      code: '404',
+      hint: 'baseUrl 路径错误。OpenAI 兼容代理通常需要 /v1 后缀（试试 https://your-host/v1）',
+    };
+  }
+  return { code: 'NETWORK', hint: `服务器返回 HTTP ${status}` };
+}
+
+function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']; hint: string } {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes('ECONNREFUSED') || message.includes('ENOTFOUND')) {
+    return {
+      code: 'ECONNREFUSED',
+      hint: '无法连接到 baseUrl，检查域名 / 端口 / 网络',
+    };
+  }
+  if (message.includes('CORS') || message.includes('cross-origin')) {
+    return {
+      code: 'NETWORK',
+      hint: '跨域错误（理论上 main 端 fetch 不该有，看日志）',
+    };
+  }
+  return {
+    code: 'NETWORK',
+    hint: `网络错误：${message}。查看日志：~/Library/Logs/open-codesign/main.log`,
+  };
+}
+
+function extractModelIds(body: unknown): string[] {
+  if (body === null || typeof body !== 'object') return [];
+  const data = (body as { data?: unknown }).data;
+  if (Array.isArray(data)) {
+    return data
+      .filter((item) => typeof item === 'object' && item !== null && 'id' in item)
+      .map((item) => String((item as { id: unknown }).id));
+  }
+  const models = (body as { models?: unknown }).models;
+  if (Array.isArray(models)) {
+    return models
+      .filter((item) => typeof item === 'object' && item !== null && 'id' in item)
+      .map((item) => String((item as { id: unknown }).id));
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Models cache (5-minute TTL keyed by provider+baseUrl)
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  models: string[];
+  expiresAt: number;
+}
+
+const modelsCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function getCacheKey(provider: string, baseUrl: string): string {
+  return `${provider}::${baseUrl}`;
+}
+
+function getCachedModels(provider: string, baseUrl: string): string[] | null {
+  const key = getCacheKey(provider, baseUrl);
+  const entry = modelsCache.get(key);
+  if (entry === undefined) return null;
+  if (Date.now() > entry.expiresAt) {
+    modelsCache.delete(key);
+    return null;
+  }
+  return entry.models;
+}
+
+function setCachedModels(provider: string, baseUrl: string, models: string[]): void {
+  const key = getCacheKey(provider, baseUrl);
+  modelsCache.set(key, { models, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// Exposed for testing only.
+export function _clearModelsCache(): void {
+  modelsCache.clear();
+}
+
+export function _getModelsCache(): Map<string, CacheEntry> {
+  return modelsCache;
+}
+
+// ---------------------------------------------------------------------------
+// IPC registration
+// ---------------------------------------------------------------------------
+
+export function registerConnectionIpc(): void {
+  ipcMain.handle(
+    'connection:v1:test',
+    async (_e, raw: unknown): Promise<ConnectionTestResult | ConnectionTestError> => {
+      let payload: ConnectionTestPayloadV1;
+      try {
+        payload = parseConnectionTestPayload(raw);
+      } catch (err) {
+        return {
+          ok: false,
+          code: 'NETWORK',
+          message: err instanceof Error ? err.message : 'Invalid payload',
+          hint: '请检查输入参数',
+        };
+      }
+
+      const { provider, apiKey, baseUrl } = payload;
+      const ep = buildModelsEndpoint(provider, baseUrl);
+      const authHeaders = buildAuthHeaders(provider, apiKey);
+
+      let res: Response;
+      try {
+        res = await fetch(ep.url, {
+          method: 'GET',
+          headers: { ...ep.headers, ...authHeaders },
+        });
+      } catch (err) {
+        const { code, hint } = classifyNetworkError(err);
+        return {
+          ok: false,
+          code,
+          message: err instanceof Error ? err.message : 'Network request failed',
+          hint,
+        };
+      }
+
+      if (!res.ok) {
+        const { code, hint } = classifyHttpError(res.status);
+        return {
+          ok: false,
+          code,
+          message: `HTTP ${res.status}`,
+          hint,
+        };
+      }
+
+      return { ok: true };
+    },
+  );
+
+  ipcMain.handle('models:v1:list', async (_e, raw: unknown): Promise<ModelsListResult> => {
+    let payload: ModelsListPayloadV1;
+    try {
+      payload = parseModelsListPayload(raw);
+    } catch {
+      return { models: [] };
+    }
+
+    const { provider, apiKey, baseUrl } = payload;
+
+    const cached = getCachedModels(provider, baseUrl);
+    if (cached !== null) return { models: cached };
+
+    const ep = buildModelsEndpoint(provider, baseUrl);
+    const authHeaders = buildAuthHeaders(provider, apiKey);
+
+    let res: Response;
+    try {
+      res = await fetch(ep.url, {
+        method: 'GET',
+        headers: { ...ep.headers, ...authHeaders },
+      });
+    } catch {
+      return { models: [] };
+    }
+
+    if (!res.ok) return { models: [] };
+
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return { models: [] };
+    }
+
+    const models = extractModelIds(body);
+    setCachedModels(provider, baseUrl, models);
+    return { models };
+  });
+}

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   CodesignError,
   type SupportedOnboardingProvider,
@@ -202,12 +203,13 @@ interface CacheEntry {
 const modelsCache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-function getCacheKey(provider: string, baseUrl: string): string {
-  return `${provider}::${baseUrl}`;
+function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
+  const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
+  return `${provider}::${baseUrl}::${keyHash}`;
 }
 
-function getCachedModels(provider: string, baseUrl: string): string[] | null {
-  const key = getCacheKey(provider, baseUrl);
+function getCachedModels(provider: string, baseUrl: string, apiKey: string): string[] | null {
+  const key = getCacheKey(provider, baseUrl, apiKey);
   const entry = modelsCache.get(key);
   if (entry === undefined) return null;
   if (Date.now() > entry.expiresAt) {
@@ -217,8 +219,13 @@ function getCachedModels(provider: string, baseUrl: string): string[] | null {
   return entry.models;
 }
 
-function setCachedModels(provider: string, baseUrl: string, models: string[]): void {
-  const key = getCacheKey(provider, baseUrl);
+function setCachedModels(
+  provider: string,
+  baseUrl: string,
+  apiKey: string,
+  models: string[],
+): void {
+  const key = getCacheKey(provider, baseUrl, apiKey);
   modelsCache.set(key, { models, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 
@@ -300,7 +307,7 @@ export function registerConnectionIpc(): void {
 
     const { provider, apiKey, baseUrl } = payload;
 
-    const cached = getCachedModels(provider, baseUrl);
+    const cached = getCachedModels(provider, baseUrl, apiKey);
     if (cached !== null) return { ok: true, models: cached };
 
     const ep = buildModelsEndpoint(provider, baseUrl);
@@ -351,7 +358,7 @@ export function registerConnectionIpc(): void {
         hint: 'Unexpected response shape — check provider /models endpoint compatibility',
       };
     }
-    setCachedModels(provider, baseUrl, ids);
+    setCachedModels(provider, baseUrl, apiKey, ids);
     return { ok: true, models: ids };
   });
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -32,9 +32,14 @@ export interface ConnectionTestError {
   hint: string;
 }
 
-export interface ModelsListResult {
-  models: string[];
-}
+export type ModelsListResponse =
+  | { ok: true; models: string[] }
+  | {
+      ok: false;
+      code: 'IPC_BAD_INPUT' | 'NETWORK' | 'HTTP' | 'PARSE';
+      message: string;
+      hint: string;
+    };
 
 function parseConnectionTestPayload(raw: unknown): ConnectionTestPayloadV1 {
   if (typeof raw !== 'object' || raw === null) {
@@ -270,18 +275,23 @@ export function registerConnectionIpc(): void {
     },
   );
 
-  ipcMain.handle('models:v1:list', async (_e, raw: unknown): Promise<ModelsListResult> => {
+  ipcMain.handle('models:v1:list', async (_e, raw: unknown): Promise<ModelsListResponse> => {
     let payload: ModelsListPayloadV1;
     try {
       payload = parseModelsListPayload(raw);
-    } catch {
-      return { models: [] };
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'IPC_BAD_INPUT',
+        message: err instanceof Error ? err.message : String(err),
+        hint: 'Invalid models:v1:list payload',
+      };
     }
 
     const { provider, apiKey, baseUrl } = payload;
 
     const cached = getCachedModels(provider, baseUrl);
-    if (cached !== null) return { models: cached };
+    if (cached !== null) return { ok: true, models: cached };
 
     const ep = buildModelsEndpoint(provider, baseUrl);
     const authHeaders = buildAuthHeaders(provider, apiKey);
@@ -292,21 +302,38 @@ export function registerConnectionIpc(): void {
         method: 'GET',
         headers: { ...ep.headers, ...authHeaders },
       });
-    } catch {
-      return { models: [] };
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'NETWORK',
+        message: err instanceof Error ? err.message : String(err),
+        hint: 'Cannot reach provider /models endpoint',
+      };
     }
 
-    if (!res.ok) return { models: [] };
+    if (!res.ok) {
+      return {
+        ok: false,
+        code: 'HTTP',
+        message: `HTTP ${res.status}`,
+        hint: 'Model list request failed',
+      };
+    }
 
     let body: unknown;
     try {
       body = await res.json();
     } catch {
-      return { models: [] };
+      return {
+        ok: false,
+        code: 'PARSE',
+        message: 'Invalid JSON in response',
+        hint: 'Provider returned non-JSON',
+      };
     }
 
     const models = extractModelIds(body);
     setCachedModels(provider, baseUrl, models);
-    return { models };
+    return { ok: true, models };
   });
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -128,7 +128,7 @@ function buildAuthHeaders(
   return { authorization: `Bearer ${apiKey}` };
 }
 
-function classifyHttpError(status: number): {
+export function classifyHttpError(status: number): {
   code: ConnectionTestError['code'];
   hint: string;
 } {
@@ -164,7 +164,7 @@ function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']
   };
 }
 
-function extractIds(items: unknown[]): string[] | null {
+export function extractIds(items: unknown[]): string[] | null {
   const ids: string[] = [];
   for (const item of items) {
     if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
@@ -177,7 +177,7 @@ function extractIds(items: unknown[]): string[] | null {
   return ids;
 }
 
-function extractModelIds(body: unknown): string[] | null {
+export function extractModelIds(body: unknown): string[] | null {
   if (body === null || typeof body !== 'object') return null;
 
   // OpenAI / OpenAI-compat: { data: [{ id: string }, ...] }
@@ -203,7 +203,7 @@ interface CacheEntry {
 const modelsCache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
+export function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
   const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
   return `${provider}::${baseUrl}::${keyHash}`;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
 } from '@open-codesign/shared';
 import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { registerConnectionIpc } from './connection-ipc';
 import { scanDesignSystem } from './design-system';
 import { BrowserWindow, app, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
@@ -350,6 +351,7 @@ void app.whenReady().then(async () => {
   await loadConfigOnBoot();
   registerIpcHandlers();
   registerLocaleIpc();
+  registerConnectionIpc();
   registerOnboardingIpc();
   registerPreferencesIpc();
   registerExporterIpc(() => mainWindow);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -9,6 +9,13 @@ import type {
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { contextBridge, ipcRenderer } from 'electron';
+import type {
+  ConnectionTestError,
+  ConnectionTestResult,
+  ModelsListResponse,
+} from '../main/connection-ipc';
+
+export type { ConnectionTestError, ConnectionTestResult, ModelsListResponse };
 
 export interface ValidateKeyResult {
   ok: true;
@@ -19,25 +26,6 @@ export interface ValidateKeyError {
   code: '401' | '402' | '429' | 'network';
   message: string;
 }
-
-export interface ConnectionTestResult {
-  ok: true;
-}
-export interface ConnectionTestError {
-  ok: false;
-  code: '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
-  message: string;
-  hint: string;
-}
-
-export type ModelsListResponse =
-  | { ok: true; models: string[] }
-  | {
-      ok: false;
-      code: 'IPC_BAD_INPUT' | 'NETWORK' | 'HTTP' | 'PARSE';
-      message: string;
-      hint: string;
-    };
 
 export type ExportFormat = 'html' | 'pdf' | 'pptx' | 'zip';
 export interface ExportInvokeResponse {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -20,6 +20,16 @@ export interface ValidateKeyError {
   message: string;
 }
 
+export interface ConnectionTestResult {
+  ok: true;
+}
+export interface ConnectionTestError {
+  ok: false;
+  code: '401' | '404' | 'ECONNREFUSED' | 'NETWORK' | 'PARSE';
+  message: string;
+  hint: string;
+}
+
 export type ExportFormat = 'html' | 'pdf' | 'pptx' | 'zip';
 export interface ExportInvokeResponse {
   status: 'saved' | 'cancelled';
@@ -153,6 +163,23 @@ const api = {
     get: () => ipcRenderer.invoke('preferences:v1:get') as Promise<Preferences>,
     update: (patch: Partial<Preferences>) =>
       ipcRenderer.invoke('preferences:v1:update', patch) as Promise<Preferences>,
+  },
+  connection: {
+    test: (input: {
+      provider: SupportedOnboardingProvider;
+      apiKey: string;
+      baseUrl: string;
+    }) =>
+      ipcRenderer.invoke('connection:v1:test', input) as Promise<
+        ConnectionTestResult | ConnectionTestError
+      >,
+  },
+  models: {
+    list: (input: {
+      provider: SupportedOnboardingProvider;
+      apiKey: string;
+      baseUrl: string;
+    }) => ipcRenderer.invoke('models:v1:list', input) as Promise<{ models: string[] }>,
   },
 };
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -30,6 +30,15 @@ export interface ConnectionTestError {
   hint: string;
 }
 
+export type ModelsListResponse =
+  | { ok: true; models: string[] }
+  | {
+      ok: false;
+      code: 'IPC_BAD_INPUT' | 'NETWORK' | 'HTTP' | 'PARSE';
+      message: string;
+      hint: string;
+    };
+
 export type ExportFormat = 'html' | 'pdf' | 'pptx' | 'zip';
 export interface ExportInvokeResponse {
   status: 'saved' | 'cancelled';
@@ -179,7 +188,7 @@ const api = {
       provider: SupportedOnboardingProvider;
       apiKey: string;
       baseUrl: string;
-    }) => ipcRenderer.invoke('models:v1:list', input) as Promise<{ models: string[] }>,
+    }) => ipcRenderer.invoke('models:v1:list', input) as Promise<ModelsListResponse>,
   },
 };
 

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Unit tests for PasteKey connection guard logic
+//
+// PasteKey cannot be imported directly because it depends on React and
+// Electron-specific globals. Instead we inline the guard logic and test it
+// in isolation, mirroring the pattern used in connection-ipc.test.ts.
+// ---------------------------------------------------------------------------
+
+type ConnectionState =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'ok' }
+  | { kind: 'error'; code: string; hint: string };
+
+// Mirrors handleConnectionTest from PasteKey.tsx
+async function handleConnectionTest(
+  provider: string | null,
+  trimmed: string,
+  trimmedBaseUrl: string,
+  connectionBridge: { test: (payload: unknown) => Promise<{ ok: boolean }> } | undefined,
+  setConnState: (s: ConnectionState) => void,
+): Promise<void> {
+  if (!provider || trimmed.length === 0 || trimmedBaseUrl.length === 0) return;
+  if (!connectionBridge) {
+    setConnState({
+      kind: 'error',
+      code: 'NETWORK',
+      hint: 'Renderer is not connected to the main process.',
+    });
+    return;
+  }
+  setConnState({ kind: 'testing' });
+  try {
+    const result = await connectionBridge.test({
+      provider,
+      apiKey: trimmed,
+      baseUrl: trimmedBaseUrl,
+    });
+    if (result.ok) {
+      setConnState({ kind: 'ok' });
+    } else {
+      setConnState({ kind: 'error', code: 'NETWORK', hint: 'Connection test failed.' });
+    }
+  } catch (err) {
+    setConnState({
+      kind: 'error',
+      code: 'NETWORK',
+      hint: err instanceof Error ? err.message : 'Connection test failed.',
+    });
+  }
+}
+
+describe('handleConnectionTest — connection bridge guard', () => {
+  it('sets NETWORK error when connection bridge is undefined (bridge not yet injected)', async () => {
+    const setConnState = vi.fn();
+    await handleConnectionTest(
+      'openai',
+      'sk-test',
+      'https://api.openai.com/v1',
+      undefined,
+      setConnState,
+    );
+    expect(setConnState).toHaveBeenCalledOnce();
+    const firstArg = setConnState.mock.calls[0]?.[0] as ConnectionState | undefined;
+    expect(firstArg?.kind).toBe('error');
+    if (firstArg?.kind === 'error') {
+      expect(firstArg.code).toBe('NETWORK');
+      expect(firstArg.hint).toContain('not connected');
+    }
+  });
+
+  it('does not call setConnState when provider is null', async () => {
+    const setConnState = vi.fn();
+    await handleConnectionTest(
+      null,
+      'sk-test',
+      'https://api.openai.com/v1',
+      undefined,
+      setConnState,
+    );
+    expect(setConnState).not.toHaveBeenCalled();
+  });
+
+  it('does not call setConnState when trimmed apiKey is empty', async () => {
+    const setConnState = vi.fn();
+    await handleConnectionTest('openai', '', 'https://api.openai.com/v1', undefined, setConnState);
+    expect(setConnState).not.toHaveBeenCalled();
+  });
+
+  it('does not call setConnState when baseUrl is empty', async () => {
+    const setConnState = vi.fn();
+    await handleConnectionTest('openai', 'sk-test', '', undefined, setConnState);
+    expect(setConnState).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to testing state when bridge is available', async () => {
+    const setConnState = vi.fn();
+    const bridge = { test: vi.fn().mockResolvedValue({ ok: true }) };
+    await handleConnectionTest(
+      'openai',
+      'sk-test',
+      'https://api.openai.com/v1',
+      bridge,
+      setConnState,
+    );
+    expect(setConnState).toHaveBeenCalledTimes(2);
+    expect(setConnState.mock.calls[0]?.[0]).toEqual({ kind: 'testing' });
+    expect(setConnState.mock.calls[1]?.[0]).toEqual({ kind: 'ok' });
+  });
+
+  it('sets NETWORK error when bridge.test throws', async () => {
+    const setConnState = vi.fn();
+    const bridge = { test: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) };
+    await handleConnectionTest(
+      'openai',
+      'sk-test',
+      'https://api.openai.com/v1',
+      bridge,
+      setConnState,
+    );
+    const lastArg = setConnState.mock.calls.at(-1)?.[0] as ConnectionState | undefined;
+    expect(lastArg?.kind).toBe('error');
+    if (lastArg?.kind === 'error') {
+      expect(lastArg.code).toBe('NETWORK');
+      expect(lastArg.hint).toContain('ECONNREFUSED');
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -49,8 +49,10 @@ function getErrorHint(code: ConnectionTestError['code']): string {
       return 'Cannot reach base URL. Check domain/port/network.';
     case 'NETWORK':
       return 'Network error. Check your connection.';
-    default:
+    case 'PARSE':
       return 'Unexpected response. View logs at ~/Library/Logs/open-codesign/main.log';
+    case 'IPC_BAD_INPUT':
+      return 'Invalid input sent to connection test. Check provider / API key / base URL fields.';
   }
 }
 

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -211,10 +211,10 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
-        <h2 className="text-[20px] font-semibold text-[var(--color-text-primary)] tracking-[-0.01em] leading-[1.2]">
+        <h2 className="text-[var(--text-lg)] font-semibold text-[var(--color-text-primary)] tracking-[var(--tracking-heading)] leading-[var(--leading-heading)]">
           Paste your API key
         </h2>
-        <p className="text-[14px] text-[var(--color-text-secondary)] leading-[1.55]">
+        <p className="text-[var(--text-base)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
           We auto-detect the provider and validate against /v1/models. Your key is encrypted with
           the OS keychain.
         </p>
@@ -223,7 +223,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
       {/* Preset selector */}
       <label className="flex flex-col gap-2">
         <span
-          className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
+          className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
           Preset
@@ -231,7 +231,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         <select
           value={selectedPresetId}
           onChange={(e) => handlePresetChange(e.target.value)}
-          className="w-full h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] appearance-none cursor-pointer"
+          className="w-full h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)] appearance-none cursor-pointer"
         >
           <option value="">-- choose a preset --</option>
           {PROXY_PRESETS.map((preset) => (
@@ -241,7 +241,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
             </option>
           ))}
         </select>
-        <span className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
+        <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
           Not sure which to pick? Choose OpenAI Official for official endpoint, or pick by relay
           name.
         </span>
@@ -249,7 +249,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
 
       <label className="flex flex-col gap-2">
         <span
-          className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
+          className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
           API key
@@ -263,7 +263,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
             placeholder="sk-ant-…  /  sk-…  /  sk-or-…"
             spellCheck={false}
             style={{ fontFamily: 'var(--font-mono)' }}
-            className="w-full h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            className="w-full h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
           />
         </div>
       </label>
@@ -273,17 +273,17 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
       <details
         open={advancedOpen}
         onToggle={(e) => setAdvancedOpen((e.currentTarget as HTMLDetailsElement).open)}
-        className="text-[13px] text-[var(--color-text-secondary)]"
+        className="text-[var(--text-sm)] text-[var(--color-text-secondary)]"
       >
         <summary
-          className="cursor-pointer select-none text-[12px] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+          className="cursor-pointer select-none text-[var(--text-xs)] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
           Advanced — custom base URL (proxy / relay)
         </summary>
         <label className="flex flex-col gap-2 mt-3">
           <span
-            className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
+            className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
             style={{ fontFamily: 'var(--font-mono)' }}
           >
             Base URL
@@ -303,7 +303,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
               }
               spellCheck={false}
               style={{ fontFamily: 'var(--font-mono)' }}
-              className="flex-1 h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+              className="flex-1 h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
             />
             <button
               type="button"
@@ -314,7 +314,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
                 trimmed.length === 0 ||
                 trimmedBaseUrl.length === 0
               }
-              className="h-[40px] px-3 rounded-[var(--radius-md)] border border-[var(--color-border)] text-[12px] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 whitespace-nowrap"
+              className="h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 whitespace-nowrap"
             >
               {connState.kind === 'testing' ? (
                 <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -329,18 +329,18 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
             </button>
           </div>
           {connState.kind === 'ok' && (
-            <span className="text-[12px] text-[var(--color-success)] flex items-center gap-1.5">
+            <span className="text-[var(--text-xs)] text-[var(--color-success)] flex items-center gap-1.5">
               <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
               Connected
             </span>
           )}
           {connState.kind === 'error' && (
-            <span className="text-[12px] text-[var(--color-error)] flex items-center gap-1.5">
+            <span className="text-[var(--text-xs)] text-[var(--color-error)] flex items-center gap-1.5">
               <AlertCircle className="w-3.5 h-3.5 shrink-0" />
               {connState.hint}
             </span>
           )}
-          <span className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
+          <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
             Override the default endpoint for your provider. Useful for relay services (e.g.
             third-party AI gateways) and self-hosted proxies. Leave empty for the official endpoint.
           </span>

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -1,12 +1,19 @@
 import {
   PROVIDER_SHORTLIST,
+  PROXY_PRESETS,
+  type ProxyPresetId,
   type SupportedOnboardingProvider,
   isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { Button } from '@open-codesign/ui';
-import { AlertCircle, CheckCircle2, ExternalLink, Loader2 } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ExternalLink, Loader2, Wifi, WifiOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ValidateKeyError, ValidateKeyResult } from '../../../preload/index';
+import type {
+  ConnectionTestError,
+  ConnectionTestResult,
+  ValidateKeyError,
+  ValidateKeyResult,
+} from '../../../preload/index';
 
 const VALIDATE_DEBOUNCE_MS = 500;
 
@@ -17,6 +24,12 @@ type ValidationState =
   | { kind: 'ok'; modelCount: number }
   | { kind: 'error'; code: ValidateKeyError['code'] | 'unsupported'; message: string };
 
+type ConnectionState =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'ok' }
+  | { kind: 'error'; code: ConnectionTestError['code']; hint: string };
+
 interface PasteKeyProps {
   onValidated: (
     provider: SupportedOnboardingProvider,
@@ -26,12 +39,29 @@ interface PasteKeyProps {
   onBack: () => void;
 }
 
+function getErrorHint(code: ConnectionTestError['code']): string {
+  switch (code) {
+    case '401':
+      return 'API key invalid or unauthorized.';
+    case '404':
+      return 'Base URL path wrong. Try adding /v1 suffix (e.g. https://your-host/v1).';
+    case 'ECONNREFUSED':
+      return 'Cannot reach base URL. Check domain/port/network.';
+    case 'NETWORK':
+      return 'Network error. Check your connection.';
+    default:
+      return 'Unexpected response. View logs at ~/Library/Logs/open-codesign/main.log';
+  }
+}
+
 export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [selectedPresetId, setSelectedPresetId] = useState<ProxyPresetId | ''>('');
   const [provider, setProvider] = useState<SupportedOnboardingProvider | null>(null);
   const [state, setState] = useState<ValidationState>({ kind: 'idle' });
+  const [connState, setConnState] = useState<ConnectionState>({ kind: 'idle' });
   const reqIdRef = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -41,6 +71,22 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
 
   const trimmed = apiKey.trim();
   const trimmedBaseUrl = baseUrl.trim();
+
+  function handlePresetChange(presetId: string) {
+    if (presetId === '') {
+      setSelectedPresetId('');
+      setBaseUrl('');
+      return;
+    }
+    const preset = PROXY_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return;
+    setSelectedPresetId(preset.id as ProxyPresetId);
+    setBaseUrl(preset.baseUrl);
+    if (preset.id !== 'custom') {
+      setAdvancedOpen(true);
+    }
+    setConnState({ kind: 'idle' });
+  }
 
   useEffect(() => {
     if (trimmed.length === 0) {
@@ -125,6 +171,31 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
     return () => window.clearTimeout(handle);
   }, [trimmed, trimmedBaseUrl]);
 
+  async function handleConnectionTest() {
+    if (!provider || trimmed.length === 0 || trimmedBaseUrl.length === 0) return;
+    if (!window.codesign?.connection) return;
+    setConnState({ kind: 'testing' });
+    try {
+      const result = await window.codesign.connection.test({
+        provider,
+        apiKey: trimmed,
+        baseUrl: trimmedBaseUrl,
+      });
+      if (result.ok) {
+        setConnState({ kind: 'ok' });
+      } else {
+        const err = result as ConnectionTestError;
+        setConnState({ kind: 'error', code: err.code, hint: getErrorHint(err.code) });
+      }
+    } catch (err) {
+      setConnState({
+        kind: 'error',
+        code: 'NETWORK',
+        hint: err instanceof Error ? err.message : 'Connection test failed.',
+      });
+    }
+  }
+
   const helpUrl = useMemo(() => {
     if (provider === null) return null;
     return PROVIDER_SHORTLIST[provider].keyHelpUrl;
@@ -134,6 +205,8 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
     if (state.kind !== 'ok' || provider === null) return;
     onValidated(provider, trimmed, trimmedBaseUrl.length > 0 ? trimmedBaseUrl : null);
   }
+
+  const selectedPreset = PROXY_PRESETS.find((p) => p.id === selectedPresetId);
 
   return (
     <div className="flex flex-col gap-5">
@@ -146,6 +219,33 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           the OS keychain.
         </p>
       </div>
+
+      {/* Preset selector */}
+      <label className="flex flex-col gap-2">
+        <span
+          className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          Preset
+        </span>
+        <select
+          value={selectedPresetId}
+          onChange={(e) => handlePresetChange(e.target.value)}
+          className="w-full h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] appearance-none cursor-pointer"
+        >
+          <option value="">-- choose a preset --</option>
+          {PROXY_PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.label}
+              {preset.notes ? ` — ${preset.notes}` : ''}
+            </option>
+          ))}
+        </select>
+        <span className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
+          Not sure which to pick? Choose OpenAI Official for official endpoint, or pick by relay
+          name.
+        </span>
+      </label>
 
       <label className="flex flex-col gap-2">
         <span
@@ -188,15 +288,58 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           >
             Base URL
           </span>
-          <input
-            type="url"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-            placeholder="https://your-proxy.example.com/v1"
-            spellCheck={false}
-            style={{ fontFamily: 'var(--font-mono)' }}
-            className="w-full h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
-          />
+          <div className="flex gap-2 items-center">
+            <input
+              type="url"
+              value={baseUrl}
+              onChange={(e) => {
+                setBaseUrl(e.target.value);
+                setConnState({ kind: 'idle' });
+              }}
+              placeholder={
+                selectedPreset && selectedPreset.id !== 'custom'
+                  ? selectedPreset.baseUrl
+                  : 'https://your-proxy.example.com/v1'
+              }
+              spellCheck={false}
+              style={{ fontFamily: 'var(--font-mono)' }}
+              className="flex-1 h-[40px] px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[13px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            />
+            <button
+              type="button"
+              onClick={handleConnectionTest}
+              disabled={
+                connState.kind === 'testing' ||
+                provider === null ||
+                trimmed.length === 0 ||
+                trimmedBaseUrl.length === 0
+              }
+              className="h-[40px] px-3 rounded-[var(--radius-md)] border border-[var(--color-border)] text-[12px] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 whitespace-nowrap"
+            >
+              {connState.kind === 'testing' ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : connState.kind === 'ok' ? (
+                <Wifi className="w-3.5 h-3.5 text-[var(--color-success)]" />
+              ) : connState.kind === 'error' ? (
+                <WifiOff className="w-3.5 h-3.5 text-[var(--color-error)]" />
+              ) : (
+                <Wifi className="w-3.5 h-3.5" />
+              )}
+              {connState.kind === 'testing' ? 'Testing...' : 'Test'}
+            </button>
+          </div>
+          {connState.kind === 'ok' && (
+            <span className="text-[12px] text-[var(--color-success)] flex items-center gap-1.5">
+              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+              Connected
+            </span>
+          )}
+          {connState.kind === 'error' && (
+            <span className="text-[12px] text-[var(--color-error)] flex items-center gap-1.5">
+              <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+              {connState.hint}
+            </span>
+          )}
           <span className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
             Override the default endpoint for your provider. Useful for relay services (e.g.
             third-party AI gateways) and self-hosted proxies. Leave empty for the official endpoint.
@@ -236,12 +379,12 @@ function StatusLine({ provider, state, helpUrl }: StatusLineProps) {
     );
   }
   if (state.kind === 'detecting') {
-    return <Pending text="Detecting provider…" />;
+    return <Pending text="Detecting provider..." />;
   }
   if (state.kind === 'validating') {
     return (
       <Pending
-        text={`Recognized: ${provider ? PROVIDER_SHORTLIST[provider].label : 'unknown'} — validating…`}
+        text={`Recognized: ${provider ? PROVIDER_SHORTLIST[provider].label : 'unknown'} — validating...`}
       />
     );
   }
@@ -256,11 +399,12 @@ function StatusLine({ provider, state, helpUrl }: StatusLineProps) {
       </div>
     );
   }
+  const errorMessage = getValidationErrorMessage(state.code, state.message);
   return (
     <div className="text-sm text-[var(--color-error)] flex flex-col gap-1">
       <span className="flex items-start gap-2">
         <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
-        <span>{state.message}</span>
+        <span>{errorMessage}</span>
       </span>
       {helpUrl !== null ? (
         <a
@@ -274,6 +418,23 @@ function StatusLine({ provider, state, helpUrl }: StatusLineProps) {
       ) : null}
     </div>
   );
+}
+
+function getValidationErrorMessage(
+  code: ValidateKeyError['code'] | 'unsupported',
+  originalMessage: string,
+): string {
+  switch (code) {
+    case '401':
+    case '402':
+      return 'API key invalid or unauthorized. Check it in your provider dashboard.';
+    case '429':
+      return 'Rate limited. Wait a moment and try again.';
+    case 'network':
+      return 'Cannot reach base URL. Check domain/port/network.';
+    default:
+      return originalMessage;
+  }
 }
 
 function Pending({ text }: { text: string }) {

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -173,7 +173,14 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
 
   async function handleConnectionTest() {
     if (!provider || trimmed.length === 0 || trimmedBaseUrl.length === 0) return;
-    if (!window.codesign?.connection) return;
+    if (!window.codesign?.connection) {
+      setConnState({
+        kind: 'error',
+        code: 'NETWORK',
+        hint: 'Renderer is not connected to the main process.',
+      });
+      return;
+    }
     setConnState({ kind: 'testing' });
     try {
       const result = await window.codesign.connection.test({

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -105,6 +105,23 @@
       "advanced": {
         "title": "Advanced — custom base URL",
         "description": "If you use a proxy or relay, paste the full base URL (must include /v1)."
+      },
+      "preset": {
+        "label": "Preset",
+        "hint": "Not sure which to pick? Choose the first one for OpenAI official, or pick by relay name.",
+        "custom": "Custom"
+      },
+      "connectionTest": {
+        "button": "Test",
+        "testing": "Testing...",
+        "ok": "Connected",
+        "errors": {
+          "401": "API key invalid or unauthorized.",
+          "404": "Base URL path wrong. Try adding /v1 suffix (e.g. https://your-host/v1).",
+          "ECONNREFUSED": "Cannot reach base URL. Check domain/port/network.",
+          "NETWORK": "Network error. Check your connection.",
+          "PARSE": "Unexpected response format."
+        }
       }
     },
     "choose": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -205,6 +205,7 @@
     "exporterNotReady": "Exporter is still loading. Try again in a moment.",
     "rendererDisconnected": "Renderer is not connected to the main process.",
     "onboardingIncomplete": "Onboarding is not complete.",
+    "modelListFailed": "Could not load model list.",
     "unknown": "Unknown error"
   },
   "demos": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -205,6 +205,7 @@
     "exporterNotReady": "导出器还在加载，稍等片刻再试。",
     "rendererDisconnected": "渲染进程未连接到主进程。",
     "onboardingIncomplete": "引导流程尚未完成。",
+    "modelListFailed": "无法加载模型列表。",
     "unknown": "未知错误"
   },
   "demos": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -105,6 +105,23 @@
       "advanced": {
         "title": "高级 — 自定义 Base URL",
         "description": "如果使用代理或中转站，请粘贴完整的 Base URL（必须包含 /v1）。"
+      },
+      "preset": {
+        "label": "预设",
+        "hint": "不知道选哪个？用 OpenAI 官方就选第一个，用中转代理选对应名字。",
+        "custom": "自定义"
+      },
+      "connectionTest": {
+        "button": "测试连通",
+        "testing": "测试中...",
+        "ok": "连接成功",
+        "errors": {
+          "401": "API key 错误或权限不足。",
+          "404": "Base URL 路径错误。试试加 /v1 后缀（如 https://your-host/v1）。",
+          "ECONNREFUSED": "无法连接到 Base URL，检查域名 / 端口 / 网络。",
+          "NETWORK": "网络错误，检查你的网络连接。",
+          "PARSE": "响应格式异常。"
+        }
       }
     },
     "choose": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -193,3 +193,12 @@ export type {
   ProviderShortlist,
   SupportedOnboardingProvider,
 } from './config';
+
+export {
+  PROXY_PRESET_SCHEMA_VERSION,
+  PROXY_PRESETS,
+  ProxyPreset,
+  ProxyPresetIdSchema,
+  getPresetById,
+} from './proxy-presets';
+export type { ProxyPresetId } from './proxy-presets';

--- a/packages/shared/src/proxy-presets.test.ts
+++ b/packages/shared/src/proxy-presets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROXY_PRESETS,
+  PROXY_PRESET_SCHEMA_VERSION,
+  ProxyPreset,
+  ProxyPresetIdSchema,
+} from './proxy-presets';
+
+describe('PROXY_PRESETS', () => {
+  it('has the correct schema version constant', () => {
+    expect(PROXY_PRESET_SCHEMA_VERSION).toBe(1);
+  });
+
+  it('all preset ids are valid ProxyPresetIdSchema values', () => {
+    for (const preset of PROXY_PRESETS) {
+      expect(() => ProxyPresetIdSchema.parse(preset.id)).not.toThrow();
+    }
+  });
+
+  it('every preset has all required fields', () => {
+    for (const preset of PROXY_PRESETS) {
+      const result = ProxyPreset.safeParse(preset);
+      expect(
+        result.success,
+        `preset "${preset.id}" failed schema: ${JSON.stringify((result as { error?: unknown }).error)}`,
+      ).toBe(true);
+    }
+  });
+
+  it('contains the expected relay ids', () => {
+    const ids = PROXY_PRESETS.map((p) => p.id);
+    expect(ids).toContain('official-openai');
+    expect(ids).toContain('official-anthropic');
+    expect(ids).toContain('duckcoding');
+    expect(ids).toContain('openrouter');
+    expect(ids).toContain('siliconflow');
+    expect(ids).toContain('one-api');
+    expect(ids).toContain('custom');
+  });
+
+  it('DuckCoding preset has /v1 in baseUrl', () => {
+    const duck = PROXY_PRESETS.find((p) => p.id === 'duckcoding');
+    expect(duck).toBeDefined();
+    expect(duck!.baseUrl).toContain('/v1');
+  });
+
+  it('official-openai uses the correct baseUrl', () => {
+    const preset = PROXY_PRESETS.find((p) => p.id === 'official-openai');
+    expect(preset?.baseUrl).toBe('https://api.openai.com/v1');
+  });
+
+  it('custom preset has empty baseUrl', () => {
+    const custom = PROXY_PRESETS.find((p) => p.id === 'custom');
+    expect(custom?.baseUrl).toBe('');
+  });
+});

--- a/packages/shared/src/proxy-presets.ts
+++ b/packages/shared/src/proxy-presets.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const PROXY_PRESET_SCHEMA_VERSION = 1 as const;
+
+export const PROXY_PRESETS = [
+  {
+    id: 'official-openai',
+    label: 'OpenAI Official',
+    provider: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    notes: '',
+  },
+  {
+    id: 'official-anthropic',
+    label: 'Anthropic Official',
+    provider: 'anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    notes: '',
+  },
+  {
+    id: 'official-google',
+    label: 'Google AI Studio',
+    provider: 'openai',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    notes: 'OpenAI-compatible endpoint',
+  },
+  {
+    id: 'duckcoding',
+    label: 'DuckCoding',
+    provider: 'openai',
+    baseUrl: 'https://api.duckcoding.ai/v1',
+    notes: 'OpenAI compatible relay',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    provider: 'openai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    notes: 'Multi-model relay',
+  },
+  {
+    id: 'siliconflow',
+    label: 'SiliconFlow',
+    provider: 'openai',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    notes: 'CN-friendly relay',
+  },
+  {
+    id: 'one-api',
+    label: 'one-api (self-hosted)',
+    provider: 'openai',
+    baseUrl: 'http://localhost:3000/v1',
+    notes: 'Edit URL to your deployment',
+  },
+  {
+    id: 'custom',
+    label: 'Custom...',
+    provider: 'openai',
+    baseUrl: '',
+    notes: 'Enter your own base URL',
+  },
+] as const;
+
+export type ProxyPresetId = (typeof PROXY_PRESETS)[number]['id'];
+
+const presetIds = PROXY_PRESETS.map((p) => p.id) as [ProxyPresetId, ...ProxyPresetId[]];
+export const ProxyPresetIdSchema = z.enum(presetIds);
+
+export const ProxyPreset = z.object({
+  id: ProxyPresetIdSchema,
+  label: z.string(),
+  provider: z.string(),
+  baseUrl: z.string(),
+  notes: z.string(),
+});
+export type ProxyPreset = z.infer<typeof ProxyPreset>;
+
+export function getPresetById(id: ProxyPresetId): (typeof PROXY_PRESETS)[number] | undefined {
+  return PROXY_PRESETS.find((p) => p.id === id);
+}

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -53,7 +53,8 @@
   --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", "SF Mono", Menlo, monospace;
 
-  /* Type scale — strict 7 sizes */
+  /* Type scale — strict 8 sizes */
+  --text-2xs: 10px;
   --text-xs: 12px;
   --text-sm: 13px;
   --text-base: 14px;
@@ -72,6 +73,12 @@
   --tracking-tight: -0.005em;
   --tracking-normal: 0;
   --tracking-wide: 0.04em;
+  --tracking-label: 0.08em;
+
+  /* Control sizes */
+  --size-control-sm: 32px;
+  --size-control-md: 40px;
+  --size-control-lg: 48px;
 
   /* Spacing — strict 4-px scale */
   --space-1: 4px;


### PR DESCRIPTION
## Summary

- **8 built-in proxy presets** — official-openai, official-anthropic, official-google, duckcoding, openrouter, siliconflow, one-api, custom — in \`packages/shared/src/proxy-presets.ts\` with \`PROXY_PRESET_SCHEMA_VERSION=1\`
- **Test connection button** — calls \`connection:v1:test\` IPC, hits \`/models\` endpoint without consuming tokens, shows green check or red hint
- **Dynamic model list** — \`models:v1:list\` IPC with 5-minute per-provider+baseUrl cache
- **Error hint messages** — 401 → "API key invalid or unauthorized", 404 → "Try /v1 suffix", ECONNREFUSED → "Check domain/port/network"
- **i18n keys** added to both \`en.json\` and \`zh-CN.json\` (all ASCII quotes)

## Compatibility / upgradeability / no-bloat / elegance

- Compatibility: no schema changes, new IPC channels are additive
- Upgradeability: PROXY_PRESET_SCHEMA_VERSION=1 allows future migration
- No-bloat: no new dependencies; fetch is built-in Node 18+
- Elegance: presets defined once in shared, consumed by UI and tests

## Test plan

- [ ] Pick DuckCoding preset — baseUrl auto-fills as `https://api.duckcoding.ai/v1`, Advanced section opens
- [ ] Enter a real API key + DuckCoding baseUrl, click Test — green "Connected"
- [ ] Enter wrong baseUrl (without /v1), click Test — red "Base URL path wrong. Try /v1 suffix"
- [ ] Enter wrong API key, click Test — red "API key invalid or unauthorized"
- [ ] Select Custom preset — baseUrl field stays empty for user input
- [ ] All 108 workspace tests pass (`pnpm test`)
- [ ] Typecheck clean (`pnpm -r typecheck`)
- [ ] Lint clean (`pnpm lint`)