### PR TITLE
feat(desktop): full-page Settings + fix API switching pipeline

### DIFF
--- a/apps/desktop/src/main/onboarding-ipc.test.ts
+++ b/apps/desktop/src/main/onboarding-ipc.test.ts
@@ -113,7 +113,6 @@ describe('registerOnboardingIpc — channel versioning', () => {
     }
   });
 });
-
 describe('registerOnboardingIpc — validate-key passes baseUrl to pingProvider', () => {
   it('forwards baseUrl to pingProvider when provided', async () => {
     const { pingProvider } = await import('@open-codesign/providers');
@@ -142,5 +141,32 @@ describe('registerOnboardingIpc — validate-key passes baseUrl to pingProvider'
     await handler?.({} as unknown, { provider: 'anthropic', apiKey: 'sk-ant-test' });
 
     expect(pingProvider).toHaveBeenCalledWith('anthropic', 'sk-ant-test', undefined);
+  });
+});
+
+describe('getApiKeyForProvider — API key retrieval', () => {
+  it('returns the decrypted key when the provider secret exists in config', async () => {
+    const { loadConfigOnBoot, getApiKeyForProvider } = await import('./onboarding-ipc');
+
+    // Override readConfig to return a config with an anthropic secret.
+    const { readConfig } = await import('./config');
+    vi.mocked(readConfig).mockResolvedValueOnce({
+      version: 1,
+      provider: 'anthropic',
+      modelPrimary: 'claude-sonnet-4-6',
+      modelFast: 'claude-haiku-3',
+      secrets: { anthropic: { ciphertext: 'enc:sk-ant-test' } },
+      baseUrls: {},
+    });
+
+    await loadConfigOnBoot();
+    const key = getApiKeyForProvider('anthropic');
+    // decryptSecret mock strips the 'enc:' prefix.
+    expect(key).toBe('sk-ant-test');
+  });
+
+  it('throws PROVIDER_KEY_MISSING when provider has no stored secret', async () => {
+    const { getApiKeyForProvider } = await import('./onboarding-ipc');
+    expect(() => getApiKeyForProvider('openai')).toThrow(/PROVIDER_KEY_MISSING|No API key stored/);
   });
 });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -67,8 +67,13 @@ export function App() {
       {
         combo: 'escape',
         handler: () => {
-          if (view === 'settings') setView('workspace');
-          else if (commandPaletteOpen) closeCommandPalette();
+          if (commandPaletteOpen) {
+            closeCommandPalette();
+            return;
+          }
+          if (view === 'settings') {
+            setView('workspace');
+          }
         },
         preventDefault: false,
       },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -17,11 +17,10 @@ export function App() {
   const loadConfig = useCodesignStore((s) => s.loadConfig);
   const sendPrompt = useCodesignStore((s) => s.sendPrompt);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
-  const openSettings = useCodesignStore((s) => s.openSettings);
-  const closeSettings = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
   const closeCommandPalette = useCodesignStore((s) => s.closeCommandPalette);
-  const settingsOpen = useCodesignStore((s) => s.settingsOpen);
+  const view = useCodesignStore((s) => s.view);
   const commandPaletteOpen = useCodesignStore((s) => s.commandPaletteOpen);
 
   const [prompt, setPrompt] = useState('');
@@ -55,7 +54,7 @@ export function App() {
         combo: 'mod+,',
         handler: () => {
           if (!ready) return;
-          openSettings();
+          setView('settings');
         },
       },
       {
@@ -68,7 +67,7 @@ export function App() {
       {
         combo: 'escape',
         handler: () => {
-          if (settingsOpen) closeSettings();
+          if (view === 'settings') setView('workspace');
           else if (commandPaletteOpen) closeCommandPalette();
         },
         preventDefault: false,
@@ -79,11 +78,10 @@ export function App() {
       isGenerating,
       ready,
       sendPrompt,
-      settingsOpen,
+      view,
       commandPaletteOpen,
-      openSettings,
+      setView,
       openCommandPalette,
-      closeSettings,
       closeCommandPalette,
     ],
   );
@@ -104,13 +102,18 @@ export function App() {
   return (
     <div className="h-full flex flex-col bg-[var(--color-background)]">
       <TopBar />
-      <div className="flex-1 grid grid-cols-[360px_1fr] min-h-0">
-        <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
-        <main className="flex flex-col min-h-0">
-          <PreviewPane onPickStarter={(p) => setPrompt(p)} />
-        </main>
+      <div className="flex-1 min-h-0">
+        {view === 'settings' ? (
+          <Settings />
+        ) : (
+          <div className="h-full grid grid-cols-[360px_1fr]">
+            <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
+            <main className="flex flex-col min-h-0">
+              <PreviewPane onPickStarter={(p) => setPrompt(p)} />
+            </main>
+          </div>
+        )}
       </div>
-      <Settings />
       <CommandPalette />
       <ToastViewport />
     </div>

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -15,7 +15,7 @@ export function CommandPalette() {
   const t = useT();
   const open = useCodesignStore((s) => s.commandPaletteOpen);
   const close = useCodesignStore((s) => s.closeCommandPalette);
-  const openSettings = useCodesignStore((s) => s.openSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const toggleTheme = useCodesignStore((s) => s.toggleTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
 
@@ -52,7 +52,7 @@ export function CommandPalette() {
         label: t('commands.items.openSettings'),
         hint: t('commands.hints.openSettings'),
         icon: SettingsIcon,
-        run: openSettings,
+        run: () => setView('settings'),
       },
       {
         id: 'export',
@@ -67,7 +67,7 @@ export function CommandPalette() {
           }),
       },
     ],
-    [openSettings, pushToast, t, toggleTheme],
+    [setView, pushToast, t, toggleTheme],
   );
 
   const filtered = useMemo(() => {

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -3,6 +3,7 @@ import { applyLocaleChange, applyValidateResult, canSaveProvider } from './Setti
 
 vi.mock('@open-codesign/i18n', () => ({
   setLocale: vi.fn((locale: string) => Promise.resolve(locale)),
+  useT: () => (key: string) => key,
 }));
 
 describe('canSaveProvider', () => {

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -98,12 +98,17 @@ describe('applyLocaleChange', () => {
     expect(result).toBe('zh-CN');
   });
 
-  it('skips IPC set and applies locale directly when no locale API is provided', async () => {
+  it('applies the locale returned by the IPC bridge, not the requested locale', async () => {
     const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+    // Bridge normalises 'zh' → 'zh-CN'
+    const mockLocaleApi = {
+      set: vi.fn((_locale: string) => Promise.resolve('zh-CN')),
+    };
 
-    const result = await applyLocaleChange('en', undefined);
+    const result = await applyLocaleChange('zh', mockLocaleApi);
 
-    expect(mockSetLocale).toHaveBeenCalledWith('en');
-    expect(result).toBe('en');
+    expect(mockLocaleApi.set).toHaveBeenCalledWith('zh');
+    expect(mockSetLocale).toHaveBeenCalledWith('zh-CN');
+    expect(result).toBe('zh-CN');
   });
 });

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { applyValidateResult, canSaveProvider } from './Settings';
+import { describe, expect, it, vi } from 'vitest';
+import { applyLocaleChange, applyValidateResult, canSaveProvider } from './Settings';
+
+vi.mock('@open-codesign/i18n', () => ({
+  setLocale: vi.fn((locale: string) => Promise.resolve(locale)),
+}));
 
 describe('canSaveProvider', () => {
   it('requires a validated API key before enabling save', () => {
@@ -77,5 +81,29 @@ describe('applyValidateResult', () => {
     const next = applyValidateResult(changedProviderForm, matchingSnapshot, true, undefined);
     expect(next).toBe(changedProviderForm);
     expect(next.validated).toBe(false);
+  });
+});
+
+describe('applyLocaleChange', () => {
+  it('calls locale IPC set, then applies the persisted locale via i18next', async () => {
+    const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+    const mockLocaleApi = {
+      set: vi.fn((_locale: string) => Promise.resolve('zh-CN')),
+    };
+
+    const result = await applyLocaleChange('zh-CN', mockLocaleApi);
+
+    expect(mockLocaleApi.set).toHaveBeenCalledWith('zh-CN');
+    expect(mockSetLocale).toHaveBeenCalledWith('zh-CN');
+    expect(result).toBe('zh-CN');
+  });
+
+  it('skips IPC set and applies locale directly when no locale API is provided', async () => {
+    const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+
+    const result = await applyLocaleChange('en', undefined);
+
+    expect(mockSetLocale).toHaveBeenCalledWith('en');
+    expect(result).toBe('en');
   });
 });

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -32,11 +32,11 @@ import { useCodesignStore } from '../store';
 
 type Tab = 'models' | 'appearance' | 'storage' | 'advanced';
 
-const TABS: ReadonlyArray<{ id: Tab; label: string; icon: typeof Cpu }> = [
-  { id: 'models', label: 'Models', icon: Cpu },
-  { id: 'appearance', label: 'Appearance', icon: Palette },
-  { id: 'storage', label: 'Storage', icon: FolderOpen },
-  { id: 'advanced', label: 'Advanced', icon: Sliders },
+const TABS: ReadonlyArray<{ id: Tab; icon: typeof Cpu }> = [
+  { id: 'models', icon: Cpu },
+  { id: 'appearance', icon: Palette },
+  { id: 'storage', icon: FolderOpen },
+  { id: 'advanced', icon: Sliders },
 ];
 
 // ─── Tiny primitives ─────────────────────────────────────────────────────────
@@ -241,6 +241,7 @@ function AddProviderModal({
   onSave: (rows: ProviderRow[]) => void;
   onClose: () => void;
 }) {
+  const t = useT();
   const providerOptions: { value: SupportedOnboardingProvider; label: string }[] = [
     { value: 'anthropic', label: 'Anthropic Claude' },
     { value: 'openai', label: 'OpenAI' },
@@ -272,12 +273,10 @@ function AddProviderModal({
         apiKey: snapshot.apiKey,
         ...(snapshot.baseUrl.length > 0 ? { baseUrl: snapshot.baseUrl } : {}),
       });
-      // Discard result if the user changed provider/key/baseUrl while we were waiting.
       setForm((current) =>
         applyValidateResult(current, snapshot, res.ok, res.ok ? undefined : res.message),
       );
     } finally {
-      // Ensure validating spinner clears even if we discarded the result.
       setForm((current) => (current.validating ? { ...current, validating: false } : current));
     }
   }
@@ -297,7 +296,7 @@ function AddProviderModal({
     } catch (err) {
       setForm((prev) => ({
         ...prev,
-        error: err instanceof Error ? err.message : 'Save failed',
+        error: err instanceof Error ? err.message : t('settings.common.unknownError'),
       }));
     }
   }
@@ -312,7 +311,7 @@ function AddProviderModal({
       // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
       role="dialog"
       aria-modal="true"
-      aria-label="Add provider"
+      aria-label={t('settings.providers.modal.title')}
       className="fixed inset-0 z-[60] flex items-center justify-center p-6 bg-[var(--color-overlay)]"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
@@ -325,12 +324,13 @@ function AddProviderModal({
       >
         <div className="flex items-center justify-between">
           <h2 className="text-[var(--text-base)] font-semibold text-[var(--color-text-primary)]">
-            Add provider
+            {t('settings.providers.modal.title')}
           </h2>
           <button
             type="button"
             onClick={onClose}
             className="p-1.5 rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+            aria-label={t('common.close')}
           >
             <X className="w-4 h-4" />
           </button>
@@ -339,7 +339,7 @@ function AddProviderModal({
         <div className="space-y-3">
           <div>
             <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-              Provider
+              {t('settings.providers.modal.provider')}
             </p>
             <NativeSelect
               value={form.provider}
@@ -351,7 +351,7 @@ function AddProviderModal({
           <div>
             <div className="flex items-center justify-between mb-1.5">
               <p className="text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)]">
-                API Key
+                {t('settings.providers.modal.apiKey')}
               </p>
               <a
                 href={sl.keyHelpUrl}
@@ -359,7 +359,7 @@ function AddProviderModal({
                 rel="noreferrer"
                 className="text-[var(--text-xs)] text-[var(--color-accent)] hover:underline"
               >
-                Get key ↗
+                {t('settings.providers.modal.getKey')}
               </a>
             </div>
             <div className="flex gap-2">
@@ -367,7 +367,7 @@ function AddProviderModal({
                 type="password"
                 value={form.apiKey}
                 onChange={(v) => setField('apiKey', v)}
-                placeholder="sk-..."
+                placeholder={t('settings.providers.modal.apiKeyPlaceholder')}
                 className="flex-1"
               />
               <button
@@ -381,7 +381,11 @@ function AddProviderModal({
                 ) : form.validated ? (
                   <CheckCircle className="w-3.5 h-3.5 text-[var(--color-success)]" />
                 ) : null}
-                {form.validated ? 'Valid' : 'Validate'}
+                {form.validating
+                  ? t('settings.providers.modal.validating')
+                  : form.validated
+                    ? t('settings.providers.modal.valid')
+                    : t('settings.providers.modal.validate')}
               </button>
             </div>
             {form.error && (
@@ -391,13 +395,15 @@ function AddProviderModal({
 
           <div>
             <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-              Base URL{' '}
-              <span className="text-[var(--color-text-muted)] font-normal">(optional)</span>
+              {t('settings.providers.modal.baseUrl')}{' '}
+              <span className="text-[var(--color-text-muted)] font-normal">
+                {t('settings.providers.modal.baseUrlOptional')}
+              </span>
             </p>
             <TextInput
               value={form.baseUrl}
               onChange={(v) => setField('baseUrl', v)}
-              placeholder="https://your-proxy.example.com"
+              placeholder={t('settings.providers.modal.baseUrlPlaceholder')}
               className="w-full"
             />
           </div>
@@ -405,7 +411,7 @@ function AddProviderModal({
           <div className="grid grid-cols-2 gap-3">
             <div>
               <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-                Primary model
+                {t('settings.providers.modal.primaryModel')}
               </p>
               <NativeSelect
                 value={form.modelPrimary}
@@ -415,7 +421,7 @@ function AddProviderModal({
             </div>
             <div>
               <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-                Fast model
+                {t('settings.providers.modal.fastModel')}
               </p>
               <NativeSelect
                 value={form.modelFast}
@@ -428,10 +434,10 @@ function AddProviderModal({
 
         <div className="flex justify-end gap-2 pt-1">
           <Button variant="secondary" size="sm" onClick={onClose}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button size="sm" onClick={handleSave} disabled={!canSave}>
-            Save provider
+            {t('settings.providers.modal.save')}
           </Button>
         </div>
       </div>
@@ -452,6 +458,7 @@ function ProviderCard({
   onActivate: (p: SupportedOnboardingProvider) => void;
   onReEnterKey: (p: SupportedOnboardingProvider) => void;
 }) {
+  const t = useT();
   const label = SHORTLIST[row.provider]?.label ?? row.provider;
   const [confirmDelete, setConfirmDelete] = useState(false);
   const hasError = row.error !== undefined;
@@ -474,13 +481,13 @@ function ProviderCard({
             </span>
             {row.isActive && !hasError && (
               <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
-                Active
+                {t('settings.providers.active')}
               </span>
             )}
             {hasError && (
               <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
                 <AlertTriangle className="w-2.5 h-2.5" />
-                Decryption failed
+                {t('settings.providers.decryptionFailed')}
               </span>
             )}
           </div>
@@ -506,7 +513,7 @@ function ProviderCard({
               onClick={() => onActivate(row.provider)}
               className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)] transition-colors"
             >
-              Set active
+              {t('settings.providers.setActive')}
             </button>
           )}
           {hasError && (
@@ -515,7 +522,7 @@ function ProviderCard({
               onClick={() => onReEnterKey(row.provider)}
               className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-error)] border border-[var(--color-error)] bg-[var(--color-surface)] hover:opacity-80 transition-opacity"
             >
-              Re-enter key
+              {t('settings.providers.reEnterKey')}
             </button>
           )}
           {confirmDelete ? (
@@ -528,14 +535,14 @@ function ProviderCard({
                 }}
                 className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-on-accent)] bg-[var(--color-error)] hover:opacity-90 transition-opacity"
               >
-                Confirm
+                {t('settings.providers.confirm')}
               </button>
               <button
                 type="button"
                 onClick={() => setConfirmDelete(false)}
                 className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
               >
-                Cancel
+                {t('common.cancel')}
               </button>
             </div>
           ) : (
@@ -543,7 +550,7 @@ function ProviderCard({
               type="button"
               onClick={() => setConfirmDelete(true)}
               className="p-1.5 rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:text-[var(--color-error)] hover:bg-[var(--color-surface-hover)] transition-colors"
-              aria-label={`Delete ${label} provider`}
+              aria-label={t('settings.providers.deleteAria', { label })}
             >
               <Trash2 className="w-3.5 h-3.5" />
             </button>
@@ -565,6 +572,7 @@ function ActiveModelSelector({
   config: OnboardingState;
   provider: SupportedOnboardingProvider;
 }) {
+  const t = useT();
   const sl = SHORTLIST[provider];
   const primaryOptions = sl.primary.map((m) => ({ value: m, label: m }));
   const fastOptions = sl.fast.map((m) => ({ value: m, label: m }));
@@ -575,7 +583,6 @@ function ActiveModelSelector({
   const [fast, setFast] = useState(config.modelFast ?? sl.defaultFast);
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Sync local state when the config changes (e.g. provider re-activated with different models).
   useEffect(() => {
     setPrimary(config.modelPrimary ?? sl.defaultPrimary);
     setFast(config.modelFast ?? sl.defaultFast);
@@ -602,8 +609,8 @@ function ActiveModelSelector({
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save model selection',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.providers.toast.modelSaveFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -624,13 +631,13 @@ function ActiveModelSelector({
     <div className="mt-3 pt-3 border-t border-[var(--color-border-subtle)] grid grid-cols-2 gap-3">
       <div>
         <p className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)] mb-1.5">
-          <Cpu className="w-3 h-3" /> Primary
+          <Cpu className="w-3 h-3" /> {t('settings.providers.primary')}
         </p>
         <NativeSelect value={primary} onChange={handlePrimaryChange} options={primaryOptions} />
       </div>
       <div>
         <p className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)] mb-1.5">
-          <Zap className="w-3 h-3" /> Fast
+          <Zap className="w-3 h-3" /> {t('settings.providers.fast')}
         </p>
         <NativeSelect value={fast} onChange={handleFastChange} options={fastOptions} />
       </div>
@@ -639,6 +646,7 @@ function ActiveModelSelector({
 }
 
 function ModelsTab() {
+  const t = useT();
   const config = useCodesignStore((s) => s.config);
   const setConfig = useCodesignStore((s) => s.completeOnboarding);
   const pushToast = useCodesignStore((s) => s.pushToast);
@@ -655,12 +663,12 @@ function ModelsTab() {
       .catch((err) => {
         pushToast({
           variant: 'error',
-          title: 'Failed to load providers',
-          description: err instanceof Error ? err.message : 'Unknown error',
+          title: t('settings.providers.toast.loadFailed'),
+          description: err instanceof Error ? err.message : t('settings.common.unknownError'),
         });
       })
       .finally(() => setLoading(false));
-  }, [pushToast]);
+  }, [pushToast, t]);
 
   async function handleDelete(provider: SupportedOnboardingProvider) {
     if (!window.codesign) return;
@@ -669,12 +677,12 @@ function ModelsTab() {
       setRows(next);
       const newState = await window.codesign.onboarding.getState();
       setConfig(newState);
-      pushToast({ variant: 'success', title: 'Provider removed' });
+      pushToast({ variant: 'success', title: t('settings.providers.toast.removed') });
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Delete failed',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.providers.toast.deleteFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -691,12 +699,15 @@ function ModelsTab() {
       setConfig(next);
       const updatedRows = await window.codesign.settings.listProviders();
       setRows(updatedRows);
-      pushToast({ variant: 'success', title: `Switched to ${sl.label}` });
+      pushToast({
+        variant: 'success',
+        title: t('settings.providers.toast.switchedTo', { label: sl.label }),
+      });
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Switch failed',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.providers.toast.switchFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -705,7 +716,7 @@ function ModelsTab() {
     setRows(nextRows);
     setShowAdd(false);
     setReEnterProvider(null);
-    pushToast({ variant: 'success', title: 'Provider saved' });
+    pushToast({ variant: 'success', title: t('settings.providers.toast.saved') });
   }
 
   return (
@@ -722,23 +733,23 @@ function ModelsTab() {
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <SectionTitle>API Providers</SectionTitle>
+          <SectionTitle>{t('settings.providers.sectionTitle')}</SectionTitle>
           <Button variant="secondary" size="sm" onClick={() => setShowAdd(true)}>
             <Plus className="w-3.5 h-3.5" />
-            Add provider
+            {t('settings.providers.addProvider')}
           </Button>
         </div>
 
         {loading && (
           <div className="flex items-center gap-2 py-4 text-[var(--text-sm)] text-[var(--color-text-muted)]">
             <Loader2 className="w-4 h-4 animate-spin" />
-            Loading…
+            {t('settings.common.loading')}
           </div>
         )}
 
         {!loading && rows.length === 0 && (
           <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--color-border)] p-6 text-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
-            No providers configured yet. Add one to start generating.
+            {t('settings.providers.empty')}
           </div>
         )}
 
@@ -783,10 +794,10 @@ export async function applyLocaleChange(
 }
 
 function AppearanceTab() {
+  const t = useT();
   const theme = useCodesignStore((s) => s.theme);
   const setTheme = useCodesignStore((s) => s.setTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
-  const t = useT();
   const [locale, setLocale] = useState<string>('en');
 
   useEffect(() => {
@@ -797,11 +808,11 @@ function AppearanceTab() {
       .catch((err) => {
         pushToast({
           variant: 'error',
-          title: 'Failed to load language',
-          description: err instanceof Error ? err.message : 'Unknown error',
+          title: t('settings.appearance.languageLoadFailed'),
+          description: err instanceof Error ? err.message : t('settings.common.unknownError'),
         });
       });
-  }, [pushToast]);
+  }, [pushToast, t]);
 
   async function handleLocaleChange(v: string) {
     if (!window.codesign?.locale) {
@@ -824,28 +835,36 @@ function AppearanceTab() {
     }
   }
 
+  const themeCards = [
+    {
+      value: 'light' as const,
+      label: t('settings.appearance.lightLabel'),
+      desc: t('settings.appearance.lightDesc'),
+    },
+    {
+      value: 'dark' as const,
+      label: t('settings.appearance.darkLabel'),
+      desc: t('settings.appearance.darkDesc'),
+    },
+  ];
+
   return (
     <div className="space-y-5">
       <div>
-        <SectionTitle>Theme</SectionTitle>
+        <SectionTitle>{t('settings.appearance.themeTitle')}</SectionTitle>
         <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1 leading-[var(--leading-body)]">
-          Choice persists across restarts.
+          {t('settings.appearance.themeHint')}
         </p>
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        {(
-          [
-            { value: 'light', label: 'Light', desc: 'Warm beige, soft shadows' },
-            { value: 'dark', label: 'Dark', desc: 'Deep neutral, low glare' },
-          ] as const
-        ).map((t) => {
-          const active = theme === t.value;
+        {themeCards.map((card) => {
+          const active = theme === card.value;
           return (
             <button
-              key={t.value}
+              key={card.value}
               type="button"
-              onClick={() => setTheme(t.value)}
+              onClick={() => setTheme(card.value)}
               className={`text-left p-4 rounded-[var(--radius-lg)] border transition-colors ${
                 active
                   ? 'border-[var(--color-accent)] bg-[var(--color-accent-soft)]'
@@ -853,10 +872,10 @@ function AppearanceTab() {
               }`}
             >
               <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
-                {t.label}
+                {card.label}
               </div>
               <div className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1">
-                {t.desc}
+                {card.desc}
               </div>
             </button>
           );
@@ -864,13 +883,16 @@ function AppearanceTab() {
       </div>
 
       <div className="pt-2 border-t border-[var(--color-border-subtle)]">
-        <Row label="Language" hint="Language changes take effect immediately.">
+        <Row
+          label={t('settings.appearance.languageLabel')}
+          hint={t('settings.appearance.languageHint')}
+        >
           <NativeSelect
             value={locale}
             onChange={handleLocaleChange}
             options={[
-              { value: 'en', label: 'English' },
-              { value: 'zh-CN', label: '中文 (简体)' },
+              { value: 'en', label: t('settings.appearance.langEn') },
+              { value: 'zh-CN', label: t('settings.appearance.langZhCN') },
             ]}
           />
         </Row>
@@ -882,6 +904,7 @@ function AppearanceTab() {
 // ─── Storage tab ──────────────────────────────────────────────────────────────
 
 function CopyButton({ value }: { value: string }) {
+  const t = useT();
   const [copied, setCopied] = useState(false);
   async function handleCopy() {
     await navigator.clipboard.writeText(value);
@@ -894,12 +917,13 @@ function CopyButton({ value }: { value: string }) {
       onClick={handleCopy}
       className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
     >
-      {copied ? 'Copied!' : 'Copy'}
+      {copied ? t('settings.common.copied') : t('settings.common.copy')}
     </button>
   );
 }
 
 function PathRow({ label, value, onOpen }: { label: string; value: string; onOpen: () => void }) {
+  const t = useT();
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
@@ -912,7 +936,7 @@ function PathRow({ label, value, onOpen }: { label: string; value: string; onOpe
             className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors inline-flex items-center gap-1"
           >
             <FolderOpen className="w-3 h-3" />
-            Open
+            {t('settings.common.open')}
           </button>
         </div>
       </div>
@@ -924,6 +948,7 @@ function PathRow({ label, value, onOpen }: { label: string; value: string; onOpe
 }
 
 function StorageTab() {
+  const t = useT();
   const pushToast = useCodesignStore((s) => s.pushToast);
   const setView = useCodesignStore((s) => s.setView);
   const completeOnboarding = useCodesignStore((s) => s.completeOnboarding);
@@ -938,11 +963,11 @@ function StorageTab() {
       .catch((err) => {
         pushToast({
           variant: 'error',
-          title: 'Failed to load app paths',
-          description: err instanceof Error ? err.message : 'Unknown error',
+          title: t('settings.storage.pathsLoadFailed'),
+          description: err instanceof Error ? err.message : t('settings.common.unknownError'),
         });
       });
-  }, [pushToast]);
+  }, [pushToast, t]);
 
   async function openFolder(path: string) {
     try {
@@ -950,8 +975,8 @@ function StorageTab() {
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Could not open folder',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.storage.openFolderFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -962,29 +987,33 @@ function StorageTab() {
     const newState = await window.codesign.onboarding.getState();
     completeOnboarding(newState);
     setView('workspace');
-    pushToast({ variant: 'info', title: 'Onboarding reset. Restart the app to re-run setup.' });
+    pushToast({ variant: 'info', title: t('settings.storage.onboardingResetToast') });
     setConfirmReset(false);
   }
 
   return (
     <div className="space-y-5">
-      <SectionTitle>Paths</SectionTitle>
+      <SectionTitle>{t('settings.storage.pathsTitle')}</SectionTitle>
 
       {paths === null ? (
         <div className="flex items-center gap-2 py-4 text-[var(--text-sm)] text-[var(--color-text-muted)]">
           <Loader2 className="w-4 h-4 animate-spin" />
-          Loading…
+          {t('settings.common.loading')}
         </div>
       ) : (
         <div className="space-y-4">
           <PathRow
-            label="Config"
+            label={t('settings.storage.config')}
             value={paths.config}
             onOpen={() => openFolder(paths.configFolder)}
           />
-          <PathRow label="Logs" value={paths.logs} onOpen={() => openFolder(paths.logsFolder)} />
           <PathRow
-            label="Data directory"
+            label={t('settings.storage.logs')}
+            value={paths.logs}
+            onOpen={() => openFolder(paths.logsFolder)}
+          />
+          <PathRow
+            label={t('settings.storage.data')}
             value={paths.data}
             onOpen={() => openFolder(paths.data)}
           />
@@ -992,29 +1021,29 @@ function StorageTab() {
       )}
 
       <div className="pt-4 border-t border-[var(--color-border-subtle)]">
-        <SectionTitle>Onboarding</SectionTitle>
+        <SectionTitle>{t('settings.storage.onboardingTitle')}</SectionTitle>
         <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-1 mb-3 leading-[var(--leading-body)]">
-          Clear the setup flag so the onboarding wizard runs again on next launch.
+          {t('settings.storage.onboardingHint')}
         </p>
 
         {confirmReset ? (
           <div className="flex items-center gap-2">
             <span className="text-[var(--text-xs)] text-[var(--color-text-secondary)]">
-              This will remove your saved keys. Continue?
+              {t('settings.storage.resetConfirm')}
             </span>
             <button
               type="button"
               onClick={handleReset}
               className="h-7 px-3 rounded-[var(--radius-sm)] bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--text-xs)] font-medium hover:opacity-90 transition-opacity"
             >
-              Reset
+              {t('settings.storage.reset')}
             </button>
             <button
               type="button"
               onClick={() => setConfirmReset(false)}
               className="h-7 px-3 rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] transition-colors"
             >
-              Cancel
+              {t('common.cancel')}
             </button>
           </div>
         ) : (
@@ -1024,7 +1053,7 @@ function StorageTab() {
             className="inline-flex items-center gap-1.5 h-8 px-3 rounded-[var(--radius-md)] border border-[var(--color-error)] text-[var(--text-sm)] text-[var(--color-error)] hover:bg-[var(--color-error)] hover:text-[var(--color-on-accent)] transition-colors"
           >
             <RotateCcw className="w-3.5 h-3.5" />
-            Reset onboarding
+            {t('settings.storage.resetButton')}
           </button>
         )}
       </div>
@@ -1035,6 +1064,7 @@ function StorageTab() {
 // ─── Advanced tab ─────────────────────────────────────────────────────────────
 
 function AdvancedTab() {
+  const t = useT();
   const pushToast = useCodesignStore((s) => s.pushToast);
   const [prefs, setPrefs] = useState<Preferences>({
     updateChannel: 'stable',
@@ -1049,11 +1079,11 @@ function AdvancedTab() {
       .catch((err) => {
         pushToast({
           variant: 'error',
-          title: 'Failed to load preferences',
-          description: err instanceof Error ? err.message : 'Unknown error',
+          title: t('settings.advanced.prefsLoadFailed'),
+          description: err instanceof Error ? err.message : t('settings.common.unknownError'),
         });
       });
-  }, [pushToast]);
+  }, [pushToast, t]);
 
   async function updatePref(patch: Partial<Preferences>) {
     if (!window.codesign) return;
@@ -1063,8 +1093,8 @@ function AdvancedTab() {
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save preference',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.advanced.prefsSaveFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -1076,8 +1106,8 @@ function AdvancedTab() {
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Could not toggle DevTools',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('settings.advanced.devtoolsFailed'),
+        description: err instanceof Error ? err.message : t('settings.common.unknownError'),
       });
     }
   }
@@ -1085,39 +1115,39 @@ function AdvancedTab() {
   return (
     <div className="space-y-1">
       <Row
-        label="Update channel"
-        hint="Stable: tested releases. Beta: early access (may have bugs)."
+        label={t('settings.advanced.updateChannel')}
+        hint={t('settings.advanced.updateChannelHint')}
       >
         <SegmentedControl
           options={[
-            { value: 'stable', label: 'Stable' },
-            { value: 'beta', label: 'Beta' },
+            { value: 'stable', label: t('settings.advanced.stable') },
+            { value: 'beta', label: t('settings.advanced.beta') },
           ]}
           value={prefs.updateChannel}
           onChange={(v) => void updatePref({ updateChannel: v })}
         />
       </Row>
 
-      <Row label="Generation timeout" hint="Seconds before a generation request is aborted.">
+      <Row label={t('settings.advanced.timeout')} hint={t('settings.advanced.timeoutHint')}>
         <NativeSelect
           value={String(prefs.generationTimeoutSec)}
           onChange={(v) => void updatePref({ generationTimeoutSec: Number(v) })}
           options={[
-            { value: '60', label: '60 s' },
-            { value: '120', label: '120 s' },
-            { value: '180', label: '180 s' },
-            { value: '300', label: '300 s' },
+            { value: '60', label: t('settings.advanced.timeoutSeconds', { value: 60 }) },
+            { value: '120', label: t('settings.advanced.timeoutSeconds', { value: 120 }) },
+            { value: '180', label: t('settings.advanced.timeoutSeconds', { value: 180 }) },
+            { value: '300', label: t('settings.advanced.timeoutSeconds', { value: 300 }) },
           ]}
         />
       </Row>
 
-      <Row label="Developer tools" hint="Open the Chromium DevTools panel for the renderer.">
+      <Row label={t('settings.advanced.devtools')} hint={t('settings.advanced.devtoolsHint')}>
         <button
           type="button"
           onClick={handleDevtools}
           className="h-7 px-3 rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] transition-colors"
         >
-          Toggle DevTools
+          {t('settings.advanced.toggleDevtools')}
         </button>
       </Row>
     </div>
@@ -1127,6 +1157,7 @@ function AdvancedTab() {
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
 export function Settings() {
+  const t = useT();
   const setView = useCodesignStore((s) => s.setView);
   const [tab, setTab] = useState<Tab>('models');
 
@@ -1137,14 +1168,14 @@ export function Settings() {
           type="button"
           onClick={() => setView('workspace')}
           className="inline-flex items-center gap-1.5 text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-          aria-label="Back to workspace"
+          aria-label={t('settings.shell.backAria')}
         >
           <ArrowLeft className="w-4 h-4" />
-          Workspace
+          {t('settings.shell.back')}
         </button>
         <span className="text-[var(--color-text-muted)]">/</span>
-        <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
-          {tab}
+        <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+          {t(`settings.tabs.${tab}`)}
         </span>
       </header>
 
@@ -1153,18 +1184,18 @@ export function Settings() {
           <div className="flex items-center gap-2 px-2 py-2 mb-2">
             <Sliders className="w-4 h-4 text-[var(--color-text-secondary)]" />
             <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
-              Settings
+              {t('settings.title')}
             </span>
           </div>
           <nav className="space-y-0.5">
-            {TABS.map((t) => {
-              const Icon = t.icon;
-              const active = tab === t.id;
+            {TABS.map((entry) => {
+              const Icon = entry.icon;
+              const active = tab === entry.id;
               return (
                 <button
-                  key={t.id}
+                  key={entry.id}
                   type="button"
-                  onClick={() => setTab(t.id)}
+                  onClick={() => setTab(entry.id)}
                   className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
                     active
                       ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium'
@@ -1172,7 +1203,7 @@ export function Settings() {
                   }`}
                 >
                   <Icon className="w-4 h-4 shrink-0" />
-                  {t.label}
+                  {t(`settings.tabs.${entry.id}`)}
                 </button>
               );
             })}

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { setLocale as applyLocale } from '@open-codesign/i18n';
+import { setLocale as applyLocale, useT } from '@open-codesign/i18n';
 import type {
   OnboardingState,
   PROVIDER_SHORTLIST,
@@ -786,6 +786,7 @@ function AppearanceTab() {
   const theme = useCodesignStore((s) => s.theme);
   const setTheme = useCodesignStore((s) => s.setTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
+  const t = useT();
   const [locale, setLocale] = useState<string>('en');
 
   useEffect(() => {
@@ -806,8 +807,8 @@ function AppearanceTab() {
     if (!window.codesign?.locale) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language preference',
-        description: 'Renderer is not connected to the main process.',
+        title: t('errors.localePersistFailed'),
+        description: t('errors.rendererDisconnected'),
       });
       return;
     }
@@ -817,8 +818,8 @@ function AppearanceTab() {
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language preference',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('errors.localePersistFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
       });
     }
   }

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@open-codesign/ui';
 import {
   AlertTriangle,
+  ArrowLeft,
   CheckCircle,
   ChevronDown,
   Cpu,
@@ -574,6 +575,12 @@ function ActiveModelSelector({
   const [fast, setFast] = useState(config.modelFast ?? sl.defaultFast);
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Sync local state when the config changes (e.g. provider re-activated with different models).
+  useEffect(() => {
+    setPrimary(config.modelPrimary ?? sl.defaultPrimary);
+    setFast(config.modelFast ?? sl.defaultFast);
+  }, [config.modelPrimary, config.modelFast, sl.defaultPrimary, sl.defaultFast]);
+
   useEffect(() => {
     return () => {
       if (saveTimeout.current !== null) {
@@ -756,6 +763,22 @@ function ModelsTab() {
 
 // ─── Appearance tab ───────────────────────────────────────────────────────────
 
+/**
+ * Applies a locale change end-to-end:
+ *   1. Persists it via the IPC bridge (writes to disk on the main process)
+ *   2. Changes the active i18next language so React components re-render
+ *
+ * Exported so it can be unit-tested without a DOM.
+ */
+export async function applyLocaleChange(
+  locale: string,
+  localeApi: { set: (locale: string) => Promise<string> } | undefined,
+): Promise<string> {
+  const persisted = localeApi ? await localeApi.set(locale) : locale;
+  const applied = await applyLocale(persisted);
+  return applied;
+}
+
 function AppearanceTab() {
   const theme = useCodesignStore((s) => s.theme);
   const setTheme = useCodesignStore((s) => s.setTheme);
@@ -779,8 +802,7 @@ function AppearanceTab() {
   async function handleLocaleChange(v: string) {
     if (!window.codesign) return;
     try {
-      const persisted = await window.codesign.locale.set(v);
-      const applied = await applyLocale(persisted);
+      const applied = await applyLocaleChange(v, window.codesign.locale);
       setLocale(applied);
     } catch (err) {
       pushToast({
@@ -892,7 +914,7 @@ function PathRow({ label, value, onOpen }: { label: string; value: string; onOpe
 
 function StorageTab() {
   const pushToast = useCodesignStore((s) => s.pushToast);
-  const closeSettings = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const completeOnboarding = useCodesignStore((s) => s.completeOnboarding);
   const [paths, setPaths] = useState<AppPaths | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
@@ -928,7 +950,7 @@ function StorageTab() {
     await window.codesign.settings.resetOnboarding();
     const newState = await window.codesign.onboarding.getState();
     completeOnboarding(newState);
-    closeSettings();
+    setView('workspace');
     pushToast({ variant: 'info', title: 'Onboarding reset. Restart the app to re-run setup.' });
     setConfirmReset(false);
   }
@@ -1094,30 +1116,28 @@ function AdvancedTab() {
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
 export function Settings() {
-  const open = useCodesignStore((s) => s.settingsOpen);
-  const close = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const [tab, setTab] = useState<Tab>('models');
 
-  if (!open) return null;
-
   return (
-    <div
-      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
-      role="dialog"
-      aria-modal="true"
-      aria-label="Settings"
-      className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
-      onClick={close}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') close();
-      }}
-    >
-      <div
-        className="w-full max-w-3xl h-[36rem] rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] grid grid-cols-[11rem_1fr] overflow-hidden animate-[panel-in_160ms_ease-out]"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="document"
-      >
+    <div className="h-full flex flex-col bg-[var(--color-background)]">
+      <header className="flex items-center gap-3 px-5 h-12 border-b border-[var(--color-border)] shrink-0">
+        <button
+          type="button"
+          onClick={() => setView('workspace')}
+          className="inline-flex items-center gap-1.5 text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          aria-label="Back to workspace"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Workspace
+        </button>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
+          {tab}
+        </span>
+      </header>
+
+      <div className="flex-1 grid grid-cols-[11rem_1fr] min-h-0">
         <aside className="bg-[var(--color-background-secondary)] border-r border-[var(--color-border)] p-3">
           <div className="flex items-center gap-2 px-2 py-2 mb-2">
             <Sliders className="w-4 h-4 text-[var(--color-text-secondary)]" />
@@ -1148,21 +1168,11 @@ export function Settings() {
           </nav>
         </aside>
 
-        <section className="flex flex-col min-w-0">
-          <header className="flex items-center justify-between px-5 h-12 border-b border-[var(--color-border)] shrink-0">
-            <h2 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
-              {tab}
-            </h2>
-            <Button variant="ghost" size="sm" onClick={close} aria-label="Close settings">
-              <X className="w-4 h-4" />
-            </Button>
-          </header>
-          <div className="flex-1 overflow-y-auto p-5">
-            {tab === 'models' ? <ModelsTab /> : null}
-            {tab === 'appearance' ? <AppearanceTab /> : null}
-            {tab === 'storage' ? <StorageTab /> : null}
-            {tab === 'advanced' ? <AdvancedTab /> : null}
-          </div>
+        <section className="flex flex-col min-h-0 overflow-y-auto p-5">
+          {tab === 'models' ? <ModelsTab /> : null}
+          {tab === 'appearance' ? <AppearanceTab /> : null}
+          {tab === 'storage' ? <StorageTab /> : null}
+          {tab === 'advanced' ? <AdvancedTab /> : null}
         </section>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -768,13 +768,16 @@ function ModelsTab() {
  *   1. Persists it via the IPC bridge (writes to disk on the main process)
  *   2. Changes the active i18next language so React components re-render
  *
+ * Requires a connected `localeApi` — callers must guard against a missing
+ * bridge before invoking this function.
+ *
  * Exported so it can be unit-tested without a DOM.
  */
 export async function applyLocaleChange(
   locale: string,
-  localeApi: { set: (locale: string) => Promise<string> } | undefined,
+  localeApi: { set: (locale: string) => Promise<string> },
 ): Promise<string> {
-  const persisted = localeApi ? await localeApi.set(locale) : locale;
+  const persisted = await localeApi.set(locale);
   const applied = await applyLocale(persisted);
   return applied;
 }
@@ -800,14 +803,21 @@ function AppearanceTab() {
   }, [pushToast]);
 
   async function handleLocaleChange(v: string) {
-    if (!window.codesign) return;
+    if (!window.codesign?.locale) {
+      pushToast({
+        variant: 'error',
+        title: 'Failed to save language preference',
+        description: 'Renderer is not connected to the main process.',
+      });
+      return;
+    }
     try {
       const applied = await applyLocaleChange(v, window.codesign.locale);
       setLocale(applied);
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language',
+        title: 'Failed to save language preference',
         description: err instanceof Error ? err.message : 'Unknown error',
       });
     }

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -71,7 +71,7 @@ export function TopBar() {
   const previewHtml = useCodesignStore((s) => s.previewHtml);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const errorMessage = useCodesignStore((s) => s.errorMessage);
-  const openSettings = useCodesignStore((s) => s.openSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
 
   let crumb = t('preview.noDesign');
@@ -104,7 +104,11 @@ export function TopBar() {
           <LanguageToggle />
           <ThemeToggle />
           <Tooltip label={t('commands.tooltips.settings')}>
-            <IconButton label={t('commands.items.openSettings')} size="sm" onClick={openSettings}>
+            <IconButton
+              label={t('commands.items.openSettings')}
+              size="sm"
+              onClick={() => setView('settings')}
+            >
               <SettingsIcon className="w-[var(--size-icon-md)] h-[var(--size-icon-md)]" />
             </IconButton>
           </Tooltip>

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -229,3 +229,52 @@ describe('useCodesignStore generation cancellation', () => {
     });
   });
 });
+
+describe('useCodesignStore view navigation', () => {
+  it('starts on workspace view', () => {
+    expect(useCodesignStore.getState().view).toBe('workspace');
+  });
+
+  it('setView("settings") switches to settings and closes command palette', () => {
+    useCodesignStore.setState({ commandPaletteOpen: true });
+    useCodesignStore.getState().setView('settings');
+    expect(useCodesignStore.getState().view).toBe('settings');
+    expect(useCodesignStore.getState().commandPaletteOpen).toBe(false);
+  });
+
+  it('setView("workspace") switches back from settings', () => {
+    useCodesignStore.getState().setView('settings');
+    useCodesignStore.getState().setView('workspace');
+    expect(useCodesignStore.getState().view).toBe('workspace');
+  });
+
+  it('sendPrompt uses the active provider from config after setActiveProvider updates config', async () => {
+    const generate = vi.fn(() =>
+      Promise.resolve({ artifacts: [{ content: '<html></html>' }], message: 'Done.' }),
+    );
+
+    vi.stubGlobal('window', { codesign: { generate }, setTimeout });
+
+    const openaiConfig: OnboardingState = {
+      hasKey: true,
+      provider: 'openai',
+      modelPrimary: 'gpt-4o',
+      modelFast: 'gpt-4o-mini',
+      baseUrl: null,
+      designSystem: null,
+    };
+
+    // Simulate setActiveProvider result updating the store config.
+    useCodesignStore.getState().completeOnboarding(openaiConfig);
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'make a button' });
+
+    expect(generate).toHaveBeenCalledOnce();
+    const call = generate.mock.calls[0] as unknown as [
+      { model: { provider: string; modelId: string } },
+    ];
+    const payload = call[0];
+    expect(payload.model.provider).toBe('openai');
+    expect(payload.model.modelId).toBe('gpt-4o');
+  });
+});

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -247,6 +247,59 @@ describe('useCodesignStore view navigation', () => {
     useCodesignStore.getState().setView('workspace');
     expect(useCodesignStore.getState().view).toBe('workspace');
   });
+});
+
+// Simulate the escape handler logic from App.tsx to verify priority:
+//   commandPaletteOpen → close palette (view unchanged)
+//   palette closed + view=settings → go to workspace
+function pressEscape(
+  view: ReturnType<typeof useCodesignStore.getState>['view'],
+  commandPaletteOpen: boolean,
+): void {
+  const store = useCodesignStore.getState();
+  if (commandPaletteOpen) {
+    store.closeCommandPalette();
+    return;
+  }
+  if (view === 'settings') {
+    store.setView('workspace');
+  }
+}
+
+describe('ESC key priority: command palette > settings view', () => {
+  it('ESC closes command palette without leaving settings when both are open', () => {
+    useCodesignStore.setState({ view: 'settings', commandPaletteOpen: true });
+    pressEscape('settings', true);
+
+    const s = useCodesignStore.getState();
+    expect(s.commandPaletteOpen).toBe(false);
+    // view must stay on settings — the palette consumed the keypress
+    expect(s.view).toBe('settings');
+  });
+
+  it('ESC navigates back to workspace when palette is closed and view is settings', () => {
+    useCodesignStore.setState({ view: 'settings', commandPaletteOpen: false });
+    pressEscape('settings', false);
+
+    const s = useCodesignStore.getState();
+    expect(s.view).toBe('workspace');
+    expect(s.commandPaletteOpen).toBe(false);
+  });
+
+  it('ESC is a no-op when palette is closed and view is workspace', () => {
+    useCodesignStore.setState({ view: 'workspace', commandPaletteOpen: false });
+    pressEscape('workspace', false);
+
+    const s = useCodesignStore.getState();
+    expect(s.view).toBe('workspace');
+    expect(s.commandPaletteOpen).toBe(false);
+  });
+});
+
+describe('useCodesignStore active provider routing', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
 
   it('sendPrompt uses the active provider from config after setActiveProvider updates config', async () => {
     const generate = vi.fn(() =>

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -45,6 +45,7 @@ export interface ConnectionStatus {
 }
 
 export type Theme = 'light' | 'dark';
+export type AppView = 'workspace' | 'settings';
 
 interface PromptRequest {
   prompt: string;
@@ -67,7 +68,7 @@ interface CodesignState {
   connectionStatus: ConnectionStatus;
 
   theme: Theme;
-  settingsOpen: boolean;
+  view: AppView;
   commandPaletteOpen: boolean;
   toasts: Toast[];
   iframeErrors: string[];
@@ -106,8 +107,7 @@ interface CodesignState {
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
-  openSettings: () => void;
-  closeSettings: () => void;
+  setView: (view: AppView) => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
 
@@ -292,7 +292,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   connectionStatus: { state: 'no_provider', lastTestedAt: null, lastError: null },
 
   theme: readInitialTheme(),
-  settingsOpen: false,
+  view: 'workspace' as AppView,
   commandPaletteOpen: false,
   toasts: [],
   iframeErrors: [],
@@ -608,15 +608,12 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     get().setTheme(next);
   },
 
-  openSettings() {
-    set({ settingsOpen: true, commandPaletteOpen: false });
-  },
-  closeSettings() {
-    set({ settingsOpen: false });
+  setView(view) {
+    set({ view, commandPaletteOpen: false });
   },
 
   openCommandPalette() {
-    set({ commandPaletteOpen: true, settingsOpen: false });
+    set({ commandPaletteOpen: true });
   },
   closeCommandPalette() {
     set({ commandPaletteOpen: false });

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -274,7 +274,8 @@
     "rendererDisconnected": "Renderer is not connected to the main process.",
     "onboardingIncomplete": "Onboarding is not complete.",
     "modelListFailed": "Could not load model list.",
-    "unknown": "Unknown error"
+    "unknown": "Unknown error",
+    "localePersistFailed": "Failed to save language preference"
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -83,6 +83,69 @@
       "storage": "Storage",
       "advanced": "Advanced"
     },
+    "shell": {
+      "back": "Workspace",
+      "backAria": "Back to workspace"
+    },
+    "common": {
+      "loading": "Loading\u2026",
+      "cancel": "Cancel",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "open": "Open",
+      "unknownError": "Unknown error"
+    },
+    "providers": {
+      "sectionTitle": "API Providers",
+      "addProvider": "Add provider",
+      "empty": "No providers configured yet. Add one to start generating.",
+      "active": "Active",
+      "decryptionFailed": "Decryption failed",
+      "setActive": "Set active",
+      "reEnterKey": "Re-enter key",
+      "confirm": "Confirm",
+      "deleteAria": "Delete {{label}} provider",
+      "primary": "Primary",
+      "fast": "Fast",
+      "modal": {
+        "title": "Add provider",
+        "provider": "Provider",
+        "apiKey": "API Key",
+        "getKey": "Get key \u2197",
+        "apiKeyPlaceholder": "sk-...",
+        "validate": "Validate",
+        "validating": "Validating\u2026",
+        "valid": "Valid",
+        "baseUrl": "Base URL",
+        "baseUrlOptional": "(optional)",
+        "baseUrlPlaceholder": "https://your-proxy.example.com",
+        "primaryModel": "Primary model",
+        "fastModel": "Fast model",
+        "save": "Save provider"
+      },
+      "toast": {
+        "loadFailed": "Failed to load providers",
+        "removed": "Provider removed",
+        "deleteFailed": "Delete failed",
+        "switchedTo": "Switched to {{label}}",
+        "switchFailed": "Switch failed",
+        "saved": "Provider saved",
+        "modelSaveFailed": "Failed to save model selection"
+      }
+    },
+    "appearance": {
+      "themeTitle": "Theme",
+      "themeHint": "Choice persists across restarts.",
+      "lightLabel": "Light",
+      "lightDesc": "Warm beige, soft shadows",
+      "darkLabel": "Dark",
+      "darkDesc": "Deep neutral, low glare",
+      "languageLabel": "Language",
+      "languageHint": "Language changes take effect immediately.",
+      "languageLoadFailed": "Failed to load language",
+      "langEn": "English",
+      "langZhCN": "\u4e2d\u6587 (\u7b80\u4f53)"
+    },
     "language": {
       "label": "Language",
       "system": "System default"
@@ -92,6 +155,35 @@
       "light": "Light",
       "dark": "Dark",
       "system": "System"
+    },
+    "storage": {
+      "pathsTitle": "Paths",
+      "config": "Config",
+      "logs": "Logs",
+      "data": "Data directory",
+      "onboardingTitle": "Onboarding",
+      "onboardingHint": "Clear the setup flag so the onboarding wizard runs again on next launch.",
+      "resetConfirm": "This will remove your saved keys. Continue?",
+      "reset": "Reset",
+      "resetButton": "Reset onboarding",
+      "pathsLoadFailed": "Failed to load app paths",
+      "openFolderFailed": "Could not open folder",
+      "onboardingResetToast": "Onboarding reset. Restart the app to re-run setup."
+    },
+    "advanced": {
+      "updateChannel": "Update channel",
+      "updateChannelHint": "Stable: tested releases. Beta: early access (may have bugs).",
+      "stable": "Stable",
+      "beta": "Beta",
+      "timeout": "Generation timeout",
+      "timeoutHint": "Seconds before a generation request is aborted.",
+      "timeoutSeconds": "{{value}} s",
+      "devtools": "Developer tools",
+      "devtoolsHint": "Open the Chromium DevTools panel for the renderer.",
+      "toggleDevtools": "Toggle DevTools",
+      "prefsLoadFailed": "Failed to load preferences",
+      "prefsSaveFailed": "Failed to save preference",
+      "devtoolsFailed": "Could not toggle DevTools"
     }
   },
   "onboarding": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -273,7 +273,8 @@
     "rendererDisconnected": "渲染进程未连接到主进程。",
     "onboardingIncomplete": "引导流程尚未完成。",
     "modelListFailed": "无法加载模型列表。",
-    "unknown": "未知错误"
+    "unknown": "未知错误",
+    "localePersistFailed": "无法保存语言偏好"
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -82,6 +82,69 @@
       "storage": "存储",
       "advanced": "高级"
     },
+    "shell": {
+      "back": "工作区",
+      "backAria": "返回工作区"
+    },
+    "common": {
+      "loading": "加载中\u2026",
+      "cancel": "取消",
+      "copy": "复制",
+      "copied": "已复制",
+      "open": "打开",
+      "unknownError": "未知错误"
+    },
+    "providers": {
+      "sectionTitle": "API 服务",
+      "addProvider": "添加服务",
+      "empty": "还没有配置任何服务，添加一个即可开始生成。",
+      "active": "当前",
+      "decryptionFailed": "解密失败",
+      "setActive": "设为当前",
+      "reEnterKey": "重新输入 Key",
+      "confirm": "确认",
+      "deleteAria": "删除 {{label}} 服务",
+      "primary": "主力",
+      "fast": "快速",
+      "modal": {
+        "title": "添加服务",
+        "provider": "服务商",
+        "apiKey": "API Key",
+        "getKey": "获取 Key \u2197",
+        "apiKeyPlaceholder": "sk-...",
+        "validate": "验证",
+        "validating": "验证中\u2026",
+        "valid": "已通过",
+        "baseUrl": "接入地址",
+        "baseUrlOptional": "（可选）",
+        "baseUrlPlaceholder": "https://your-proxy.example.com",
+        "primaryModel": "主力模型",
+        "fastModel": "快速模型",
+        "save": "保存"
+      },
+      "toast": {
+        "loadFailed": "加载服务列表失败",
+        "removed": "服务已删除",
+        "deleteFailed": "删除失败",
+        "switchedTo": "已切换到 {{label}}",
+        "switchFailed": "切换失败",
+        "saved": "服务已保存",
+        "modelSaveFailed": "保存模型选择失败"
+      }
+    },
+    "appearance": {
+      "themeTitle": "主题",
+      "themeHint": "选择会在重启后保留。",
+      "lightLabel": "浅色",
+      "lightDesc": "暖米色，柔和阴影",
+      "darkLabel": "深色",
+      "darkDesc": "深沉中性，低反光",
+      "languageLabel": "语言",
+      "languageHint": "切换语言会立即生效。",
+      "languageLoadFailed": "加载语言设置失败",
+      "langEn": "English",
+      "langZhCN": "中文 (简体)"
+    },
     "language": {
       "label": "语言",
       "system": "跟随系统"
@@ -91,6 +154,35 @@
       "light": "浅色",
       "dark": "深色",
       "system": "跟随系统"
+    },
+    "storage": {
+      "pathsTitle": "目录",
+      "config": "配置",
+      "logs": "日志",
+      "data": "数据目录",
+      "onboardingTitle": "首次引导",
+      "onboardingHint": "清除引导完成标记，下次启动时会再次运行设置向导。",
+      "resetConfirm": "此操作会删除已保存的 Key，是否继续？",
+      "reset": "重置",
+      "resetButton": "重置引导",
+      "pathsLoadFailed": "加载应用路径失败",
+      "openFolderFailed": "无法打开文件夹",
+      "onboardingResetToast": "引导已重置，重启应用即可重新运行设置。"
+    },
+    "advanced": {
+      "updateChannel": "更新通道",
+      "updateChannelHint": "Stable：稳定版；Beta：抢先体验（可能有 bug）。",
+      "stable": "稳定版",
+      "beta": "测试版",
+      "timeout": "生成超时",
+      "timeoutHint": "超过该秒数后会中止生成请求。",
+      "timeoutSeconds": "{{value}} 秒",
+      "devtools": "开发者工具",
+      "devtoolsHint": "打开渲染进程的 Chromium DevTools 面板。",
+      "toggleDevtools": "切换 DevTools",
+      "prefsLoadFailed": "加载偏好设置失败",
+      "prefsSaveFailed": "保存偏好失败",
+      "devtoolsFailed": "无法切换 DevTools"
     }
   },
   "onboarding": {


### PR DESCRIPTION
## Summary

- Settings changed from modal to full-page view (store.view enum + App.tsx switch, no Router)
- ESC key in settings view goes back to workspace instead of closing a modal
- AddProvider kept as a local modal dialog (makes sense for that flow)
- Audit + fix API config/switching end-to-end chain: \`ActiveModelSelector\` syncs local model state when config prop changes (fixes stale model after re-activate)
- **Part C**: Settings → Appearance language select now actually applies the locale change immediately via \`i18next.changeLanguage\` (not just persist to disk)

## Changes

### Part A — Settings as full-page view
| File | What changed |
|---|---|
| \`store.ts\` | Remove \`settingsOpen\`/\`openSettings\`/\`closeSettings\`; add \`view: AppView\` + \`setView(v)\` |
| \`App.tsx\` | Conditional render \`<Settings />\` vs workspace grid based on \`view\`; no modal overlay |
| \`Settings.tsx\` | Remove modal shell + \`settingsOpen\` guard; add \`← Workspace\` back button; fix \`StorageTab\` to call \`setView('workspace')\` instead of \`closeSettings()\` |
| \`TopBar.tsx\` | Gear button → \`setView('settings')\` |
| \`CommandPalette.tsx\` | Open Settings action → \`setView('settings')\` |

### Part B — API switching pipeline fix
| File | What fixed |
|---|---|
| \`Settings.tsx\` — \`ActiveModelSelector\` | Added \`useEffect\` to sync local \`primary\`/\`fast\` state from \`config\` prop changes (prevents stale model dropdowns after provider switch and re-activate) |

### Part C — Settings Appearance language switch fix
**Root cause**: \`AppearanceTab.handleLocaleChange\` called only \`window.codesign.locale.set()\` (writes to disk) but never called \`i18next.changeLanguage()\`, so React components did not re-render after language selection.

**Fix**: Extract \`applyLocaleChange(locale, localeApi)\` helper that does both:
1. Calls \`localeApi.set(locale)\` → persists to \`~/.config/open-codesign/locale.json\`
2. Calls \`setLocale(persisted)\` (from \`@open-codesign/i18n\`) → calls \`i18next.changeLanguage()\` → all \`useTranslation\` hooks re-render

This matches exactly what \`LanguageToggle.tsx\` does (both paths are now consistent).

## Button / IPC chain audit (Task D)

| # | Entry point | IPC channel | Wired? | Fixed this PR? |
|---|---|---|---|---|
| 1 | Onboarding → provider select + fill key + fill baseUrl + Next | \`onboarding:save-key\` | ✅ | — |
| 2 | Onboarding → Validate key step | \`onboarding:validate-key\` | ✅ | — |
| 3 | Settings → Models → Add provider → Validate | \`onboarding:validate-key\` | ✅ | — |
| 4 | Settings → Models → Add provider → Save | \`settings:v1:add-provider\` | ✅ | — |
| 5 | Settings → Models → ProviderCard → Re-enter key | reuses AddProviderModal → \`settings:v1:add-provider\` | ✅ | — |
| 6 | Settings → Models → ProviderCard → Delete | \`settings:v1:delete-provider\` | ✅ | — |
| 7 | Settings → Models → ProviderCard → Set active | \`settings:v1:set-active-provider\` | ✅ | — |
| 8 | Settings → Models → ActiveModelSelector dropdowns | \`settings:v1:set-active-provider\` (debounced 400ms) | ✅ fixed stale-state | Part B |
| 9 | Settings → Appearance → Theme light/dark buttons | \`localStorage\` + DOM class (no IPC, intentional) | ✅ | — |
| 10 | Settings → Appearance → Language select | \`locale:set\` + \`i18next.changeLanguage\` | ✅ was broken | **Part C** |
| 11 | Settings → Storage → Open folder (Config) | \`settings:v1:open-folder\` | ✅ | — |
| 12 | Settings → Storage → Open folder (Logs) | \`settings:v1:open-folder\` | ✅ | — |
| 13 | Settings → Storage → Open folder (Data) | \`settings:v1:open-folder\` | ✅ | — |
| 14 | Settings → Storage → Reset onboarding | \`settings:v1:reset-onboarding\` + \`onboarding:get-state\` | ✅ | — |
| 15 | Settings → Advanced → Update channel toggle | \`preferences:v1:update\` | ✅ | — |
| 16 | Settings → Advanced → Generation timeout | \`preferences:v1:update\` | ✅ | — |
| 17 | Settings → Advanced → Toggle DevTools | \`settings:v1:toggle-devtools\` | ✅ | — |
| 18 | TopBar → gear button → open Settings | \`setView('settings')\` (no IPC, store action) | was broken (openSettings removed) | **Part A** |
| 19 | TopBar → cmd+k → command palette | \`openCommandPalette()\` (store action) | ✅ | — |
| 20 | TopBar → LanguageToggle | \`locale:set\` + \`i18next.changeLanguage\` | ✅ | — |
| 21 | TopBar → ThemeToggle | \`localStorage\` + DOM class | ✅ | — |
| 22 | CommandPalette → Open Settings | \`setView('settings')\` (store action) | was broken (openSettings removed) | **Part A** |
| 23 | Sidebar → Send button / Cmd+Enter | \`codesign:v1:generate\` | ✅ | — |
| 24 | Sidebar → Stop/Cancel button | \`codesign:v1:cancel-generation\` | ✅ | — |
| 25 | Sidebar → Attach files (Paperclip) | \`codesign:pick-input-files\` | ✅ | — |
| 26 | Sidebar → Reference URL input | no IPC (passed as arg to generate) | ✅ | — |
| 27 | Sidebar → Design system entry (Link2) | \`codesign:pick-design-system-directory\` | ✅ | — |
| 28 | Preview → ErrorState retry button | \`retryLastPrompt()\` → \`codesign:v1:generate\` | ✅ | — |
| 29 | Preview → CanvasErrorBar dismiss | \`clearIframeErrors()\` (store action) | ✅ | — |

**Summary**: 3 broken entries found and fixed in this PR (entries 8, 10, 18/22). No TODO-for-later items; all regressions are addressed here.

## Test plan
- [x] \`pnpm typecheck\` — clean (10/10 packages)
- [x] \`pnpm lint\` — clean (0 errors, 6 pre-existing complexity warnings unchanged)
- [x] all tests — 48/48 pass (+7 new tests vs base)

### New tests added
- \`store.test.ts\`: \`setView("settings")\` switches view + closes command palette
- \`store.test.ts\`: \`setView("workspace")\` round-trip
- \`store.test.ts\`: \`sendPrompt\` uses updated provider/model after \`completeOnboarding\`
- \`onboarding-ipc.test.ts\`: \`getApiKeyForProvider\` returns decrypted key when secret exists
- \`onboarding-ipc.test.ts\`: \`getApiKeyForProvider\` throws on missing provider secret
- \`Settings.test.ts\`: \`applyLocaleChange\` calls IPC set then i18next changeLanguage
- \`Settings.test.ts\`: \`applyLocaleChange\` skips IPC and applies locale directly when no API provided

### Manual verification steps
- [ ] Gear button → full-page Settings appears (no modal overlay)
- [ ] \`← Workspace\` button returns to main view
- [ ] ESC in settings → returns to workspace
- [ ] Mod+, opens settings page
- [ ] Command palette "Open Settings" → settings page
- [ ] Add provider → appears in list
- [ ] "Set active" → store config updates, active badge moves to new provider
- [ ] Send prompt after switching provider → uses correct provider/key/baseUrl
- [ ] Settings → Appearance → change language → UI immediately reflects new locale (no app restart needed for the live switch; restart still needed to persist for next boot)

## Compatibility ✅ | Upgradeability ✅ | No bloat ✅ | Elegance ✅