### PR TITLE
feat(desktop): Snapshots SQLite schema + IPC handlers (PR-A)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "@open-codesign/shared": "workspace:*",
     "@open-codesign/templates": "workspace:*",
     "@open-codesign/ui": "workspace:*",
+    "better-sqlite3": "^11.0.0",
     "electron-log": "^5",
     "electron-updater": "^6.3.9",
     "lucide-react": "^0.460.0",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,7 +31,7 @@ import { registerPreferencesIpc } from './preferences-ipc';
 import { preparePromptContext } from './prompt-context';
 import { resolveActiveModel } from './provider-settings';
 import { safeInitSnapshotsDb } from './snapshots-db';
-import { registerSnapshotsIpc } from './snapshots-ipc';
+import { registerSnapshotsIpc, registerSnapshotsUnavailableIpc } from './snapshots-ipc';
 
 let mainWindow: ElectronBrowserWindow | null = null;
 
@@ -452,6 +452,10 @@ void app.whenReady().then(async () => {
       message: dbResult.error.message,
       stack: dbResult.error.stack,
     });
+    // Install stub handlers so renderer-side calls reject with a typed
+    // SNAPSHOTS_UNAVAILABLE CodesignError instead of Electron's opaque
+    // "No handler registered" rejection — see snapshots-ipc.ts.
+    registerSnapshotsUnavailableIpc(dbResult.error.message);
     dialog.showErrorBox(
       'Design history unavailable',
       `Could not open the local snapshots database. Version history will be disabled for this session.\n\n${dbResult.error.message}`,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -30,7 +30,7 @@ import {
 import { registerPreferencesIpc } from './preferences-ipc';
 import { preparePromptContext } from './prompt-context';
 import { resolveActiveModel } from './provider-settings';
-import { initSnapshotsDb } from './snapshots-db';
+import { safeInitSnapshotsDb } from './snapshots-db';
 import { registerSnapshotsIpc } from './snapshots-ipc';
 
 let mainWindow: ElectronBrowserWindow | null = null;
@@ -439,14 +439,30 @@ function setupAutoUpdater(): void {
 void app.whenReady().then(async () => {
   initLogger();
   await loadConfigOnBoot();
-  const snapshotsDb = initSnapshotsDb(join(app.getPath('userData'), 'designs.db'));
+  // Snapshot persistence is best-effort at boot — a failure here (corrupt DB,
+  // permission denied, missing native binding) must NOT block the BrowserWindow
+  // from opening. Surface it via an error dialog and skip registering the
+  // snapshots IPC channels; the rest of the app stays usable.
+  const dbResult = safeInitSnapshotsDb(join(app.getPath('userData'), 'designs.db'));
+  if (dbResult.ok) {
+    registerSnapshotsIpc(dbResult.db);
+  } else {
+    const bootLog = getLogger('main:boot');
+    bootLog.error('snapshotsDb.init.fail', {
+      message: dbResult.error.message,
+      stack: dbResult.error.stack,
+    });
+    dialog.showErrorBox(
+      'Design history unavailable',
+      `Could not open the local snapshots database. Version history will be disabled for this session.\n\n${dbResult.error.message}`,
+    );
+  }
   registerIpcHandlers();
   registerLocaleIpc();
   registerConnectionIpc();
   registerOnboardingIpc();
   registerPreferencesIpc();
   registerExporterIpc(() => mainWindow);
-  registerSnapshotsIpc(snapshotsDb);
   setupAutoUpdater();
   createWindow();
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -30,6 +30,8 @@ import {
 import { registerPreferencesIpc } from './preferences-ipc';
 import { preparePromptContext } from './prompt-context';
 import { resolveActiveModel } from './provider-settings';
+import { initSnapshotsDb } from './snapshots-db';
+import { registerSnapshotsIpc } from './snapshots-ipc';
 
 let mainWindow: ElectronBrowserWindow | null = null;
 
@@ -437,12 +439,14 @@ function setupAutoUpdater(): void {
 void app.whenReady().then(async () => {
   initLogger();
   await loadConfigOnBoot();
+  const snapshotsDb = initSnapshotsDb(join(app.getPath('userData'), 'designs.db'));
   registerIpcHandlers();
   registerLocaleIpc();
   registerConnectionIpc();
   registerOnboardingIpc();
   registerPreferencesIpc();
   registerExporterIpc(() => mainWindow);
+  registerSnapshotsIpc(snapshotsDb);
   setupAutoUpdater();
   createWindow();
 

--- a/apps/desktop/src/main/snapshots-db.safe.test.ts
+++ b/apps/desktop/src/main/snapshots-db.safe.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Boot-time guard: when better-sqlite3 fails to open the file (corrupt DB,
+ * missing directory, permission denied, etc.) safeInitSnapshotsDb must
+ * capture the error instead of rethrowing — otherwise the failure would
+ * reject app.whenReady() and prevent the BrowserWindow from opening.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { safeInitSnapshotsDb } from './snapshots-db';
+
+describe('safeInitSnapshotsDb', () => {
+  it('returns { ok: false, error } when better-sqlite3 throws — does not rethrow', () => {
+    // Pointing at a path inside a directory that does not exist makes
+    // better-sqlite3 throw synchronously on open. The wrapper must catch
+    // it so app boot can proceed without snapshots.
+    const result = safeInitSnapshotsDb('/nonexistent-dir-for-test/designs.db');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure path');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for snapshots-db.ts using an in-memory SQLite instance.
+ *
+ * No Electron, no filesystem — just better-sqlite3 :memory:.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createDesign,
+  createSnapshot,
+  deleteSnapshot,
+  getSnapshot,
+  initInMemoryDb,
+  listDesigns,
+  listSnapshots,
+} from './snapshots-db';
+
+function makeDb() {
+  return initInMemoryDb();
+}
+
+// ---------------------------------------------------------------------------
+// designs
+// ---------------------------------------------------------------------------
+
+describe('createDesign + listDesigns', () => {
+  it('creates a design with defaults and returns it via listDesigns', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    expect(d.schemaVersion).toBe(1);
+    expect(d.name).toBe('Untitled design');
+    expect(typeof d.id).toBe('string');
+    expect(d.id.length).toBeGreaterThan(0);
+    expect(d.createdAt).toBeTruthy();
+    expect(d.updatedAt).toBeTruthy();
+
+    const list = listDesigns(db);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe(d.id);
+  });
+
+  it('creates a design with a custom name', () => {
+    const db = makeDb();
+    const d = createDesign(db, 'My landing page');
+    expect(d.name).toBe('My landing page');
+  });
+
+  it('orders designs by created_at DESC (most recent first)', () => {
+    const db = makeDb();
+    // Insert with a small delay via overriding created_at via raw SQL to guarantee ordering.
+    const idA = 'aaaa-design';
+    const idB = 'bbbb-design';
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    ).run(idA, 'A', '2024-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z');
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    ).run(idB, 'B', '2024-01-02T00:00:00.000Z', '2024-01-02T00:00:00.000Z');
+
+    const list = listDesigns(db);
+    const ids = list.map((d) => d.id);
+    // B was created on day 2, A on day 1 — B should come first (DESC).
+    expect(ids.indexOf(idB)).toBeLessThan(ids.indexOf(idA));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots
+// ---------------------------------------------------------------------------
+
+describe('createSnapshot + listSnapshots', () => {
+  it('creates an initial snapshot and lists it', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    const snap = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: 'Create a landing page',
+      artifactType: 'html',
+      artifactSource: '<html>v1</html>',
+    });
+
+    expect(snap.schemaVersion).toBe(1);
+    expect(snap.designId).toBe(design.id);
+    expect(snap.parentId).toBeNull();
+    expect(snap.type).toBe('initial');
+    expect(snap.artifactSource).toBe('<html>v1</html>');
+    expect(snap.createdAt).toBeTruthy();
+
+    const list = listSnapshots(db, design.id);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe(snap.id);
+  });
+
+  it('lists snapshots ordered by created_at DESC', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    // Insert with explicit timestamps to avoid sub-millisecond collisions.
+    const insertSnap = (at: string, parentId: string | null, type: 'initial' | 'edit', prompt: string) => {
+      const id = crypto.randomUUID();
+      db.prepare(
+        `INSERT INTO design_snapshots
+           (id, schema_version, design_id, parent_id, type, prompt, artifact_type, artifact_source, created_at, message)
+         VALUES (?, 1, ?, ?, ?, ?, 'html', '<html/>', ?, NULL)`,
+      ).run(id, design.id, parentId, type, prompt, at);
+      return id;
+    };
+    const id1 = insertSnap('2024-01-01T00:00:00.000Z', null, 'initial', 'v1');
+    const id2 = insertSnap('2024-01-02T00:00:00.000Z', id1, 'edit', 'v2');
+    const id3 = insertSnap('2024-01-03T00:00:00.000Z', id2, 'edit', 'v3');
+
+    const list = listSnapshots(db, design.id);
+    expect(list).toHaveLength(3);
+    // Most recent first.
+    expect(list[0]?.id).toBe(id3);
+    expect(list[1]?.id).toBe(id2);
+    expect(list[2]?.id).toBe(id1);
+  });
+
+  it('builds a parent_id chain: initial → edit → edit', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    const s1 = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html>v1</html>',
+    });
+    const s2 = createSnapshot(db, {
+      designId: design.id,
+      parentId: s1.id,
+      type: 'edit',
+      prompt: 'tweak 1',
+      artifactType: 'html',
+      artifactSource: '<html>v2</html>',
+    });
+    const s3 = createSnapshot(db, {
+      designId: design.id,
+      parentId: s2.id,
+      type: 'edit',
+      prompt: 'tweak 2',
+      artifactType: 'html',
+      artifactSource: '<html>v3</html>',
+    });
+
+    expect(s1.parentId).toBeNull();
+    expect(s2.parentId).toBe(s1.id);
+    expect(s3.parentId).toBe(s2.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSnapshot
+// ---------------------------------------------------------------------------
+
+describe('getSnapshot', () => {
+  it('returns the snapshot by id', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    const snap = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'svg',
+      artifactSource: '<svg/>',
+    });
+
+    const found = getSnapshot(db, snap.id);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(snap.id);
+    expect(found?.artifactType).toBe('svg');
+  });
+
+  it('returns null for an unknown id', () => {
+    const db = makeDb();
+    expect(getSnapshot(db, 'does-not-exist')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSnapshot
+// ---------------------------------------------------------------------------
+
+describe('deleteSnapshot', () => {
+  it('deletes a snapshot so it no longer appears in listSnapshots', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    const snap = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+
+    expect(listSnapshots(db, design.id)).toHaveLength(1);
+    deleteSnapshot(db, snap.id);
+    expect(listSnapshots(db, design.id)).toHaveLength(0);
+    expect(getSnapshot(db, snap.id)).toBeNull();
+  });
+
+  it('is idempotent — deleting a non-existent id does not throw', () => {
+    const db = makeDb();
+    expect(() => deleteSnapshot(db, 'ghost-id')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FK cascade: deleting a design removes all its snapshots
+// ---------------------------------------------------------------------------
+
+describe('FK cascade on design delete', () => {
+  it('removes snapshots when parent design is deleted', () => {
+    const db = makeDb();
+    // PRAGMA foreign_keys must be ON for cascade to fire.
+    db.pragma('foreign_keys = ON');
+
+    const design = createDesign(db);
+    createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    expect(listSnapshots(db, design.id)).toHaveLength(1);
+
+    db.prepare('DELETE FROM designs WHERE id = ?').run(design.id);
+    expect(listSnapshots(db, design.id)).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -220,10 +220,8 @@ describe('deleteSnapshot', () => {
 // ---------------------------------------------------------------------------
 
 describe('FK cascade on design delete', () => {
-  it('removes snapshots when parent design is deleted', () => {
+  it('removes snapshots when parent design is deleted (foreign_keys ON by default)', () => {
     const db = makeDb();
-    // PRAGMA foreign_keys must be ON for cascade to fire.
-    db.pragma('foreign_keys = ON');
 
     const design = createDesign(db);
     createSnapshot(db, {
@@ -238,5 +236,62 @@ describe('FK cascade on design delete', () => {
 
     db.prepare('DELETE FROM designs WHERE id = ?').run(design.id);
     expect(listSnapshots(db, design.id)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parent FK SET NULL: deleting a middle snapshot nulls its children's parent_id
+// ---------------------------------------------------------------------------
+
+describe('parent FK SET NULL on snapshot delete', () => {
+  it('nulls child parent_id when the parent snapshot is deleted', () => {
+    const db = makeDb();
+    const design = createDesign(db);
+    const s1 = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html>v1</html>',
+    });
+    const s2 = createSnapshot(db, {
+      designId: design.id,
+      parentId: s1.id,
+      type: 'edit',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html>v2</html>',
+    });
+
+    deleteSnapshot(db, s1.id);
+    const reloaded = getSnapshot(db, s2.id);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.parentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listDesigns sort order: most recently active first
+// ---------------------------------------------------------------------------
+
+describe('listDesigns activity sort', () => {
+  it('surfaces a design whose updated_at is newer than another design created later', () => {
+    const db = makeDb();
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    ).run('older', 'A', '2024-01-01T00:00:00.000Z', '2024-01-01T00:00:00.000Z');
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    ).run('newer', 'B', '2024-01-02T00:00:00.000Z', '2024-01-02T00:00:00.000Z');
+
+    // Bump the older design's activity past the newer one.
+    db.prepare('UPDATE designs SET updated_at = ? WHERE id = ?').run(
+      '2024-01-03T00:00:00.000Z',
+      'older',
+    );
+
+    const ids = listDesigns(db).map((d) => d.id);
+    expect(ids.indexOf('older')).toBeLessThan(ids.indexOf('newer'));
   });
 });

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -97,7 +97,12 @@ describe('createSnapshot + listSnapshots', () => {
     const db = makeDb();
     const design = createDesign(db);
     // Insert with explicit timestamps to avoid sub-millisecond collisions.
-    const insertSnap = (at: string, parentId: string | null, type: 'initial' | 'edit', prompt: string) => {
+    const insertSnap = (
+      at: string,
+      parentId: string | null,
+      type: 'initial' | 'edit',
+      prompt: string,
+    ) => {
       const id = crypto.randomUUID();
       db.prepare(
         `INSERT INTO design_snapshots

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -59,9 +59,37 @@ function applySchema(db: Database): void {
 /** Initialize and return the singleton DB instance for production use. */
 export function initSnapshotsDb(dbPath: string): Database {
   if (singleton) return singleton;
-  singleton = openDatabase(dbPath);
-  applySchema(singleton);
+  const db = openDatabase(dbPath);
+  try {
+    applySchema(db);
+  } catch (cause) {
+    // Don't cache a half-open DB — let the next caller retry from scratch.
+    try {
+      db.close();
+    } catch {
+      /* swallow secondary close failure */
+    }
+    throw cause;
+  }
+  singleton = db;
   return singleton;
+}
+
+/**
+ * Boot-time wrapper that never throws. Returns either the live DB or the
+ * underlying error, so the caller can degrade gracefully without blocking
+ * the BrowserWindow from opening when snapshot persistence is unavailable
+ * (e.g. corrupt file, permission denied, native binding missing).
+ */
+export function safeInitSnapshotsDb(
+  dbPath: string,
+): { ok: true; db: Database } | { ok: false; error: Error } {
+  try {
+    return { ok: true, db: initSnapshotsDb(dbPath) };
+  } catch (cause) {
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    return { ok: false, error };
+  }
 }
 
 /** For use in Vitest tests only — returns a fresh isolated in-memory instance. */

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -25,6 +25,9 @@ function openDatabase(path: string, options?: BetterSqlite3.Options): Database {
 }
 
 function applySchema(db: Database): void {
+  // foreign_keys is a per-connection pragma and defaults to OFF; enabling it
+  // here is what makes the ON DELETE CASCADE / SET NULL clauses below actually fire.
+  db.pragma('foreign_keys = ON');
   db.pragma('journal_mode = WAL');
   db.exec(`
     CREATE TABLE IF NOT EXISTS designs (
@@ -39,7 +42,7 @@ function applySchema(db: Database): void {
       id             TEXT PRIMARY KEY,
       schema_version INTEGER NOT NULL DEFAULT 1,
       design_id      TEXT NOT NULL REFERENCES designs(id) ON DELETE CASCADE,
-      parent_id      TEXT,
+      parent_id      TEXT REFERENCES design_snapshots(id) ON DELETE SET NULL,
       type           TEXT NOT NULL CHECK(type IN ('initial','edit','fork')),
       prompt         TEXT,
       artifact_type  TEXT NOT NULL CHECK(artifact_type IN ('html','react','svg')),
@@ -137,9 +140,13 @@ export function createDesign(db: Database, name = 'Untitled design'): Design {
 }
 
 export function listDesigns(db: Database): Design[] {
-  return (db.prepare('SELECT * FROM designs ORDER BY created_at DESC').all() as DesignRow[]).map(
-    rowToDesign,
-  );
+  // updated_at bumps on each new snapshot, so recently edited designs surface first;
+  // created_at is the tiebreaker for designs that have never been edited.
+  return (
+    db
+      .prepare('SELECT * FROM designs ORDER BY updated_at DESC, created_at DESC')
+      .all() as DesignRow[]
+  ).map(rowToDesign);
 }
 
 export function createSnapshot(db: Database, input: SnapshotCreateInput): DesignSnapshot {

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -1,0 +1,187 @@
+/**
+ * SQLite persistence layer for design snapshots.
+ *
+ * Uses better-sqlite3 (synchronous API — safe in the Electron main process,
+ * which is the only caller). WAL mode for concurrent read performance.
+ *
+ * Call initSnapshotsDb(dbPath) once at app start.
+ * Call initInMemoryDb() in tests to get an isolated in-memory instance.
+ */
+
+import { createRequire } from 'node:module';
+import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign/shared';
+import type BetterSqlite3 from 'better-sqlite3';
+
+// better-sqlite3 is a native module — require() instead of import.
+const require = createRequire(import.meta.url);
+
+type Database = BetterSqlite3.Database;
+
+let singleton: Database | null = null;
+
+function openDatabase(path: string, options?: BetterSqlite3.Options): Database {
+  const Database = require('better-sqlite3') as typeof BetterSqlite3;
+  return new Database(path, options);
+}
+
+function applySchema(db: Database): void {
+  db.pragma('journal_mode = WAL');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS designs (
+      id            TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL DEFAULT 1,
+      name          TEXT NOT NULL DEFAULT 'Untitled design',
+      created_at    TEXT NOT NULL,
+      updated_at    TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS design_snapshots (
+      id             TEXT PRIMARY KEY,
+      schema_version INTEGER NOT NULL DEFAULT 1,
+      design_id      TEXT NOT NULL REFERENCES designs(id) ON DELETE CASCADE,
+      parent_id      TEXT,
+      type           TEXT NOT NULL CHECK(type IN ('initial','edit','fork')),
+      prompt         TEXT,
+      artifact_type  TEXT NOT NULL CHECK(artifact_type IN ('html','react','svg')),
+      artifact_source TEXT NOT NULL,
+      created_at     TEXT NOT NULL,
+      message        TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_snapshots_design_created
+      ON design_snapshots(design_id, created_at DESC);
+  `);
+}
+
+/** Initialize and return the singleton DB instance for production use. */
+export function initSnapshotsDb(dbPath: string): Database {
+  if (singleton) return singleton;
+  singleton = openDatabase(dbPath);
+  applySchema(singleton);
+  return singleton;
+}
+
+/** For use in Vitest tests only — returns a fresh isolated in-memory instance. */
+export function initInMemoryDb(): Database {
+  // ':memory:' as filename creates an in-memory database in better-sqlite3.
+  const db = openDatabase(':memory:');
+  applySchema(db);
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Row types (snake_case columns from SQLite)
+// ---------------------------------------------------------------------------
+
+interface DesignRow {
+  id: string;
+  schema_version: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SnapshotRow {
+  id: string;
+  schema_version: number;
+  design_id: string;
+  parent_id: string | null;
+  type: string;
+  prompt: string | null;
+  artifact_type: string;
+  artifact_source: string;
+  created_at: string;
+  message: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Row → domain type mappers
+// ---------------------------------------------------------------------------
+
+function rowToDesign(row: DesignRow): Design {
+  return {
+    schemaVersion: 1,
+    id: row.id,
+    name: row.name,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToSnapshot(row: SnapshotRow): DesignSnapshot {
+  return {
+    schemaVersion: 1,
+    id: row.id,
+    designId: row.design_id,
+    parentId: row.parent_id,
+    type: row.type as DesignSnapshot['type'],
+    prompt: row.prompt,
+    artifactType: row.artifact_type as DesignSnapshot['artifactType'],
+    artifactSource: row.artifact_source,
+    createdAt: row.created_at,
+    ...(row.message !== null ? { message: row.message } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public DB functions
+// ---------------------------------------------------------------------------
+
+export function createDesign(db: Database, name = 'Untitled design'): Design {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+  ).run(id, name, now, now);
+  return rowToDesign(db.prepare('SELECT * FROM designs WHERE id = ?').get(id) as DesignRow);
+}
+
+export function listDesigns(db: Database): Design[] {
+  return (db.prepare('SELECT * FROM designs ORDER BY created_at DESC').all() as DesignRow[]).map(
+    rowToDesign,
+  );
+}
+
+export function createSnapshot(db: Database, input: SnapshotCreateInput): DesignSnapshot {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO design_snapshots
+       (id, schema_version, design_id, parent_id, type, prompt, artifact_type, artifact_source, created_at, message)
+     VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    input.designId,
+    input.parentId,
+    input.type,
+    input.prompt,
+    input.artifactType,
+    input.artifactSource,
+    now,
+    input.message ?? null,
+  );
+  // Bump the parent design's updated_at so clients can sort designs by activity.
+  db.prepare('UPDATE designs SET updated_at = ? WHERE id = ?').run(now, input.designId);
+  return rowToSnapshot(
+    db.prepare('SELECT * FROM design_snapshots WHERE id = ?').get(id) as SnapshotRow,
+  );
+}
+
+export function listSnapshots(db: Database, designId: string): DesignSnapshot[] {
+  return (
+    db
+      .prepare('SELECT * FROM design_snapshots WHERE design_id = ? ORDER BY created_at DESC')
+      .all(designId) as SnapshotRow[]
+  ).map(rowToSnapshot);
+}
+
+export function getSnapshot(db: Database, id: string): DesignSnapshot | null {
+  const row = db.prepare('SELECT * FROM design_snapshots WHERE id = ?').get(id) as
+    | SnapshotRow
+    | undefined;
+  return row ? rowToSnapshot(row) : null;
+}
+
+export function deleteSnapshot(db: Database, id: string): void {
+  db.prepare('DELETE FROM design_snapshots WHERE id = ?').run(id);
+}

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -226,6 +226,45 @@ describe('snapshots:v1:create', () => {
 });
 
 // ---------------------------------------------------------------------------
+// snapshots:v1:create-design
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:create-design', () => {
+  it('creates a design with the trimmed name', () => {
+    const result = call('snapshots:v1:create-design', '  My design  ') as Record<string, unknown>;
+    expect(result['name']).toBe('My design');
+    expect(typeof result['id']).toBe('string');
+  });
+
+  it('rejects undefined with IPC_BAD_INPUT (no silent default)', () => {
+    expect(() => call('snapshots:v1:create-design', undefined)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create-design', undefined);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects an empty / whitespace-only string with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:create-design', '   ')).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create-design', '');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects a non-string payload with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:create-design', { name: 'x' })).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create-design', 42);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // snapshots:v1:get
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -327,3 +327,97 @@ describe('snapshots:v1:delete', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// SQLite error translation
+//
+// Stubs better-sqlite3's prepare() to throw an Error carrying the SqliteError
+// .code property and asserts each known code maps to the documented IPC code.
+// Renderer must never see the raw "SqliteError: SQLITE_..." string.
+// ---------------------------------------------------------------------------
+
+describe('SQLite error translation', () => {
+  function withDbThrowing(code: string, fn: () => unknown): unknown {
+    const original = db.prepare.bind(db);
+    const err = Object.assign(new Error(`${code}: synthetic`), { code });
+    // Throw on the INSERT used by createSnapshot; pass through every other prepare.
+    (db as unknown as { prepare: (sql: string) => unknown }).prepare = (sql: string) => {
+      if (sql.trim().startsWith('INSERT INTO design_snapshots')) {
+        throw err;
+      }
+      return original(sql);
+    };
+    try {
+      return fn();
+    } finally {
+      (db as unknown as { prepare: typeof original }).prepare = original;
+    }
+  }
+
+  function attemptCreate(): unknown {
+    const design = createDesign(db);
+    return call('snapshots:v1:create', {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+  }
+
+  it('translates SQLITE_CONSTRAINT_FOREIGNKEY to IPC_BAD_INPUT', () => {
+    try {
+      withDbThrowing('SQLITE_CONSTRAINT_FOREIGNKEY', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+      expect((err as Error).message).toBe('Parent snapshot does not exist');
+      expect((err as Error).message).not.toMatch(/SQLITE_/);
+    }
+  });
+
+  it('translates SQLITE_BUSY to IPC_DB_BUSY', () => {
+    try {
+      withDbThrowing('SQLITE_BUSY', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_DB_BUSY');
+      expect((err as Error).message).toBe('Database is locked, retry shortly');
+    }
+  });
+
+  it('translates SQLITE_LOCKED to IPC_DB_BUSY', () => {
+    try {
+      withDbThrowing('SQLITE_LOCKED', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_DB_BUSY');
+    }
+  });
+
+  it('translates SQLITE_FULL to IPC_DB_FULL', () => {
+    try {
+      withDbThrowing('SQLITE_FULL', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_DB_FULL');
+      expect((err as Error).message).toBe('Disk is full');
+    }
+  });
+
+  it('translates unknown SQLite errors to IPC_DB_ERROR with no leak', () => {
+    try {
+      withDbThrowing('SQLITE_CORRUPT', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_DB_ERROR');
+      expect((err as Error).message).not.toMatch(/SQLITE_/);
+      // Original error preserved for server-side logging only.
+      expect((err as Error).cause).toBeDefined();
+    }
+  });
+});

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -28,7 +28,11 @@ vi.mock('./logger', () => ({
 }));
 
 import { createDesign, createSnapshot, initInMemoryDb } from './snapshots-db';
-import { registerSnapshotsIpc } from './snapshots-ipc';
+import {
+  SNAPSHOTS_CHANNELS_V1,
+  registerSnapshotsIpc,
+  registerSnapshotsUnavailableIpc,
+} from './snapshots-ipc';
 
 function call(channel: string, raw: unknown): unknown {
   const fn = handlers.get(channel);
@@ -531,5 +535,47 @@ describe('SQLite error translation', () => {
       // Original error preserved for server-side logging only.
       expect((err as Error).cause).toBeDefined();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerSnapshotsUnavailableIpc — DB init failure path
+//
+// When safeInitSnapshotsDb fails at boot, main/index.ts installs stub handlers
+// instead of skipping registration entirely. Without these, every renderer
+// call to window.codesign.snapshots.* would surface as Electron's opaque
+// "No handler registered" rejection. The stub MUST throw a typed CodesignError
+// with code SNAPSHOTS_UNAVAILABLE so the renderer can branch deterministically.
+// ---------------------------------------------------------------------------
+
+describe('registerSnapshotsUnavailableIpc', () => {
+  beforeEach(() => {
+    handlers.clear();
+    registerSnapshotsUnavailableIpc('disk_full: out of space');
+  });
+
+  for (const channel of SNAPSHOTS_CHANNELS_V1) {
+    it(`${channel} throws SNAPSHOTS_UNAVAILABLE instead of going unhandled`, () => {
+      try {
+        call(channel, { schemaVersion: 1 });
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(CodesignError);
+        expect((err as CodesignError).code).toBe('SNAPSHOTS_UNAVAILABLE');
+        expect((err as Error).message).toMatch(/Snapshots database failed to initialize/);
+        expect((err as Error).message).toMatch(/disk_full: out of space/);
+      }
+    });
+  }
+
+  it('covers exactly the channels registered by registerSnapshotsIpc', () => {
+    handlers.clear();
+    const dbForLive = initInMemoryDb();
+    registerSnapshotsIpc(dbForLive);
+    const live = new Set(handlers.keys());
+    handlers.clear();
+    registerSnapshotsUnavailableIpc('reason');
+    const stubs = new Set(handlers.keys());
+    expect(stubs).toEqual(live);
   });
 });

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -178,6 +178,51 @@ describe('snapshots:v1:create', () => {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
   });
+
+  it('rejects a parentId that does not exist with IPC_BAD_INPUT', () => {
+    const design = createDesign(db);
+    const bad = {
+      designId: design.id,
+      parentId: 'no-such-snapshot',
+      type: 'edit',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    };
+    expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', bad);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects a parentId from a different design with IPC_BAD_INPUT', () => {
+    const designA = createDesign(db);
+    const designB = createDesign(db);
+    const parentInA = createSnapshot(db, {
+      designId: designA.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    const bad = {
+      designId: designB.id,
+      parentId: parentInA.id,
+      type: 'edit',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    };
+    expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', bad);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -408,6 +408,53 @@ describe('SQLite error translation', () => {
     }
   });
 
+  it('translates SQLITE_CONSTRAINT_UNIQUE to IPC_CONFLICT', () => {
+    try {
+      withDbThrowing('SQLITE_CONSTRAINT_UNIQUE', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_CONFLICT');
+      expect((err as Error).message).toBe('Snapshot already exists');
+      expect((err as Error).message).not.toMatch(/SQLITE_/);
+    }
+  });
+
+  it('translates SQLITE_CONSTRAINT_NOTNULL to IPC_BAD_INPUT with neutral message', () => {
+    try {
+      withDbThrowing('SQLITE_CONSTRAINT_NOTNULL', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+      expect((err as Error).message).toBe('Snapshot input violates database constraints');
+      expect((err as Error).message).not.toMatch(/Parent snapshot/);
+    }
+  });
+
+  it('translates SQLITE_CONSTRAINT_CHECK to IPC_BAD_INPUT with neutral message', () => {
+    try {
+      withDbThrowing('SQLITE_CONSTRAINT_CHECK', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+      expect((err as Error).message).toBe('Snapshot input violates database constraints');
+    }
+  });
+
+  it('translates bare SQLITE_CONSTRAINT (no subcode) to generic IPC_DB_ERROR', () => {
+    try {
+      withDbThrowing('SQLITE_CONSTRAINT', attemptCreate);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodesignError);
+      expect((err as CodesignError).code).toBe('IPC_DB_ERROR');
+      expect((err as Error).message).not.toMatch(/Parent snapshot/);
+      expect((err as Error).message).not.toMatch(/SQLITE_/);
+      expect((err as Error).cause).toBeDefined();
+    }
+  });
+
   it('translates unknown SQLite errors to IPC_DB_ERROR with no leak', () => {
     try {
       withDbThrowing('SQLITE_CORRUPT', attemptCreate);

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -36,6 +36,12 @@ function call(channel: string, raw: unknown): unknown {
   return fn(null, raw);
 }
 
+// All snapshots:v1:* object payloads carry schemaVersion: 1; this helper keeps
+// tests focused on the field under test rather than repeating the version field.
+function v1<T extends object>(payload: T): T & { schemaVersion: 1 } {
+  return { schemaVersion: 1, ...payload };
+}
+
 let db: ReturnType<typeof initInMemoryDb>;
 
 beforeEach(() => {
@@ -50,13 +56,13 @@ beforeEach(() => {
 
 describe('snapshots:v1:list-designs', () => {
   it('returns an empty array when no designs exist', () => {
-    const result = call('snapshots:v1:list-designs', undefined);
+    const result = call('snapshots:v1:list-designs', v1({}));
     expect(result).toEqual([]);
   });
 
   it('returns created designs', () => {
     createDesign(db, 'Test design');
-    const result = call('snapshots:v1:list-designs', undefined) as unknown[];
+    const result = call('snapshots:v1:list-designs', v1({})) as unknown[];
     expect(result).toHaveLength(1);
   });
 });
@@ -76,14 +82,14 @@ describe('snapshots:v1:list', () => {
       artifactType: 'html',
       artifactSource: '<html/>',
     });
-    const result = call('snapshots:v1:list', { designId: design.id }) as unknown[];
+    const result = call('snapshots:v1:list', v1({ designId: design.id })) as unknown[];
     expect(result).toHaveLength(1);
   });
 
   it('rejects a missing designId with IPC_BAD_INPUT', () => {
-    expect(() => call('snapshots:v1:list', {})).toThrow(CodesignError);
+    expect(() => call('snapshots:v1:list', v1({}))).toThrow(CodesignError);
     try {
-      call('snapshots:v1:list', {});
+      call('snapshots:v1:list', v1({}));
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
@@ -106,14 +112,14 @@ describe('snapshots:v1:list', () => {
 describe('snapshots:v1:create', () => {
   it('creates and returns a snapshot', () => {
     const design = createDesign(db);
-    const input = {
+    const input = v1({
       designId: design.id,
       parentId: null,
       type: 'initial',
       prompt: 'Build a hero section',
       artifactType: 'html',
       artifactSource: '<html>hero</html>',
-    };
+    });
     const result = call('snapshots:v1:create', input) as Record<string, unknown>;
     expect(result['id']).toBeTruthy();
     expect(result['designId']).toBe(design.id);
@@ -121,13 +127,13 @@ describe('snapshots:v1:create', () => {
   });
 
   it('rejects bad payload (missing designId) with IPC_BAD_INPUT', () => {
-    const bad = {
+    const bad = v1({
       parentId: null,
       type: 'initial',
       prompt: null,
       artifactType: 'html',
       artifactSource: '<html/>',
-    };
+    });
     expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
     try {
       call('snapshots:v1:create', bad);
@@ -137,14 +143,14 @@ describe('snapshots:v1:create', () => {
   });
 
   it('rejects invalid type with IPC_BAD_INPUT', () => {
-    const bad = {
+    const bad = v1({
       designId: 'some-id',
       parentId: null,
       type: 'invalid-type',
       prompt: null,
       artifactType: 'html',
       artifactSource: '<html/>',
-    };
+    });
     expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
     try {
       call('snapshots:v1:create', bad);
@@ -154,14 +160,14 @@ describe('snapshots:v1:create', () => {
   });
 
   it('rejects invalid artifactType with IPC_BAD_INPUT', () => {
-    const bad = {
+    const bad = v1({
       designId: 'some-id',
       parentId: null,
       type: 'edit',
       prompt: null,
       artifactType: 'pptx',
       artifactSource: '<html/>',
-    };
+    });
     expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
     try {
       call('snapshots:v1:create', bad);
@@ -181,14 +187,14 @@ describe('snapshots:v1:create', () => {
 
   it('rejects a parentId that does not exist with IPC_BAD_INPUT', () => {
     const design = createDesign(db);
-    const bad = {
+    const bad = v1({
       designId: design.id,
       parentId: 'no-such-snapshot',
       type: 'edit',
       prompt: null,
       artifactType: 'html',
       artifactSource: '<html/>',
-    };
+    });
     expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
     try {
       call('snapshots:v1:create', bad);
@@ -208,14 +214,14 @@ describe('snapshots:v1:create', () => {
       artifactType: 'html',
       artifactSource: '<html/>',
     });
-    const bad = {
+    const bad = v1({
       designId: designB.id,
       parentId: parentInA.id,
       type: 'edit',
       prompt: null,
       artifactType: 'html',
       artifactSource: '<html/>',
-    };
+    });
     expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
     try {
       call('snapshots:v1:create', bad);
@@ -231,7 +237,10 @@ describe('snapshots:v1:create', () => {
 
 describe('snapshots:v1:create-design', () => {
   it('creates a design with the trimmed name', () => {
-    const result = call('snapshots:v1:create-design', '  My design  ') as Record<string, unknown>;
+    const result = call('snapshots:v1:create-design', v1({ name: '  My design  ' })) as Record<
+      string,
+      unknown
+    >;
     expect(result['name']).toBe('My design');
     expect(typeof result['id']).toBe('string');
   });
@@ -245,19 +254,19 @@ describe('snapshots:v1:create-design', () => {
     }
   });
 
-  it('rejects an empty / whitespace-only string with IPC_BAD_INPUT', () => {
-    expect(() => call('snapshots:v1:create-design', '   ')).toThrow(CodesignError);
+  it('rejects an empty / whitespace-only name with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:create-design', v1({ name: '   ' }))).toThrow(CodesignError);
     try {
-      call('snapshots:v1:create-design', '');
+      call('snapshots:v1:create-design', v1({ name: '' }));
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
   });
 
-  it('rejects a non-string payload with IPC_BAD_INPUT', () => {
-    expect(() => call('snapshots:v1:create-design', { name: 'x' })).toThrow(CodesignError);
+  it('rejects a non-string name with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:create-design', v1({ name: 42 }))).toThrow(CodesignError);
     try {
-      call('snapshots:v1:create-design', 42);
+      call('snapshots:v1:create-design', v1({ name: { wrong: true } }));
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
@@ -270,7 +279,7 @@ describe('snapshots:v1:create-design', () => {
 
 describe('snapshots:v1:get', () => {
   it('returns null for an unknown id', () => {
-    const result = call('snapshots:v1:get', { id: 'ghost' });
+    const result = call('snapshots:v1:get', v1({ id: 'ghost' }));
     expect(result).toBeNull();
   });
 
@@ -284,14 +293,14 @@ describe('snapshots:v1:get', () => {
       artifactType: 'html',
       artifactSource: '<html/>',
     });
-    const result = call('snapshots:v1:get', { id: snap.id }) as Record<string, unknown>;
+    const result = call('snapshots:v1:get', v1({ id: snap.id })) as Record<string, unknown>;
     expect(result['id']).toBe(snap.id);
   });
 
   it('rejects missing id with IPC_BAD_INPUT', () => {
-    expect(() => call('snapshots:v1:get', {})).toThrow(CodesignError);
+    expect(() => call('snapshots:v1:get', v1({}))).toThrow(CodesignError);
     try {
-      call('snapshots:v1:get', {});
+      call('snapshots:v1:get', v1({}));
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
@@ -313,19 +322,72 @@ describe('snapshots:v1:delete', () => {
       artifactType: 'html',
       artifactSource: '<html/>',
     });
-    call('snapshots:v1:delete', { id: snap.id });
-    const result = call('snapshots:v1:get', { id: snap.id });
+    call('snapshots:v1:delete', v1({ id: snap.id }));
+    const result = call('snapshots:v1:get', v1({ id: snap.id }));
     expect(result).toBeNull();
   });
 
   it('rejects missing id with IPC_BAD_INPUT', () => {
-    expect(() => call('snapshots:v1:delete', {})).toThrow(CodesignError);
+    expect(() => call('snapshots:v1:delete', v1({}))).toThrow(CodesignError);
     try {
-      call('snapshots:v1:delete', {});
+      call('snapshots:v1:delete', v1({}));
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// schemaVersion gating
+//
+// Every snapshots:v1:* object payload must carry schemaVersion: 1. Older or
+// future callers that omit it (or send a different value) get IPC_BAD_INPUT
+// rather than a silent mis-parse, so handler revisions can break cleanly.
+// ---------------------------------------------------------------------------
+
+describe('schemaVersion gating', () => {
+  const channelsAndSamples: Array<[string, Record<string, unknown>]> = [
+    ['snapshots:v1:list-designs', {}],
+    ['snapshots:v1:list', { designId: 'd' }],
+    ['snapshots:v1:get', { id: 'x' }],
+    ['snapshots:v1:delete', { id: 'x' }],
+    ['snapshots:v1:create-design', { name: 'd' }],
+    [
+      'snapshots:v1:create',
+      {
+        designId: 'd',
+        parentId: null,
+        type: 'initial',
+        prompt: null,
+        artifactType: 'html',
+        artifactSource: '<html/>',
+      },
+    ],
+  ];
+
+  for (const [channel, sample] of channelsAndSamples) {
+    it(`${channel} rejects missing schemaVersion with IPC_BAD_INPUT`, () => {
+      try {
+        call(channel, sample);
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(CodesignError);
+        expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+        expect((err as Error).message).toMatch(/schemaVersion/);
+      }
+    });
+
+    it(`${channel} rejects schemaVersion: 2 with IPC_BAD_INPUT`, () => {
+      try {
+        call(channel, { schemaVersion: 2, ...sample });
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(CodesignError);
+        expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+        expect((err as Error).message).toMatch(/schemaVersion/);
+      }
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -356,14 +418,17 @@ describe('SQLite error translation', () => {
 
   function attemptCreate(): unknown {
     const design = createDesign(db);
-    return call('snapshots:v1:create', {
-      designId: design.id,
-      parentId: null,
-      type: 'initial',
-      prompt: null,
-      artifactType: 'html',
-      artifactSource: '<html/>',
-    });
+    return call(
+      'snapshots:v1:create',
+      v1({
+        designId: design.id,
+        parentId: null,
+        type: 'initial',
+        prompt: null,
+        artifactType: 'html',
+        artifactSource: '<html/>',
+      }),
+    );
   }
 
   it('translates SQLITE_CONSTRAINT_FOREIGNKEY to IPC_BAD_INPUT', () => {

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for snapshots-ipc.ts.
+ *
+ * Mocks electron-runtime so ipcMain.handle() can be intercepted, then
+ * calls the registered handlers directly with an in-memory DB.
+ */
+
+import { CodesignError } from '@open-codesign/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Collect registered handlers so tests can invoke them directly.
+const handlers = new Map<string, (e: unknown, raw: unknown) => unknown>();
+
+vi.mock('./electron-runtime', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (e: unknown, raw: unknown) => unknown) => {
+      handlers.set(channel, fn);
+    },
+  },
+}));
+
+vi.mock('./logger', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { createDesign, createSnapshot, initInMemoryDb } from './snapshots-db';
+import { registerSnapshotsIpc } from './snapshots-ipc';
+
+function call(channel: string, raw: unknown): unknown {
+  const fn = handlers.get(channel);
+  if (!fn) throw new Error(`No handler for channel: ${channel}`);
+  return fn(null, raw);
+}
+
+let db: ReturnType<typeof initInMemoryDb>;
+
+beforeEach(() => {
+  handlers.clear();
+  db = initInMemoryDb();
+  registerSnapshotsIpc(db);
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:list-designs
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:list-designs', () => {
+  it('returns an empty array when no designs exist', () => {
+    const result = call('snapshots:v1:list-designs', undefined);
+    expect(result).toEqual([]);
+  });
+
+  it('returns created designs', () => {
+    createDesign(db, 'Test design');
+    const result = call('snapshots:v1:list-designs', undefined) as unknown[];
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:list
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:list', () => {
+  it('returns snapshots for a design', () => {
+    const design = createDesign(db);
+    createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    const result = call('snapshots:v1:list', { designId: design.id }) as unknown[];
+    expect(result).toHaveLength(1);
+  });
+
+  it('rejects a missing designId with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:list', {})).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:list', {});
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects a non-object payload with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:list', null)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:list', null);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:create
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:create', () => {
+  it('creates and returns a snapshot', () => {
+    const design = createDesign(db);
+    const input = {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: 'Build a hero section',
+      artifactType: 'html',
+      artifactSource: '<html>hero</html>',
+    };
+    const result = call('snapshots:v1:create', input) as Record<string, unknown>;
+    expect(result['id']).toBeTruthy();
+    expect(result['designId']).toBe(design.id);
+    expect(result['type']).toBe('initial');
+  });
+
+  it('rejects bad payload (missing designId) with IPC_BAD_INPUT', () => {
+    const bad = {
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    };
+    expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', bad);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects invalid type with IPC_BAD_INPUT', () => {
+    const bad = {
+      designId: 'some-id',
+      parentId: null,
+      type: 'invalid-type',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    };
+    expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', bad);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects invalid artifactType with IPC_BAD_INPUT', () => {
+    const bad = {
+      designId: 'some-id',
+      parentId: null,
+      type: 'edit',
+      prompt: null,
+      artifactType: 'pptx',
+      artifactSource: '<html/>',
+    };
+    expect(() => call('snapshots:v1:create', bad)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', bad);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects null payload with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:create', null)).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:create', null);
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:get
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:get', () => {
+  it('returns null for an unknown id', () => {
+    const result = call('snapshots:v1:get', { id: 'ghost' });
+    expect(result).toBeNull();
+  });
+
+  it('returns the snapshot by id', () => {
+    const design = createDesign(db);
+    const snap = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    const result = call('snapshots:v1:get', { id: snap.id }) as Record<string, unknown>;
+    expect(result['id']).toBe(snap.id);
+  });
+
+  it('rejects missing id with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:get', {})).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:get', {});
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:delete
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:delete', () => {
+  it('deletes a snapshot', () => {
+    const design = createDesign(db);
+    const snap = createSnapshot(db, {
+      designId: design.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    call('snapshots:v1:delete', { id: snap.id });
+    const result = call('snapshots:v1:get', { id: snap.id });
+    expect(result).toBeNull();
+  });
+
+  it('rejects missing id with IPC_BAD_INPUT', () => {
+    expect(() => call('snapshots:v1:delete', {})).toThrow(CodesignError);
+    try {
+      call('snapshots:v1:delete', {});
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -373,7 +373,7 @@ describe('SQLite error translation', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(CodesignError);
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
-      expect((err as Error).message).toBe('Parent snapshot does not exist');
+      expect((err as Error).message).toBe('Referenced design or parent snapshot does not exist');
       expect((err as Error).message).not.toMatch(/SQLITE_/);
     }
   });

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -29,14 +29,26 @@ const logger = getLogger('snapshots-ipc');
 
 /**
  * Translate a raw better-sqlite3 SqliteError into a typed CodesignError so the
- * renderer never sees provider-specific error strings. Unrecognised errors fall
- * through as IPC_DB_ERROR with the original cause attached for server-side logs.
+ * renderer never sees provider-specific error strings. Constraint subcodes are
+ * matched individually because the bare `SQLITE_CONSTRAINT` parent code covers
+ * unrelated failures (UNIQUE, NOT NULL, CHECK, FK), and surfacing all of them
+ * as "Parent snapshot does not exist" would mislead the UI. Unrecognised errors
+ * fall through as IPC_DB_ERROR with the original cause attached for server-side
+ * logs.
  */
 function translateSqliteError(err: unknown, context: string): CodesignError {
   const code = (err as { code?: unknown })?.code;
   if (typeof code === 'string') {
-    if (code === 'SQLITE_CONSTRAINT_FOREIGNKEY' || code === 'SQLITE_CONSTRAINT') {
+    if (code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
       return new CodesignError('Parent snapshot does not exist', 'IPC_BAD_INPUT', { cause: err });
+    }
+    if (code === 'SQLITE_CONSTRAINT_UNIQUE' || code === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
+      return new CodesignError('Snapshot already exists', 'IPC_CONFLICT', { cause: err });
+    }
+    if (code === 'SQLITE_CONSTRAINT_NOTNULL' || code === 'SQLITE_CONSTRAINT_CHECK') {
+      return new CodesignError('Snapshot input violates database constraints', 'IPC_BAD_INPUT', {
+        cause: err,
+      });
     }
     if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') {
       return new CodesignError('Database is locked, retry shortly', 'IPC_DB_BUSY', { cause: err });

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -140,7 +140,9 @@ export function registerSnapshotsIpc(db: Database): void {
   });
 
   ipcMain.handle('snapshots:v1:create-design', (_e: unknown, raw: unknown): Design => {
-    const name = typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : 'Untitled design';
-    return createDesign(db, name);
+    if (typeof raw !== 'string' || raw.trim().length === 0) {
+      throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    return createDesign(db, raw.trim());
   });
 }

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -97,11 +97,23 @@ function runDb<T>(context: string, fn: () => T): T {
   }
 }
 
+/**
+ * Every snapshots:v1:* object payload carries `schemaVersion: 1` so that future
+ * handler revisions can reject older callers up-front rather than silently
+ * mis-parsing fields. Bare scalar payloads (none currently) would not carry one.
+ */
+function requireSchemaV1(r: Record<string, unknown>, channel: string): void {
+  if (r['schemaVersion'] !== 1) {
+    throw new CodesignError(`${channel} requires schemaVersion: 1`, 'IPC_BAD_INPUT');
+  }
+}
+
 function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
   if (typeof raw !== 'object' || raw === null) {
     throw new CodesignError('snapshots:v1:create expects an object payload', 'IPC_BAD_INPUT');
   }
   const r = raw as Record<string, unknown>;
+  requireSchemaV1(r, 'snapshots:v1:create');
 
   if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
     throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
@@ -145,7 +157,14 @@ function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
 }
 
 export function registerSnapshotsIpc(db: Database): void {
-  ipcMain.handle('snapshots:v1:list-designs', (): Design[] => {
+  ipcMain.handle('snapshots:v1:list-designs', (_e: unknown, raw: unknown): Design[] => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:list-designs expects an object payload',
+        'IPC_BAD_INPUT',
+      );
+    }
+    requireSchemaV1(raw as Record<string, unknown>, 'snapshots:v1:list-designs');
     return runDb('list-designs', () => listDesigns(db));
   });
 
@@ -154,6 +173,7 @@ export function registerSnapshotsIpc(db: Database): void {
       throw new CodesignError('snapshots:v1:list expects an object with designId', 'IPC_BAD_INPUT');
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:list');
     if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
       throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -165,6 +185,7 @@ export function registerSnapshotsIpc(db: Database): void {
       throw new CodesignError('snapshots:v1:get expects an object with id', 'IPC_BAD_INPUT');
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:get');
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -202,6 +223,7 @@ export function registerSnapshotsIpc(db: Database): void {
       throw new CodesignError('snapshots:v1:delete expects an object with id', 'IPC_BAD_INPUT');
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:delete');
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -210,9 +232,17 @@ export function registerSnapshotsIpc(db: Database): void {
   });
 
   ipcMain.handle('snapshots:v1:create-design', (_e: unknown, raw: unknown): Design => {
-    if (typeof raw !== 'string' || raw.trim().length === 0) {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:create-design expects an object with name',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:create-design');
+    if (typeof r['name'] !== 'string' || r['name'].trim().length === 0) {
       throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
     }
-    return runDb('create-design', () => createDesign(db, raw.trim()));
+    return runDb('create-design', () => createDesign(db, (r['name'] as string).trim()));
   });
 }

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -103,6 +103,21 @@ export function registerSnapshotsIpc(db: Database): void {
 
   ipcMain.handle('snapshots:v1:create', (_e: unknown, raw: unknown): DesignSnapshot => {
     const input = parseSnapshotCreateInput(raw);
+    if (input.parentId !== null) {
+      const parent = getSnapshot(db, input.parentId);
+      if (parent === null) {
+        throw new CodesignError(
+          'parentId references a snapshot that does not exist',
+          'IPC_BAD_INPUT',
+        );
+      }
+      if (parent.designId !== input.designId) {
+        throw new CodesignError(
+          'parentId must reference a snapshot in the same design',
+          'IPC_BAD_INPUT',
+        );
+      }
+    }
     const snapshot = createSnapshot(db, input);
     logger.info('snapshot.created', {
       id: snapshot.id,

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -27,6 +27,42 @@ type Database = BetterSqlite3.Database;
 
 const logger = getLogger('snapshots-ipc');
 
+/**
+ * Translate a raw better-sqlite3 SqliteError into a typed CodesignError so the
+ * renderer never sees provider-specific error strings. Unrecognised errors fall
+ * through as IPC_DB_ERROR with the original cause attached for server-side logs.
+ */
+function translateSqliteError(err: unknown, context: string): CodesignError {
+  const code = (err as { code?: unknown })?.code;
+  if (typeof code === 'string') {
+    if (code === 'SQLITE_CONSTRAINT_FOREIGNKEY' || code === 'SQLITE_CONSTRAINT') {
+      return new CodesignError('Parent snapshot does not exist', 'IPC_BAD_INPUT', { cause: err });
+    }
+    if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') {
+      return new CodesignError('Database is locked, retry shortly', 'IPC_DB_BUSY', { cause: err });
+    }
+    if (code === 'SQLITE_FULL') {
+      return new CodesignError('Disk is full', 'IPC_DB_FULL', { cause: err });
+    }
+  }
+  logger.error('snapshot.db_error', {
+    context,
+    code: typeof code === 'string' ? code : 'unknown',
+    message: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+  return new CodesignError(`Snapshot database error (${context})`, 'IPC_DB_ERROR', { cause: err });
+}
+
+function runDb<T>(context: string, fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof CodesignError) throw err;
+    throw translateSqliteError(err, context);
+  }
+}
+
 function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
   if (typeof raw !== 'object' || raw === null) {
     throw new CodesignError('snapshots:v1:create expects an object payload', 'IPC_BAD_INPUT');
@@ -76,7 +112,7 @@ function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
 
 export function registerSnapshotsIpc(db: Database): void {
   ipcMain.handle('snapshots:v1:list-designs', (): Design[] => {
-    return listDesigns(db);
+    return runDb('list-designs', () => listDesigns(db));
   });
 
   ipcMain.handle('snapshots:v1:list', (_e: unknown, raw: unknown): DesignSnapshot[] => {
@@ -87,7 +123,7 @@ export function registerSnapshotsIpc(db: Database): void {
     if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
       throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
     }
-    return listSnapshots(db, r['designId'] as string);
+    return runDb('list', () => listSnapshots(db, r['designId'] as string));
   });
 
   ipcMain.handle('snapshots:v1:get', (_e: unknown, raw: unknown): DesignSnapshot | null => {
@@ -98,13 +134,13 @@ export function registerSnapshotsIpc(db: Database): void {
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
-    return getSnapshot(db, r['id'] as string);
+    return runDb('get', () => getSnapshot(db, r['id'] as string));
   });
 
   ipcMain.handle('snapshots:v1:create', (_e: unknown, raw: unknown): DesignSnapshot => {
     const input = parseSnapshotCreateInput(raw);
     if (input.parentId !== null) {
-      const parent = getSnapshot(db, input.parentId);
+      const parent = runDb('create.lookup-parent', () => getSnapshot(db, input.parentId as string));
       if (parent === null) {
         throw new CodesignError(
           'parentId references a snapshot that does not exist',
@@ -118,7 +154,7 @@ export function registerSnapshotsIpc(db: Database): void {
         );
       }
     }
-    const snapshot = createSnapshot(db, input);
+    const snapshot = runDb('create', () => createSnapshot(db, input));
     logger.info('snapshot.created', {
       id: snapshot.id,
       type: input.type,
@@ -135,7 +171,7 @@ export function registerSnapshotsIpc(db: Database): void {
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
-    deleteSnapshot(db, r['id'] as string);
+    runDb('delete', () => deleteSnapshot(db, r['id'] as string));
     logger.info('snapshot.deleted', { id: r['id'] });
   });
 
@@ -143,6 +179,6 @@ export function registerSnapshotsIpc(db: Database): void {
     if (typeof raw !== 'string' || raw.trim().length === 0) {
       throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
     }
-    return createDesign(db, raw.trim());
+    return runDb('create-design', () => createDesign(db, raw.trim()));
   });
 }

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -1,0 +1,131 @@
+/**
+ * Snapshot IPC handlers (main process).
+ *
+ * All channels are namespaced snapshots:v1:* so they can be versioned
+ * independently of other codesign:* channels.
+ *
+ * The `db` argument is injected so tests can pass an in-memory instance
+ * without module-level state. Production callers pass the singleton from
+ * initSnapshotsDb().
+ */
+
+import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign/shared';
+import { CodesignError } from '@open-codesign/shared';
+import type BetterSqlite3 from 'better-sqlite3';
+import { ipcMain } from './electron-runtime';
+import { getLogger } from './logger';
+import {
+  createDesign,
+  createSnapshot,
+  deleteSnapshot,
+  getSnapshot,
+  listDesigns,
+  listSnapshots,
+} from './snapshots-db';
+
+type Database = BetterSqlite3.Database;
+
+const logger = getLogger('snapshots-ipc');
+
+function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new CodesignError('snapshots:v1:create expects an object payload', 'IPC_BAD_INPUT');
+  }
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+    throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  if (r['parentId'] !== null && typeof r['parentId'] !== 'string') {
+    throw new CodesignError('parentId must be a string or null', 'IPC_BAD_INPUT');
+  }
+  const validTypes = ['initial', 'edit', 'fork'] as const;
+  if (!validTypes.includes(r['type'] as (typeof validTypes)[number])) {
+    throw new CodesignError(`type must be one of: ${validTypes.join(', ')}`, 'IPC_BAD_INPUT');
+  }
+  if (r['prompt'] !== null && typeof r['prompt'] !== 'string') {
+    throw new CodesignError('prompt must be a string or null', 'IPC_BAD_INPUT');
+  }
+  const validArtifactTypes = ['html', 'react', 'svg'] as const;
+  if (!validArtifactTypes.includes(r['artifactType'] as (typeof validArtifactTypes)[number])) {
+    throw new CodesignError(
+      `artifactType must be one of: ${validArtifactTypes.join(', ')}`,
+      'IPC_BAD_INPUT',
+    );
+  }
+  if (typeof r['artifactSource'] !== 'string') {
+    throw new CodesignError('artifactSource must be a string', 'IPC_BAD_INPUT');
+  }
+  if (r['message'] !== undefined && typeof r['message'] !== 'string') {
+    throw new CodesignError('message must be a string if provided', 'IPC_BAD_INPUT');
+  }
+
+  const base = {
+    designId: r['designId'] as string,
+    parentId: r['parentId'] as string | null,
+    type: r['type'] as SnapshotCreateInput['type'],
+    prompt: r['prompt'] as string | null,
+    artifactType: r['artifactType'] as SnapshotCreateInput['artifactType'],
+    artifactSource: r['artifactSource'] as string,
+  };
+  if (typeof r['message'] === 'string') {
+    return { ...base, message: r['message'] };
+  }
+  return base;
+}
+
+export function registerSnapshotsIpc(db: Database): void {
+  ipcMain.handle('snapshots:v1:list-designs', (): Design[] => {
+    return listDesigns(db);
+  });
+
+  ipcMain.handle('snapshots:v1:list', (_e: unknown, raw: unknown): DesignSnapshot[] => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError('snapshots:v1:list expects an object with designId', 'IPC_BAD_INPUT');
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    return listSnapshots(db, r['designId'] as string);
+  });
+
+  ipcMain.handle('snapshots:v1:get', (_e: unknown, raw: unknown): DesignSnapshot | null => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError('snapshots:v1:get expects an object with id', 'IPC_BAD_INPUT');
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+      throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    return getSnapshot(db, r['id'] as string);
+  });
+
+  ipcMain.handle('snapshots:v1:create', (_e: unknown, raw: unknown): DesignSnapshot => {
+    const input = parseSnapshotCreateInput(raw);
+    const snapshot = createSnapshot(db, input);
+    logger.info('snapshot.created', {
+      id: snapshot.id,
+      type: input.type,
+      designId: input.designId,
+    });
+    return snapshot;
+  });
+
+  ipcMain.handle('snapshots:v1:delete', (_e: unknown, raw: unknown): void => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError('snapshots:v1:delete expects an object with id', 'IPC_BAD_INPUT');
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+      throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    deleteSnapshot(db, r['id'] as string);
+    logger.info('snapshot.deleted', { id: r['id'] });
+  });
+
+  ipcMain.handle('snapshots:v1:create-design', (_e: unknown, raw: unknown): Design => {
+    const name = typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : 'Untitled design';
+    return createDesign(db, name);
+  });
+}

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -246,3 +246,31 @@ export function registerSnapshotsIpc(db: Database): void {
     return runDb('create-design', () => createDesign(db, (r['name'] as string).trim()));
   });
 }
+
+/**
+ * Stub channels installed when snapshots DB init fails at boot. Without these,
+ * any renderer call to window.codesign.snapshots.* would surface as Electron's
+ * generic "No handler registered for ..." rejection — opaque to the user and
+ * to logs. We register handlers that throw a typed CodesignError so the
+ * renderer can branch on `SNAPSHOTS_UNAVAILABLE` and surface a placeholder.
+ *
+ * Channels listed here MUST match the set registered in registerSnapshotsIpc.
+ */
+export const SNAPSHOTS_CHANNELS_V1 = [
+  'snapshots:v1:list-designs',
+  'snapshots:v1:create-design',
+  'snapshots:v1:list',
+  'snapshots:v1:get',
+  'snapshots:v1:create',
+  'snapshots:v1:delete',
+] as const;
+
+export function registerSnapshotsUnavailableIpc(reason: string): void {
+  const message = `Snapshots database failed to initialize. Check Settings → Storage for diagnostics. (${reason})`;
+  const fail = (): never => {
+    throw new CodesignError(message, 'SNAPSHOTS_UNAVAILABLE');
+  };
+  for (const channel of SNAPSHOTS_CHANNELS_V1) {
+    ipcMain.handle(channel, fail);
+  }
+}

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -32,29 +32,51 @@ const logger = getLogger('snapshots-ipc');
  * renderer never sees provider-specific error strings. Constraint subcodes are
  * matched individually because the bare `SQLITE_CONSTRAINT` parent code covers
  * unrelated failures (UNIQUE, NOT NULL, CHECK, FK), and surfacing all of them
- * as "Parent snapshot does not exist" would mislead the UI. Unrecognised errors
- * fall through as IPC_DB_ERROR with the original cause attached for server-side
- * logs.
+ * as a single message would mislead the UI. The FK message is keyed by call-site
+ * context because the same SQLITE_CONSTRAINT_FOREIGNKEY code fires for both a
+ * missing `design_id` and a missing `parent_id` in design_snapshots — naming
+ * only the parent led contributors to chase the wrong cause. Unrecognised
+ * errors fall through as IPC_DB_ERROR with the original cause attached for
+ * server-side logs.
  */
+const FK_MESSAGES: Record<string, string> = {
+  create: 'Referenced design or parent snapshot does not exist',
+  'create.lookup-parent': 'Referenced design or parent snapshot does not exist',
+};
+
+type Translation = {
+  code: 'IPC_BAD_INPUT' | 'IPC_CONFLICT' | 'IPC_DB_BUSY' | 'IPC_DB_FULL';
+  message: string;
+};
+
+function staticTranslation(sqliteCode: string): Translation | null {
+  switch (sqliteCode) {
+    case 'SQLITE_CONSTRAINT_UNIQUE':
+    case 'SQLITE_CONSTRAINT_PRIMARYKEY':
+      return { code: 'IPC_CONFLICT', message: 'Snapshot already exists' };
+    case 'SQLITE_CONSTRAINT_NOTNULL':
+    case 'SQLITE_CONSTRAINT_CHECK':
+      return { code: 'IPC_BAD_INPUT', message: 'Snapshot input violates database constraints' };
+    case 'SQLITE_BUSY':
+    case 'SQLITE_LOCKED':
+      return { code: 'IPC_DB_BUSY', message: 'Database is locked, retry shortly' };
+    case 'SQLITE_FULL':
+      return { code: 'IPC_DB_FULL', message: 'Disk is full' };
+    default:
+      return null;
+  }
+}
+
 function translateSqliteError(err: unknown, context: string): CodesignError {
   const code = (err as { code?: unknown })?.code;
   if (typeof code === 'string') {
     if (code === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
-      return new CodesignError('Parent snapshot does not exist', 'IPC_BAD_INPUT', { cause: err });
+      const message = FK_MESSAGES[context] ?? 'Referenced item does not exist';
+      return new CodesignError(message, 'IPC_BAD_INPUT', { cause: err });
     }
-    if (code === 'SQLITE_CONSTRAINT_UNIQUE' || code === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
-      return new CodesignError('Snapshot already exists', 'IPC_CONFLICT', { cause: err });
-    }
-    if (code === 'SQLITE_CONSTRAINT_NOTNULL' || code === 'SQLITE_CONSTRAINT_CHECK') {
-      return new CodesignError('Snapshot input violates database constraints', 'IPC_BAD_INPUT', {
-        cause: err,
-      });
-    }
-    if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') {
-      return new CodesignError('Database is locked, retry shortly', 'IPC_DB_BUSY', { cause: err });
-    }
-    if (code === 'SQLITE_FULL') {
-      return new CodesignError('Disk is full', 'IPC_DB_FULL', { cause: err });
+    const t = staticTranslation(code);
+    if (t !== null) {
+      return new CodesignError(t.message, t.code, { cause: err });
     }
   }
   logger.error('snapshot.db_error', {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -187,11 +187,8 @@ const api = {
   },
   snapshots: {
     listDesigns: () => ipcRenderer.invoke('snapshots:v1:list-designs') as Promise<Design[]>,
-    createDesign: (name?: string) =>
-      ipcRenderer.invoke(
-        'snapshots:v1:create-design',
-        name ?? 'Untitled design',
-      ) as Promise<Design>,
+    createDesign: (name: string) =>
+      ipcRenderer.invoke('snapshots:v1:create-design', name) as Promise<Design>,
     list: (designId: string) =>
       ipcRenderer.invoke('snapshots:v1:list', { designId }) as Promise<DesignSnapshot[]>,
     get: (id: string) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,11 +1,14 @@
 import type {
   CancelGenerationPayloadV1,
   ChatMessage,
+  Design,
+  DesignSnapshot,
   GeneratePayloadV1,
   LocalInputFile,
   ModelRef,
   OnboardingState,
   SelectedElement,
+  SnapshotCreateInput,
   SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { contextBridge, ipcRenderer } from 'electron';
@@ -181,6 +184,21 @@ const api = {
       apiKey: string;
       baseUrl: string;
     }) => ipcRenderer.invoke('models:v1:list', input) as Promise<ModelsListResponse>,
+  },
+  snapshots: {
+    listDesigns: () => ipcRenderer.invoke('snapshots:v1:list-designs') as Promise<Design[]>,
+    createDesign: (name?: string) =>
+      ipcRenderer.invoke(
+        'snapshots:v1:create-design',
+        name ?? 'Untitled design',
+      ) as Promise<Design>,
+    list: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:list', { designId }) as Promise<DesignSnapshot[]>,
+    get: (id: string) =>
+      ipcRenderer.invoke('snapshots:v1:get', { id }) as Promise<DesignSnapshot | null>,
+    create: (input: SnapshotCreateInput) =>
+      ipcRenderer.invoke('snapshots:v1:create', input) as Promise<DesignSnapshot>,
+    delete: (id: string) => ipcRenderer.invoke('snapshots:v1:delete', { id }) as Promise<void>,
   },
 };
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -186,16 +186,29 @@ const api = {
     }) => ipcRenderer.invoke('models:v1:list', input) as Promise<ModelsListResponse>,
   },
   snapshots: {
-    listDesigns: () => ipcRenderer.invoke('snapshots:v1:list-designs') as Promise<Design[]>,
+    listDesigns: () =>
+      ipcRenderer.invoke('snapshots:v1:list-designs', { schemaVersion: 1 }) as Promise<Design[]>,
     createDesign: (name: string) =>
-      ipcRenderer.invoke('snapshots:v1:create-design', name) as Promise<Design>,
+      ipcRenderer.invoke('snapshots:v1:create-design', {
+        schemaVersion: 1,
+        name,
+      }) as Promise<Design>,
     list: (designId: string) =>
-      ipcRenderer.invoke('snapshots:v1:list', { designId }) as Promise<DesignSnapshot[]>,
+      ipcRenderer.invoke('snapshots:v1:list', { schemaVersion: 1, designId }) as Promise<
+        DesignSnapshot[]
+      >,
     get: (id: string) =>
-      ipcRenderer.invoke('snapshots:v1:get', { id }) as Promise<DesignSnapshot | null>,
+      ipcRenderer.invoke('snapshots:v1:get', {
+        schemaVersion: 1,
+        id,
+      }) as Promise<DesignSnapshot | null>,
     create: (input: SnapshotCreateInput) =>
-      ipcRenderer.invoke('snapshots:v1:create', input) as Promise<DesignSnapshot>,
-    delete: (id: string) => ipcRenderer.invoke('snapshots:v1:delete', { id }) as Promise<void>,
+      ipcRenderer.invoke('snapshots:v1:create', {
+        schemaVersion: 1,
+        ...input,
+      }) as Promise<DesignSnapshot>,
+    delete: (id: string) =>
+      ipcRenderer.invoke('snapshots:v1:delete', { schemaVersion: 1, id }) as Promise<void>,
   },
 };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -202,6 +202,8 @@ export {
   getPresetById,
 } from './proxy-presets';
 export type { ProxyPresetId } from './proxy-presets';
-
 export { DesignTokenV1, DesignTokenSet } from './design-token';
 export type { DesignToken } from './design-token';
+
+export { DesignSnapshotV1, DesignV1 } from './snapshot';
+export type { Design, DesignSnapshot, SnapshotCreateInput } from './snapshot';

--- a/packages/shared/src/snapshot.ts
+++ b/packages/shared/src/snapshot.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const DesignSnapshotV1 = z.object({
+  schemaVersion: z.literal(1).default(1),
+  id: z.string().min(1),
+  designId: z.string().min(1),
+  parentId: z.string().nullable(),
+  type: z.enum(['initial', 'edit', 'fork']),
+  prompt: z.string().nullable(),
+  artifactType: z.enum(['html', 'react', 'svg']),
+  artifactSource: z.string(),
+  createdAt: z.string(),
+  message: z.string().optional(),
+});
+export type DesignSnapshot = z.infer<typeof DesignSnapshotV1>;
+
+export const DesignV1 = z.object({
+  schemaVersion: z.literal(1).default(1),
+  id: z.string().min(1),
+  name: z.string().default('Untitled design'),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Design = z.infer<typeof DesignV1>;
+
+export interface SnapshotCreateInput {
+  designId: string;
+  parentId: string | null;
+  type: 'initial' | 'edit' | 'fork';
+  prompt: string | null;
+  artifactType: 'html' | 'react' | 'svg';
+  artifactSource: string;
+  message?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@open-codesign/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
       electron-log:
         specifier: ^5
         version: 5.4.3
@@ -78,6 +81,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.2
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.17
@@ -1748,6 +1754,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -2180,8 +2189,14 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
@@ -2298,6 +2313,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -2437,6 +2455,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -2669,6 +2691,10 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2732,6 +2758,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -2836,6 +2865,9 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3017,6 +3049,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3427,6 +3462,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -3443,6 +3481,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -3659,6 +3700,12 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -3724,6 +3771,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -3907,6 +3958,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
@@ -4008,6 +4065,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
@@ -4032,6 +4093,9 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
@@ -4108,6 +4172,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
@@ -6245,6 +6312,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -6739,7 +6810,16 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   birpc@2.9.0: {}
 
@@ -6902,6 +6982,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chownr@1.1.4: {}
+
   chownr@2.0.0: {}
 
   chromium-bidi@14.0.0(devtools-protocol@0.0.1595872):
@@ -7018,6 +7100,8 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   defaults@1.0.4:
     dependencies:
@@ -7340,6 +7424,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -7403,6 +7489,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.6:
     dependencies:
@@ -7544,6 +7632,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7772,6 +7862,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ip-address@10.1.0: {}
 
@@ -8144,6 +8236,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   mri@1.2.0: {}
@@ -8151,6 +8245,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
 
   negotiator@0.6.4: {}
 
@@ -8360,6 +8456,21 @@ snapshots:
 
   preact@10.29.1: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -8444,6 +8555,13 @@ snapshots:
       inherits: 2.0.4
 
   quick-lru@5.1.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -8641,6 +8759,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -8754,6 +8880,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strnum@2.2.3: {}
 
   sumchecker@3.0.1:
@@ -8775,6 +8903,13 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
 
   tar-fs@3.1.2:
     dependencies:
@@ -8872,6 +9007,10 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.9.6:
     optionalDependencies:


### PR DESCRIPTION
## Summary

First PR of 3 implementing version history (research 14).

- **packages/shared**: `DesignSnapshotV1` + `DesignV1` Zod schemas, `SnapshotCreateInput` interface — schema-versioned, exported from index
- **apps/desktop main**: `snapshots-db.ts` — better-sqlite3 WAL persistence (`designs` + `design_snapshots` tables, FK cascade on delete, `idx_snapshots_design_created` index). `initSnapshotsDb(path)` for production, `initInMemoryDb()` for tests (no filesystem)
- **apps/desktop main**: `snapshots-ipc.ts` — `snapshots:v1:*` IPC handlers (list-designs, create-design, list, get, create, delete). All reject malformed payloads with `CodesignError('IPC_BAD_INPUT')`
- **apps/desktop preload**: `window.codesign.snapshots` namespace bridged to renderer
- **apps/desktop main/index**: registers `registerSnapshotsIpc(snapshotsDb)` on app ready

## New dependency

`better-sqlite3@^11` (MIT) + `@types/better-sqlite3` (dev). No `ulid` added — using `crypto.randomUUID()` instead to keep dep count lean.

## DB location

`<userData>/designs.db` via `app.getPath('userData')` — respects Electron XDG conventions.

## Test plan

- [x] `snapshots-db.test.ts` (11 tests): createDesign, listDesigns DESC, createSnapshot, parent_id chain, getSnapshot, deleteSnapshot (idempotent), FK cascade
- [x] `snapshots-ipc.test.ts` (15 tests): list returns array, create roundtrip, bad payloads throw `CodesignError` with `IPC_BAD_INPUT`, get/delete
- [x] `pnpm -r typecheck` — all packages pass
- [x] `pnpm lint` — 0 errors (8 pre-existing warnings in unrelated files)
- [x] `pnpm -r test` — 111 tests pass workspace-wide

## Follow-up

- PR-B: history sidebar + auto-snapshot on `sendPrompt`
- PR-C: Monaco diff viewer + restore / fork UI

## Design notes

Compatibility ✅ Upgradeability ✅ No bloat ✅ Elegance ✅