### PR TITLE
ci: narrow CI matrix to ubuntu (cost reduction)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,10 @@ concurrency:
 
 jobs:
   check:
+    # Cross-platform builds happen on tag releases via release.yml.
+    # PR/main CI runs on ubuntu only to control Actions cost (macOS 10x / Win 2x multiplier).
     name: Lint, typecheck, test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+echo "Running pre-push checks..."
+pnpm -r typecheck
+pnpm lint
+echo "Pre-push checks passed"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
-echo "Running pre-push checks..."
+set -e
+echo "Running pre-push checks (typecheck + lint)..."
 pnpm -r typecheck
 pnpm lint
 echo "Pre-push checks passed"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ open-codesign is an open-source desktop app that turns natural-language prompts 
 
 See [`docs/ROADMAP.md`](./docs/ROADMAP.md). MVP success criterion: replicate every public Claude Design demo.
 
+## CI
+
+PR / main pushes run lint + typecheck + test on ubuntu-latest (1-2 min feedback).
+Cross-platform builds happen on tag releases (`v*.*.*`) via `release.yml` (mac/win/linux).
+
+Local pre-push hook (auto-installed via `pnpm install`) runs typecheck + lint in seconds
+to fail fast before pushing.
+
 ## License
 
 Apache-2.0

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "packageManager": "pnpm@9.15.0",
   "scripts": {
+    "prepare": "husky",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "test": "turbo run test",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.27.11",
+    "husky": "^9.1.7",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.11
         version: 2.31.0(@types/node@22.19.17)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       turbo:
         specifier: ^2.3.3
         version: 2.9.6
@@ -2883,6 +2886,11 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
@@ -7576,6 +7584,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  husky@9.1.7: {}
 
   i18next@23.16.8:
     dependencies:


### PR DESCRIPTION
## Summary
- ci.yml lint/typecheck/test 收窄到 ubuntu-only（fast 1-2 min feedback）
- 三平台 build 由 release.yml tag 触发（不影响日常开发节奏）
- husky pre-push hook 本地强制 typecheck + lint（几秒就 fail fast）
- 仓库已转 public，Actions 完全免费

## Why
- 开发期间 CI 慢会拖慢节奏；ubuntu only 1-2 min vs 三平台 5+ min
- 跨平台风险主要在 native deps，release tag build 时验证一次足够
- husky 兜底保证本地不挂的代码才推

## Test plan
- [ ] PR 触发只跑 ubuntu CI
- [ ] tag push 仍触发 release.yml 三平台
- [ ] 故意 typecheck 失败时 git push 被 husky 阻止