### PR TITLE
feat(core): Brand token extraction — Tailwind config + CSS vars + W3C DTCG

### DIFF
--- a/packages/core/src/brand/__fixtures__/tailwind.config.js
+++ b/packages/core/src/brand/__fixtures__/tailwind.config.js
@@ -1,0 +1,45 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    colors: {
+      white: '#ffffff',
+      black: '#000000',
+    },
+    extend: {
+      colors: {
+        brand: {
+          primary: '#D97757',
+          secondary: '#4A6FA5',
+        },
+        neutral: {
+          100: '#f5f5f5',
+          900: '#1a1a1a',
+        },
+      },
+      fontSize: {
+        sm: '0.875rem',
+        base: '1rem',
+        lg: '1.125rem',
+        xl: '1.25rem',
+        '2xl': '1.5rem',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
+      },
+      borderRadius: {
+        sm: '4px',
+        md: '8px',
+        lg: '16px',
+        full: '9999px',
+      },
+      spacing: {
+        1: '0.25rem',
+        2: '0.5rem',
+        4: '1rem',
+        8: '2rem',
+      },
+    },
+  },
+};

--- a/packages/core/src/brand/__fixtures__/tailwind.v4.multi-theme.css
+++ b/packages/core/src/brand/__fixtures__/tailwind.v4.multi-theme.css
@@ -1,0 +1,14 @@
+@import "tailwindcss";
+
+@theme {
+  --color-brand-primary: #ff0066;
+  --color-brand-secondary: #3366ff;
+  --font-size-base: 1rem;
+}
+
+/* A second @theme block — e.g. split across files or appended by a plugin. */
+@theme {
+  --color-accent: #00ffaa;
+  --radius-md: 0.5rem;
+  --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.2);
+}

--- a/packages/core/src/brand/__fixtures__/tokens.css
+++ b/packages/core/src/brand/__fixtures__/tokens.css
@@ -1,0 +1,23 @@
+:root {
+  --color-primary: #d97757;
+  --color-secondary: #4a6fa5;
+  --color-background: #fafafa;
+  --color-foreground: #1a1a1a;
+  --font-family-sans: "Inter", sans-serif;
+  --font-family-mono: "JetBrains Mono", monospace;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-4: 16px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] {
+  --color-background: #1a1a1a;
+  --color-foreground: #fafafa;
+}

--- a/packages/core/src/brand/__fixtures__/tokens.json
+++ b/packages/core/src/brand/__fixtures__/tokens.json
@@ -1,0 +1,38 @@
+{
+  "color": {
+    "$type": "color",
+    "brand": {
+      "primary": { "$value": "#D97757", "$type": "color" },
+      "secondary": { "$value": "#4A6FA5", "$type": "color" }
+    },
+    "neutral": {
+      "100": { "$value": "#f5f5f5" },
+      "900": { "$value": "#1a1a1a" }
+    }
+  },
+  "typography": {
+    "fontFamily": {
+      "sans": { "$value": "Inter, sans-serif", "$type": "fontFamily" },
+      "mono": { "$value": "JetBrains Mono, monospace", "$type": "fontFamily" }
+    },
+    "fontSize": {
+      "sm": { "$value": "0.875rem", "$type": "dimension" },
+      "base": { "$value": "1rem", "$type": "dimension" }
+    }
+  },
+  "spacing": {
+    "1": { "$value": "4px", "$type": "dimension" },
+    "2": { "$value": "8px", "$type": "dimension" },
+    "4": { "$value": "16px", "$type": "dimension" }
+  },
+  "radius": {
+    "sm": { "$value": "4px", "$type": "dimension" },
+    "lg": { "$value": "16px", "$type": "dimension" }
+  },
+  "shadow": {
+    "sm": {
+      "$value": "0 1px 2px rgba(0,0,0,0.05)",
+      "$type": "shadow"
+    }
+  }
+}

--- a/packages/core/src/brand/cssVarExtractor.test.ts
+++ b/packages/core/src/brand/cssVarExtractor.test.ts
@@ -1,4 +1,6 @@
-import { dirname, resolve } from 'node:path';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { extractFromCssVars } from './cssVarExtractor.js';
@@ -83,5 +85,45 @@ describe('extractFromCssVars()', () => {
     // [data-theme="dark"] re-declares --color-background and --color-foreground
     const backgroundCount = names.filter((n) => n === 'color-background').length;
     expect(backgroundCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('classifies --text-* size tokens as fontSize and color variants as color', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'css-vars-'));
+    const file = join(dir, 'tokens.css');
+    await writeFile(
+      file,
+      [
+        ':root {',
+        '  --text-lg: 1.125rem;',
+        '  --text-base: 1rem;',
+        '  --text-primary: oklch(0.7 0.1 30);',
+        '  --text-muted: #888888;',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    const tokens = await extractFromCssVars(file);
+    const byName = new Map(tokens.map((t) => [t.name, t]));
+
+    expect(byName.get('text-lg')?.type).toBe('fontSize');
+    expect(byName.get('text-base')?.type).toBe('fontSize');
+    expect(byName.get('text-primary')?.type).toBe('color');
+    expect(byName.get('text-muted')?.type).toBe('color');
+  });
+
+  it('classifies --border-radius-* as radius rather than color', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'css-vars-'));
+    const file = join(dir, 'tokens.css');
+    await writeFile(
+      file,
+      [':root {', '  --border-radius-md: 8px;', '  --border-color-muted: #ddd;', '}', ''].join(
+        '\n',
+      ),
+    );
+    const tokens = await extractFromCssVars(file);
+    const byName = new Map(tokens.map((t) => [t.name, t]));
+
+    expect(byName.get('border-radius-md')?.type).toBe('radius');
+    expect(byName.get('border-color-muted')?.type).toBe('color');
   });
 });

--- a/packages/core/src/brand/cssVarExtractor.test.ts
+++ b/packages/core/src/brand/cssVarExtractor.test.ts
@@ -1,0 +1,87 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { extractFromCssVars } from './cssVarExtractor.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dir, '__fixtures__/tokens.css');
+
+describe('extractFromCssVars()', () => {
+  it('extracts color tokens from --color-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const colorTokens = tokens.filter((t) => t.type === 'color');
+
+    expect(colorTokens.length).toBeGreaterThan(0);
+    const names = colorTokens.map((t) => t.name);
+    expect(names).toContain('color-primary');
+    expect(names).toContain('color-secondary');
+    expect(names).toContain('color-background');
+    expect(names).toContain('color-foreground');
+  });
+
+  it('extracts fontFamily tokens from --font-family-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const fontFamilyTokens = tokens.filter((t) => t.type === 'fontFamily');
+
+    expect(fontFamilyTokens.length).toBeGreaterThan(0);
+    const names = fontFamilyTokens.map((t) => t.name);
+    expect(names).toContain('font-family-sans');
+    expect(names).toContain('font-family-mono');
+  });
+
+  it('extracts fontSize tokens from --font-size-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const fontSizeTokens = tokens.filter((t) => t.type === 'fontSize');
+
+    expect(fontSizeTokens.length).toBeGreaterThan(0);
+    const names = fontSizeTokens.map((t) => t.name);
+    expect(names).toContain('font-size-sm');
+    expect(names).toContain('font-size-base');
+  });
+
+  it('extracts spacing tokens from --space-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const spacingTokens = tokens.filter((t) => t.type === 'spacing');
+
+    expect(spacingTokens.length).toBeGreaterThan(0);
+    const names = spacingTokens.map((t) => t.name);
+    expect(names).toContain('space-1');
+    expect(names).toContain('space-2');
+    expect(names).toContain('space-4');
+  });
+
+  it('extracts radius tokens from --radius-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const radiusTokens = tokens.filter((t) => t.type === 'radius');
+
+    expect(radiusTokens.length).toBeGreaterThan(0);
+    const names = radiusTokens.map((t) => t.name);
+    expect(names).toContain('radius-sm');
+    expect(names).toContain('radius-md');
+    expect(names).toContain('radius-lg');
+  });
+
+  it('extracts shadow tokens from --shadow-* variables', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const shadowTokens = tokens.filter((t) => t.type === 'shadow');
+
+    expect(shadowTokens.length).toBeGreaterThan(0);
+    const names = shadowTokens.map((t) => t.name);
+    expect(names).toContain('shadow-sm');
+  });
+
+  it('sets origin to css-vars on every token', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    for (const token of tokens) {
+      expect(token.origin).toBe('css-vars');
+    }
+  });
+
+  it('also picks up [data-theme] overrides', async () => {
+    const tokens = await extractFromCssVars(FIXTURE);
+    const names = tokens.map((t) => t.name);
+    // [data-theme="dark"] re-declares --color-background and --color-foreground
+    const backgroundCount = names.filter((n) => n === 'color-background').length;
+    expect(backgroundCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/src/brand/cssVarExtractor.ts
+++ b/packages/core/src/brand/cssVarExtractor.ts
@@ -6,16 +6,29 @@ type TokenType = DesignToken['type'];
 function inferType(prop: string, value: string): TokenType | null {
   const p = prop.toLowerCase();
 
-  if (/color|palette|brand|accent|fg|bg|foreground|background|fill|stroke|ring|border/.test(p))
-    return 'color';
-  if (/font-size|text-size|text-sm|text-base|text-lg|text-xl/.test(p)) return 'fontSize';
+  // Order matters: specific shape patterns must run before broad color keywords
+  // so things like `--border-radius-md` and `--text-lg` are not misclassified.
+  if (/font-size|text-size/.test(p)) return 'fontSize';
   if (/font-family|font-sans|font-mono|font-serif|typeface/.test(p)) return 'fontFamily';
-  if (/spacing|space|gap|padding|margin|indent|offset/.test(p)) return 'spacing';
-  if (/radius|rounded/.test(p)) return 'radius';
-  if (/shadow|elevation/.test(p)) return 'shadow';
   if (/line-height|leading/.test(p)) return 'lineHeight';
+  if (/radius|rounded|border-radius/.test(p)) return 'radius';
+  if (/shadow|elevation/.test(p)) return 'shadow';
+  if (/spacing|space|gap|padding|margin|indent|offset/.test(p)) return 'spacing';
 
-  // Value-based fallback
+  // `--text-*` is ambiguous in Tailwind v4 (size vs color). Disambiguate by value.
+  if (/^text-/.test(p)) {
+    if (looksLikeColor(value)) return 'color';
+    if (looksLikeLength(value)) return 'fontSize';
+    if (/^text-(xs|sm|base|lg|xl|\d+xl)$/.test(p)) return 'fontSize';
+    return 'color';
+  }
+
+  if (
+    /color|palette|brand|accent|fg|bg|foreground|background|fill|stroke|ring|border-color/.test(p)
+  )
+    return 'color';
+
+  // Value-based fallback (handles e.g. `--border-primary: #fff` after broad keywords).
   if (looksLikeColor(value)) return 'color';
 
   return null;
@@ -29,6 +42,10 @@ function looksLikeColor(value: string): boolean {
     /^oklch\s*\(/.test(value) ||
     /^color\s*\(/.test(value)
   );
+}
+
+function looksLikeLength(value: string): boolean {
+  return /^-?\d*\.?\d+(px|rem|em|%|vh|vw|ch|ex|pt|cm|mm|in)\b/i.test(value.trim());
 }
 
 // Extract all CSS custom-property declarations from `:root` or `[data-theme]`

--- a/packages/core/src/brand/cssVarExtractor.ts
+++ b/packages/core/src/brand/cssVarExtractor.ts
@@ -1,0 +1,79 @@
+import { readFile } from 'node:fs/promises';
+import type { DesignToken } from '@open-codesign/shared';
+
+type TokenType = DesignToken['type'];
+
+function inferType(prop: string, value: string): TokenType | null {
+  const p = prop.toLowerCase();
+
+  if (/color|palette|brand|accent|fg|bg|foreground|background|fill|stroke|ring|border/.test(p))
+    return 'color';
+  if (/font-size|text-size|text-sm|text-base|text-lg|text-xl/.test(p)) return 'fontSize';
+  if (/font-family|font-sans|font-mono|font-serif|typeface/.test(p)) return 'fontFamily';
+  if (/spacing|space|gap|padding|margin|indent|offset/.test(p)) return 'spacing';
+  if (/radius|rounded/.test(p)) return 'radius';
+  if (/shadow|elevation/.test(p)) return 'shadow';
+  if (/line-height|leading/.test(p)) return 'lineHeight';
+
+  // Value-based fallback
+  if (looksLikeColor(value)) return 'color';
+
+  return null;
+}
+
+function looksLikeColor(value: string): boolean {
+  return (
+    /^#[0-9a-fA-F]{3,8}$/.test(value) ||
+    /^rgba?\s*\(/.test(value) ||
+    /^hsla?\s*\(/.test(value) ||
+    /^oklch\s*\(/.test(value) ||
+    /^color\s*\(/.test(value)
+  );
+}
+
+// Extract all CSS custom-property declarations from `:root` or `[data-theme]`
+// blocks in the given CSS source text.
+function extractDeclarations(source: string): Array<{ prop: string; value: string }> {
+  const results: Array<{ prop: string; value: string }> = [];
+
+  const blockRe = /(?::root|\[data-theme[^\]]*\])\s*\{([^}]*)\}/g;
+  const blockMatches = [...source.matchAll(blockRe)];
+
+  for (const blockMatch of blockMatches) {
+    const body = blockMatch[1];
+    if (!body) continue;
+
+    const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
+    const declMatches = [...body.matchAll(declRe)];
+
+    for (const dm of declMatches) {
+      const prop = dm[1]?.trim();
+      const value = dm[2]?.trim();
+      if (prop && value) results.push({ prop, value });
+    }
+  }
+
+  return results;
+}
+
+export async function extractFromCssVars(filePath: string): Promise<DesignToken[]> {
+  const source = await readFile(filePath, 'utf-8');
+  const declarations = extractDeclarations(source);
+  const tokens: DesignToken[] = [];
+
+  for (const { prop, value } of declarations) {
+    const tokenType = inferType(prop, value);
+    if (!tokenType) continue;
+
+    tokens.push({
+      schemaVersion: 1,
+      type: tokenType,
+      name: prop,
+      value,
+      origin: 'css-vars',
+      group: prop.split('-').slice(0, 3).join('-'),
+    });
+  }
+
+  return tokens;
+}

--- a/packages/core/src/brand/dtcgImporter.test.ts
+++ b/packages/core/src/brand/dtcgImporter.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { importDtcgJson } from './dtcgImporter.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(__dir, '__fixtures__/tokens.json');
+const FIXTURE_JSON: unknown = JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8'));
+
+describe('importDtcgJson()', () => {
+  it('flattens nested DTCG structure into DesignToken array', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+
+  it('extracts color tokens with dot-path names', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const colorTokens = tokens.filter((t) => t.type === 'color');
+    const names = colorTokens.map((t) => t.name);
+
+    expect(names).toContain('color.brand.primary');
+    expect(names).toContain('color.brand.secondary');
+  });
+
+  it('uses $type: color for explicitly typed color tokens', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const primary = tokens.find((t) => t.name === 'color.brand.primary');
+
+    expect(primary).toBeDefined();
+    expect(primary?.type).toBe('color');
+    expect(primary?.value).toBe('#D97757');
+  });
+
+  it('inherits group $type for children without explicit $type', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    // neutral.100 and neutral.900 have no explicit $type but are under color group
+    const neutral100 = tokens.find((t) => t.name === 'color.neutral.100');
+    expect(neutral100).toBeDefined();
+    expect(neutral100?.type).toBe('color');
+  });
+
+  it('extracts fontFamily tokens', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const fontFamilyTokens = tokens.filter((t) => t.type === 'fontFamily');
+
+    expect(fontFamilyTokens.length).toBeGreaterThan(0);
+    const sansToken = fontFamilyTokens.find((t) => t.name === 'typography.fontFamily.sans');
+    expect(sansToken).toBeDefined();
+    expect(sansToken?.value).toContain('Inter');
+  });
+
+  it('maps $type: dimension to spacing for spacing tokens', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const spacingTokens = tokens.filter((t) => t.type === 'spacing');
+    const names = spacingTokens.map((t) => t.name);
+
+    expect(names).toContain('spacing.1');
+    expect(names).toContain('spacing.4');
+  });
+
+  it('extracts shadow tokens', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const shadowTokens = tokens.filter((t) => t.type === 'shadow');
+
+    expect(shadowTokens.length).toBeGreaterThan(0);
+    expect(shadowTokens[0]?.name).toBe('shadow.sm');
+  });
+
+  it('sets group from parent path segments', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const primary = tokens.find((t) => t.name === 'color.brand.primary');
+
+    expect(primary?.group).toBe('color.brand');
+  });
+
+  it('sets top-level tokens group to parent key', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const spacing1 = tokens.find((t) => t.name === 'spacing.1');
+    expect(spacing1?.group).toBe('spacing');
+  });
+
+  it('sets origin to dtcg-json on every token', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    for (const token of tokens) {
+      expect(token.origin).toBe('dtcg-json');
+    }
+  });
+
+  it('sets schemaVersion to 1 on every token', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    for (const token of tokens) {
+      expect(token.schemaVersion).toBe(1);
+    }
+  });
+
+  it('handles non-object input gracefully (returns empty array)', () => {
+    expect(importDtcgJson(null)).toEqual([]);
+    expect(importDtcgJson('not-an-object')).toEqual([]);
+    expect(importDtcgJson(42)).toEqual([]);
+    expect(importDtcgJson([])).toEqual([]);
+  });
+});

--- a/packages/core/src/brand/dtcgImporter.test.ts
+++ b/packages/core/src/brand/dtcgImporter.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { importDtcgJson } from './dtcgImporter.js';
 
 const __dir = dirname(fileURLToPath(import.meta.url));
@@ -139,5 +139,42 @@ describe('importDtcgJson()', () => {
     expect(importDtcgJson('not-an-object')).toEqual([]);
     expect(importDtcgJson(42)).toEqual([]);
     expect(importDtcgJson([])).toEqual([]);
+  });
+
+  describe('unresolved type inference', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('preserves tokens with unresolvable type as `unknown` and warns with token name', () => {
+      const tokens = importDtcgJson({
+        misc: {
+          mystery: { $value: '42deg', $type: 'angle' },
+        },
+      });
+
+      const mystery = tokens.find((t) => t.name === 'misc.mystery');
+      expect(mystery).toBeDefined();
+      expect(mystery?.type).toBe('unknown');
+      expect(mystery?.value).toBe('42deg');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(message).toContain('misc.mystery');
+      expect(message).toContain('unknown');
+    });
+
+    it('does not warn when every token resolves to a known type', () => {
+      importDtcgJson({
+        color: { brand: { $value: '#fff', $type: 'color' } },
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/brand/dtcgImporter.test.ts
+++ b/packages/core/src/brand/dtcgImporter.test.ts
@@ -94,6 +94,46 @@ describe('importDtcgJson()', () => {
     }
   });
 
+  it('classifies $type: dimension under typography.fontSize.* as fontSize, not spacing', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const sm = tokens.find((t) => t.name === 'typography.fontSize.sm');
+    const base = tokens.find((t) => t.name === 'typography.fontSize.base');
+
+    expect(sm?.type).toBe('fontSize');
+    expect(base?.type).toBe('fontSize');
+    const spacingNames = tokens.filter((t) => t.type === 'spacing').map((t) => t.name);
+    expect(spacingNames).not.toContain('typography.fontSize.sm');
+  });
+
+  it('classifies $type: dimension under radius.* as radius, not spacing', () => {
+    const tokens = importDtcgJson(FIXTURE_JSON);
+    const radiusSm = tokens.find((t) => t.name === 'radius.sm');
+    expect(radiusSm?.type).toBe('radius');
+  });
+
+  it('does not coerce border-width style dimension tokens into spacing', () => {
+    const tokens = importDtcgJson({
+      border: {
+        width: {
+          thin: { $value: '1px', $type: 'dimension' },
+        },
+      },
+    });
+    // Schema has no `borderWidth`; we must NOT silently bucket it as spacing.
+    const thin = tokens.find((t) => t.name === 'border.width.thin');
+    expect(thin?.type).not.toBe('spacing');
+  });
+
+  it('does not promote a generic $type: dimension (no path hint) into spacing', () => {
+    const tokens = importDtcgJson({
+      misc: {
+        thingy: { $value: '12px', $type: 'dimension' },
+      },
+    });
+    const spacingNames = tokens.filter((t) => t.type === 'spacing').map((t) => t.name);
+    expect(spacingNames).not.toContain('misc.thingy');
+  });
+
   it('handles non-object input gracefully (returns empty array)', () => {
     expect(importDtcgJson(null)).toEqual([]);
     expect(importDtcgJson('not-an-object')).toEqual([]);

--- a/packages/core/src/brand/dtcgImporter.ts
+++ b/packages/core/src/brand/dtcgImporter.ts
@@ -6,14 +6,16 @@ import type { DesignToken } from '@open-codesign/shared';
 
 type TokenType = DesignToken['type'];
 
-// Map W3C DTCG $type values to our internal token types.
+// Map W3C DTCG $type values that have an unambiguous internal counterpart.
+// `dimension` and `number` are intentionally absent: they can mean spacing,
+// font-size, line-height, radius, border-width, etc. — the path is the only
+// reliable hint, so we infer instead of forcing a single bucket.
 const DTCG_TYPE_MAP: Partial<Record<string, TokenType>> = {
   color: 'color',
   fontFamily: 'fontFamily',
   fontSize: 'fontSize',
-  dimension: 'spacing',
   shadow: 'shadow',
-  number: 'spacing',
+  lineHeight: 'lineHeight',
 };
 
 function resolveTypeFromPath(path: string): TokenType | null {
@@ -21,14 +23,18 @@ function resolveTypeFromPath(path: string): TokenType | null {
   if (/color|palette|fill|bg|background|foreground/.test(p)) return 'color';
   if (/font-family|fontfamily|typeface/.test(p)) return 'fontFamily';
   if (/font-size|fontsize|text-size/.test(p)) return 'fontSize';
-  if (/spacing|space|gap|padding|margin/.test(p)) return 'spacing';
+  if (/line-height|lineheight|leading/.test(p)) return 'lineHeight';
   if (/radius|rounded/.test(p)) return 'radius';
   if (/shadow|elevation/.test(p)) return 'shadow';
-  if (/line-height|lineheight|leading/.test(p)) return 'lineHeight';
+  if (/spacing|space|gap|padding|margin/.test(p)) return 'spacing';
   return null;
 }
 
 function resolveType(dtcgType: string | undefined, path: string): TokenType | null {
+  // Ambiguous DTCG types — name/path is authoritative, never silently coerce.
+  if (dtcgType === 'dimension' || dtcgType === 'number') {
+    return resolveTypeFromPath(path);
+  }
   if (dtcgType) {
     const mapped = DTCG_TYPE_MAP[dtcgType];
     if (mapped) return mapped;

--- a/packages/core/src/brand/dtcgImporter.ts
+++ b/packages/core/src/brand/dtcgImporter.ts
@@ -1,0 +1,101 @@
+import type { DesignToken } from '@open-codesign/shared';
+
+// W3C Design Tokens Community Group spec (2025.10 stable) defines leaf tokens
+// as JSON objects containing a `$value` key and an optional `$type` key.
+// Groups are plain objects without `$value`.
+
+type TokenType = DesignToken['type'];
+
+// Map W3C DTCG $type values to our internal token types.
+const DTCG_TYPE_MAP: Partial<Record<string, TokenType>> = {
+  color: 'color',
+  fontFamily: 'fontFamily',
+  fontSize: 'fontSize',
+  dimension: 'spacing',
+  shadow: 'shadow',
+  number: 'spacing',
+};
+
+function resolveTypeFromPath(path: string): TokenType | null {
+  const p = path.toLowerCase();
+  if (/color|palette|fill|bg|background|foreground/.test(p)) return 'color';
+  if (/font-family|fontfamily|typeface/.test(p)) return 'fontFamily';
+  if (/font-size|fontsize|text-size/.test(p)) return 'fontSize';
+  if (/spacing|space|gap|padding|margin/.test(p)) return 'spacing';
+  if (/radius|rounded/.test(p)) return 'radius';
+  if (/shadow|elevation/.test(p)) return 'shadow';
+  if (/line-height|lineheight|leading/.test(p)) return 'lineHeight';
+  return null;
+}
+
+function resolveType(dtcgType: string | undefined, path: string): TokenType | null {
+  if (dtcgType) {
+    const mapped = DTCG_TYPE_MAP[dtcgType];
+    if (mapped) return mapped;
+  }
+  return resolveTypeFromPath(path);
+}
+
+function serializeValue(rawValue: unknown): string {
+  if (typeof rawValue === 'string') return rawValue;
+  if (typeof rawValue === 'number') return String(rawValue);
+  return JSON.stringify(rawValue);
+}
+
+function pushLeafToken(
+  record: Record<string, unknown>,
+  pathSegments: string[],
+  inherited$type: string | undefined,
+  into: DesignToken[],
+): void {
+  const rawValue = record['$value'];
+  const $type = typeof record['$type'] === 'string' ? record['$type'] : inherited$type;
+
+  const value = serializeValue(rawValue);
+  const name = pathSegments.join('.');
+  const tokenType = resolveType($type, name);
+  if (!tokenType) return;
+
+  const group = pathSegments.length > 1 ? pathSegments.slice(0, -1).join('.') : undefined;
+
+  into.push({
+    schemaVersion: 1,
+    type: tokenType,
+    name,
+    value,
+    origin: 'dtcg-json',
+    ...(group !== undefined ? { group } : {}),
+  });
+}
+
+// Recursively walk a DTCG JSON tree. Leaf token nodes carry `$value`;
+// group nodes hold other nodes.
+function walk(
+  node: unknown,
+  pathSegments: string[],
+  inherited$type: string | undefined,
+  into: DesignToken[],
+): void {
+  if (typeof node !== 'object' || node === null || Array.isArray(node)) return;
+
+  const record = node as Record<string, unknown>;
+
+  if ('$value' in record) {
+    pushLeafToken(record, pathSegments, inherited$type, into);
+    return;
+  }
+
+  // Group node — descend, inheriting $type if declared on the group.
+  const groupType = typeof record['$type'] === 'string' ? record['$type'] : inherited$type;
+
+  for (const key of Object.keys(record)) {
+    if (key.startsWith('$')) continue;
+    walk(record[key], [...pathSegments, key], groupType, into);
+  }
+}
+
+export function importDtcgJson(json: unknown): DesignToken[] {
+  const tokens: DesignToken[] = [];
+  walk(json, [], undefined, tokens);
+  return tokens;
+}

--- a/packages/core/src/brand/dtcgImporter.ts
+++ b/packages/core/src/brand/dtcgImporter.ts
@@ -53,14 +53,21 @@ function pushLeafToken(
   pathSegments: string[],
   inherited$type: string | undefined,
   into: DesignToken[],
+  unresolved: string[],
 ): void {
   const rawValue = record['$value'];
   const $type = typeof record['$type'] === 'string' ? record['$type'] : inherited$type;
 
   const value = serializeValue(rawValue);
   const name = pathSegments.join('.');
-  const tokenType = resolveType($type, name);
-  if (!tokenType) return;
+  const resolved = resolveType($type, name);
+  // Preserve unrecognized tokens under `unknown` rather than silently dropping
+  // them — losing user-authored brand tokens is worse than carrying a token
+  // the renderer chooses to ignore. Caller is warned with the full name list.
+  const tokenType: TokenType = resolved ?? 'unknown';
+  if (resolved === null) {
+    unresolved.push(name);
+  }
 
   const group = pathSegments.length > 1 ? pathSegments.slice(0, -1).join('.') : undefined;
 
@@ -81,13 +88,14 @@ function walk(
   pathSegments: string[],
   inherited$type: string | undefined,
   into: DesignToken[],
+  unresolved: string[],
 ): void {
   if (typeof node !== 'object' || node === null || Array.isArray(node)) return;
 
   const record = node as Record<string, unknown>;
 
   if ('$value' in record) {
-    pushLeafToken(record, pathSegments, inherited$type, into);
+    pushLeafToken(record, pathSegments, inherited$type, into, unresolved);
     return;
   }
 
@@ -96,12 +104,18 @@ function walk(
 
   for (const key of Object.keys(record)) {
     if (key.startsWith('$')) continue;
-    walk(record[key], [...pathSegments, key], groupType, into);
+    walk(record[key], [...pathSegments, key], groupType, into, unresolved);
   }
 }
 
 export function importDtcgJson(json: unknown): DesignToken[] {
   const tokens: DesignToken[] = [];
-  walk(json, [], undefined, tokens);
+  const unresolved: string[] = [];
+  walk(json, [], undefined, tokens, unresolved);
+  if (unresolved.length > 0) {
+    console.warn(
+      `[dtcgImporter] ${unresolved.length} token(s) imported as type "unknown" (could not infer DTCG type from $type or path): ${unresolved.join(', ')}`,
+    );
+  }
   return tokens;
 }

--- a/packages/core/src/brand/index.ts
+++ b/packages/core/src/brand/index.ts
@@ -1,0 +1,4 @@
+export { extractFromTailwindConfig } from './tailwindExtractor.js';
+export { extractFromCssVars } from './cssVarExtractor.js';
+export { importDtcgJson } from './dtcgImporter.js';
+export type { DesignToken, DesignTokenSet } from '@open-codesign/shared';

--- a/packages/core/src/brand/tailwindExtractor.test.ts
+++ b/packages/core/src/brand/tailwindExtractor.test.ts
@@ -74,4 +74,18 @@ describe('extractFromTailwindConfig()', () => {
     const unique = new Set(names);
     expect(unique.size).toBe(names.length);
   });
+
+  it('extracts tokens from every @theme block when multiple are present (v4)', async () => {
+    const multiThemeFixture = resolve(__dir, '__fixtures__/tailwind.v4.multi-theme.css');
+    const tokens = await extractFromTailwindConfig(multiThemeFixture);
+    const names = tokens.map((t) => t.name);
+
+    expect(names).toContain('color-brand-primary');
+    expect(names).toContain('color-brand-secondary');
+    expect(names).toContain('font-size-base');
+
+    expect(names).toContain('color-accent');
+    expect(names).toContain('radius-md');
+    expect(names).toContain('shadow-lg');
+  });
 });

--- a/packages/core/src/brand/tailwindExtractor.test.ts
+++ b/packages/core/src/brand/tailwindExtractor.test.ts
@@ -116,6 +116,33 @@ describe('extractFromTailwindConfig()', () => {
     expect(names).toContain('color-brand-secondary');
   });
 
+  it('detects and extracts tokens from @theme inline { ... } (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(file, '@theme inline {\n  --color-brand-x: #112233;\n}\n');
+    const tokens = await extractFromTailwindConfig(file);
+    const names = tokens.map((t) => t.name);
+    expect(names).toContain('color-brand-x');
+  });
+
+  it('detects and extracts tokens from @theme static { ... } (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(file, '@theme static {\n  --spacing-y: 2px;\n}\n');
+    const tokens = await extractFromTailwindConfig(file);
+    const names = tokens.map((t) => t.name);
+    expect(names).toContain('spacing-y');
+  });
+
+  it('detects and extracts tokens from @theme reference { ... } (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(file, '@theme reference {\n  --radius-z: 3px;\n}\n');
+    const tokens = await extractFromTailwindConfig(file);
+    const names = tokens.map((t) => t.name);
+    expect(names).toContain('radius-z');
+  });
+
   it('classifies --text-* size tokens as fontSize and color tokens as color (v4)', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
     const file = join(dir, 'tailwind.css');

--- a/packages/core/src/brand/tailwindExtractor.test.ts
+++ b/packages/core/src/brand/tailwindExtractor.test.ts
@@ -1,0 +1,77 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { extractFromTailwindConfig } from './tailwindExtractor.js';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dir, '__fixtures__/tailwind.config.js');
+
+describe('extractFromTailwindConfig()', () => {
+  it('extracts brand colors from theme.extend.colors', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const colorTokens = tokens.filter((t) => t.type === 'color');
+    const names = colorTokens.map((t) => t.name);
+
+    expect(names).toContain('colors.brand.primary');
+    expect(names).toContain('colors.brand.secondary');
+  });
+
+  it('extracts top-level colors from theme.colors', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const colorTokens = tokens.filter((t) => t.type === 'color');
+    const names = colorTokens.map((t) => t.name);
+
+    expect(names).toContain('colors.white');
+    expect(names).toContain('colors.black');
+  });
+
+  it('extracts fontSize tokens', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const fontSizeTokens = tokens.filter((t) => t.type === 'fontSize');
+
+    expect(fontSizeTokens.length).toBeGreaterThan(0);
+    const names = fontSizeTokens.map((t) => t.name);
+    expect(names).toContain('fontSize.base');
+    expect(names).toContain('fontSize.lg');
+  });
+
+  it('extracts fontFamily tokens', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const fontFamilyTokens = tokens.filter((t) => t.type === 'fontFamily');
+
+    expect(fontFamilyTokens.length).toBeGreaterThan(0);
+    const sansToken = fontFamilyTokens.find((t) => t.name === 'fontFamily.sans');
+    expect(sansToken).toBeDefined();
+    expect(sansToken?.value).toContain('Inter');
+  });
+
+  it('extracts borderRadius tokens', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const radiusTokens = tokens.filter((t) => t.type === 'radius');
+
+    expect(radiusTokens.length).toBeGreaterThan(0);
+    const names = radiusTokens.map((t) => t.name);
+    expect(names).toContain('borderRadius.md');
+  });
+
+  it('sets origin to tailwind-config on every token', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    for (const token of tokens) {
+      expect(token.origin).toBe('tailwind-config');
+    }
+  });
+
+  it('sets schemaVersion to 1 on every token', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    for (const token of tokens) {
+      expect(token.schemaVersion).toBe(1);
+    }
+  });
+
+  it('does not return duplicate token names', async () => {
+    const tokens = await extractFromTailwindConfig(FIXTURE);
+    const names = tokens.map((t) => t.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+});

--- a/packages/core/src/brand/tailwindExtractor.test.ts
+++ b/packages/core/src/brand/tailwindExtractor.test.ts
@@ -115,4 +115,28 @@ describe('extractFromTailwindConfig()', () => {
     const names = tokens.map((t) => t.name);
     expect(names).toContain('color-brand-secondary');
   });
+
+  it('classifies --text-* size tokens as fontSize and color tokens as color (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(
+      file,
+      [
+        '@theme {',
+        '  --text-lg: 1.125rem;',
+        '  --text-base: 1rem;',
+        '  --text-primary: oklch(0.7 0.1 30);',
+        '  --text-muted: #888888;',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    const tokens = await extractFromTailwindConfig(file);
+    const byName = new Map(tokens.map((t) => [t.name, t]));
+
+    expect(byName.get('text-lg')?.type).toBe('fontSize');
+    expect(byName.get('text-base')?.type).toBe('fontSize');
+    expect(byName.get('text-primary')?.type).toBe('color');
+    expect(byName.get('text-muted')?.type).toBe('color');
+  });
 });

--- a/packages/core/src/brand/tailwindExtractor.test.ts
+++ b/packages/core/src/brand/tailwindExtractor.test.ts
@@ -1,4 +1,6 @@
-import { dirname, resolve } from 'node:path';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { extractFromTailwindConfig } from './tailwindExtractor.js';
@@ -87,5 +89,30 @@ describe('extractFromTailwindConfig()', () => {
     expect(names).toContain('color-accent');
     expect(names).toContain('radius-md');
     expect(names).toContain('shadow-lg');
+  });
+
+  it('does not terminate @theme block on `}` inside a string literal (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(
+      file,
+      '@theme {\n  --font-family-display: "Inter, fallback }";\n  --color-brand-primary: #ff0000;\n}\n',
+    );
+    const tokens = await extractFromTailwindConfig(file);
+    const names = tokens.map((t) => t.name);
+    expect(names).toContain('font-family-display');
+    expect(names).toContain('color-brand-primary');
+  });
+
+  it('ignores `}` inside a CSS comment (v4)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'tw-extract-'));
+    const file = join(dir, 'tailwind.css');
+    await writeFile(
+      file,
+      '@theme {\n  /* close brace } in a comment */\n  --color-brand-secondary: #00ff00;\n}\n',
+    );
+    const tokens = await extractFromTailwindConfig(file);
+    const names = tokens.map((t) => t.name);
+    expect(names).toContain('color-brand-secondary');
   });
 });

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -155,33 +155,34 @@ function inferTypeFromCssProp(prop: string, value: string): TokenType | null {
 function extractFromV4Theme(source: string): DesignToken[] {
   const results: DesignToken[] = [];
 
-  const themeBlockRe = /@theme\s*\{/g;
-  const m = themeBlockRe.exec(source);
-  if (!m) return results;
+  const themeBlockRe = /@theme\b[^{]*\{/g;
+  const seen = new Set<string>();
 
-  const blockStart = m.index + m[0].length - 1;
-  const body = extractBodyAt(source, blockStart);
-  if (!body) return results;
+  for (const m of source.matchAll(themeBlockRe)) {
+    const blockStart = (m.index ?? 0) + m[0].length - 1;
+    const body = extractBodyAt(source, blockStart);
+    if (!body) continue;
 
-  const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
-  const declMatches = [...body.matchAll(declRe)];
+    const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
+    for (const dm of body.matchAll(declRe)) {
+      const prop = dm[1];
+      const rawValue = dm[2]?.trim();
+      if (!prop || !rawValue) continue;
+      if (seen.has(prop)) continue;
 
-  for (const dm of declMatches) {
-    const prop = dm[1];
-    const rawValue = dm[2]?.trim();
-    if (!prop || !rawValue) continue;
+      const tokenType = inferTypeFromCssProp(prop, rawValue);
+      if (!tokenType) continue;
 
-    const tokenType = inferTypeFromCssProp(prop, rawValue);
-    if (!tokenType) continue;
-
-    results.push({
-      schemaVersion: 1,
-      type: tokenType,
-      name: prop,
-      value: rawValue,
-      origin: 'tailwind-config',
-      group: prop.split('-').slice(0, 2).join('.'),
-    });
+      seen.add(prop);
+      results.push({
+        schemaVersion: 1,
+        type: tokenType,
+        name: prop,
+        value: rawValue,
+        origin: 'tailwind-config',
+        group: prop.split('-').slice(0, 2).join('.'),
+      });
+    }
   }
 
   return results;

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -93,8 +93,7 @@ function collectLeafPairs(body: string, prefix: string): Array<{ name: string; v
   const flat = stripNestedBlocks(body);
 
   // Match  key: 'value'  or  key: "value"  or  key: ['a', 'b']  or  key: ["a", "b"]
-  const leafRe =
-    /['"]?([\w-]+)['"]?\s*:\s*(?:'([^']+)'|"([^"]+)"|\[(['"]?[^[\]]+['"]?)\])/g;
+  const leafRe = /['"]?([\w-]+)['"]?\s*:\s*(?:'([^']+)'|"([^"]+)"|\[(['"]?[^[\]]+['"]?)\])/g;
   const leafMatches = [...flat.matchAll(leafRe)];
 
   for (const m of leafMatches) {

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -182,7 +182,7 @@ function collectLeafPairs(body: string, prefix: string): Array<{ name: string; v
 }
 
 function hasTailwindV4Theme(source: string): boolean {
-  return /@theme\s*\{/.test(source);
+  return /@theme\b[^{]*\{/.test(source);
 }
 
 function inferTypeFromCssProp(prop: string, value: string): TokenType | null {

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -36,6 +36,10 @@ function looksLikeColor(value: string): boolean {
   );
 }
 
+function looksLikeLength(value: string): boolean {
+  return /^-?\d*\.?\d+(px|rem|em|%|vh|vw|ch|ex|pt|cm|mm|in)\b/i.test(value.trim());
+}
+
 // Extract all section object literal bodies for a given key.
 // We collect all occurrences (e.g. theme.colors AND theme.extend.colors) so
 // nested extends do not shadow the base theme.
@@ -182,13 +186,24 @@ function hasTailwindV4Theme(source: string): boolean {
 }
 
 function inferTypeFromCssProp(prop: string, value: string): TokenType | null {
-  if (/color|bg|text|border|fill|stroke|ring/.test(prop)) return 'color';
+  // Order matters: specific shape patterns must run before broad keyword fallbacks
+  // so Tailwind v4 `--text-*` size tokens are not misclassified as color.
   if (/font-size|text-size/.test(prop)) return 'fontSize';
   if (/font-family/.test(prop)) return 'fontFamily';
-  if (/spacing|gap|padding|margin|space/.test(prop)) return 'spacing';
+  if (/line-height|leading/.test(prop)) return 'lineHeight';
   if (/radius|rounded/.test(prop)) return 'radius';
   if (/shadow/.test(prop)) return 'shadow';
-  if (/line-height|leading/.test(prop)) return 'lineHeight';
+  if (/spacing|gap|padding|margin|space/.test(prop)) return 'spacing';
+
+  // `--text-*` is ambiguous in Tailwind v4 (size vs color). Disambiguate by value.
+  if (/^text-/.test(prop)) {
+    if (looksLikeColor(value)) return 'color';
+    if (looksLikeLength(value)) return 'fontSize';
+    if (/^text-(xs|sm|base|lg|xl|\d+xl)$/.test(prop)) return 'fontSize';
+    return 'color';
+  }
+
+  if (/color|bg|border|fill|stroke|ring/.test(prop)) return 'color';
   if (looksLikeColor(value)) return 'color';
   return null;
 }

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -1,0 +1,237 @@
+import { readFile } from 'node:fs/promises';
+import type { DesignToken } from '@open-codesign/shared';
+
+// Matches a JS/TS object key that starts a nested block or a leaf value.
+// We intentionally parse the config as text — never require() or eval() it.
+// This prevents arbitrary code execution from user-supplied config files.
+
+type TokenType = DesignToken['type'];
+
+interface TailwindThemeSection {
+  key: string;
+  tokenType: TokenType;
+}
+
+const THEME_SECTIONS: TailwindThemeSection[] = [
+  { key: 'colors', tokenType: 'color' },
+  { key: 'color', tokenType: 'color' },
+  { key: 'backgroundColor', tokenType: 'color' },
+  { key: 'textColor', tokenType: 'color' },
+  { key: 'borderColor', tokenType: 'color' },
+  { key: 'fontSize', tokenType: 'fontSize' },
+  { key: 'fontFamily', tokenType: 'fontFamily' },
+  { key: 'spacing', tokenType: 'spacing' },
+  { key: 'borderRadius', tokenType: 'radius' },
+  { key: 'boxShadow', tokenType: 'shadow' },
+  { key: 'lineHeight', tokenType: 'lineHeight' },
+];
+
+function looksLikeColor(value: string): boolean {
+  return (
+    /^#[0-9a-fA-F]{3,8}$/.test(value) ||
+    /^rgba?\s*\(/.test(value) ||
+    /^hsla?\s*\(/.test(value) ||
+    /^oklch\s*\(/.test(value) ||
+    /^color\s*\(/.test(value)
+  );
+}
+
+// Extract all section object literal bodies for a given key.
+// We collect all occurrences (e.g. theme.colors AND theme.extend.colors) so
+// nested extends do not shadow the base theme.
+function extractAllSectionBodies(source: string, sectionKey: string): string[] {
+  const bodies: string[] = [];
+  const sectionRe = new RegExp(`\\b${sectionKey}\\s*:\\s*\\{`, 'g');
+  const matches = [...source.matchAll(sectionRe)];
+
+  for (const match of matches) {
+    const startBrace = (match.index ?? 0) + match[0].length - 1;
+    const body = extractBodyAt(source, startBrace);
+    if (body !== null) bodies.push(body);
+  }
+
+  return bodies;
+}
+
+// Extract the body of a `{` brace at position `bracePos` in `text`.
+function extractBodyAt(text: string, bracePos: number): string | null {
+  if (text[bracePos] !== '{') return null;
+  let depth = 0;
+  let i = bracePos;
+  while (i < text.length) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}') {
+      depth--;
+      if (depth === 0) return text.slice(bracePos + 1, i);
+    }
+    i++;
+  }
+  return null;
+}
+
+// Remove nested object blocks so leaf regex only sees top-level keys.
+function stripNestedBlocks(body: string): string {
+  let result = '';
+  let depth = 0;
+  for (const ch of body) {
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      if (depth > 0) depth--;
+    } else if (depth === 0) {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+// Walk object literal text and collect leaf key→value pairs.
+// Only extracts simple string literals and string arrays; skips functions and spreads.
+function collectLeafPairs(body: string, prefix: string): Array<{ name: string; value: string }> {
+  const results: Array<{ name: string; value: string }> = [];
+
+  const flat = stripNestedBlocks(body);
+
+  // Match  key: 'value'  or  key: "value"  or  key: ['a', 'b']  or  key: ["a", "b"]
+  const leafRe =
+    /['"]?([\w-]+)['"]?\s*:\s*(?:'([^']+)'|"([^"]+)"|\[(['"]?[^[\]]+['"]?)\])/g;
+  const leafMatches = [...flat.matchAll(leafRe)];
+
+  for (const m of leafMatches) {
+    const key = m[1];
+    const strValue = m[2] ?? m[3];
+    const arrRaw = m[4];
+
+    if (key === undefined) continue;
+    if (['DEFAULT', 'screens', 'container'].includes(key)) continue;
+
+    let value: string | undefined;
+    if (strValue !== undefined) {
+      value = strValue;
+    } else if (arrRaw !== undefined) {
+      // Extract first element of the array as the primary value
+      const firstEl = arrRaw.match(/['"]?([^'",]+)['"]?/);
+      value = firstEl?.[1]?.trim();
+    }
+
+    if (!value) continue;
+    const name = prefix ? `${prefix}.${key}` : key;
+    results.push({ name, value });
+  }
+
+  // Recurse into nested blocks
+  const nestedRe = /['"]?([\w-]+)['"]?\s*:\s*\{/g;
+  const nestedMatches = [...body.matchAll(nestedRe)];
+
+  for (const nm of nestedMatches) {
+    const subKey = nm[1];
+    if (subKey === undefined) continue;
+    const subStart = (nm.index ?? 0) + nm[0].length - 1;
+    const subBody = extractBodyAt(body, subStart);
+    if (subBody !== null) {
+      const subPrefix = prefix ? `${prefix}.${subKey}` : subKey;
+      results.push(...collectLeafPairs(subBody, subPrefix));
+    }
+  }
+
+  return results;
+}
+
+function hasTailwindV4Theme(source: string): boolean {
+  return /@theme\s*\{/.test(source);
+}
+
+function inferTypeFromCssProp(prop: string, value: string): TokenType | null {
+  if (/color|bg|text|border|fill|stroke|ring/.test(prop)) return 'color';
+  if (/font-size|text-size/.test(prop)) return 'fontSize';
+  if (/font-family/.test(prop)) return 'fontFamily';
+  if (/spacing|gap|padding|margin|space/.test(prop)) return 'spacing';
+  if (/radius|rounded/.test(prop)) return 'radius';
+  if (/shadow/.test(prop)) return 'shadow';
+  if (/line-height|leading/.test(prop)) return 'lineHeight';
+  if (looksLikeColor(value)) return 'color';
+  return null;
+}
+
+function extractFromV4Theme(source: string): DesignToken[] {
+  const results: DesignToken[] = [];
+
+  const themeBlockRe = /@theme\s*\{/g;
+  const m = themeBlockRe.exec(source);
+  if (!m) return results;
+
+  const blockStart = m.index + m[0].length - 1;
+  const body = extractBodyAt(source, blockStart);
+  if (!body) return results;
+
+  const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
+  const declMatches = [...body.matchAll(declRe)];
+
+  for (const dm of declMatches) {
+    const prop = dm[1];
+    const rawValue = dm[2]?.trim();
+    if (!prop || !rawValue) continue;
+
+    const tokenType = inferTypeFromCssProp(prop, rawValue);
+    if (!tokenType) continue;
+
+    results.push({
+      schemaVersion: 1,
+      type: tokenType,
+      name: prop,
+      value: rawValue,
+      origin: 'tailwind-config',
+      group: prop.split('-').slice(0, 2).join('.'),
+    });
+  }
+
+  return results;
+}
+
+function extractFromV3Config(source: string): DesignToken[] {
+  const results: DesignToken[] = [];
+
+  for (const section of THEME_SECTIONS) {
+    const bodies = extractAllSectionBodies(source, section.key);
+
+    for (const body of bodies) {
+      const pairs = collectLeafPairs(body, section.key);
+      for (const { name, value } of pairs) {
+        if (!value) continue;
+        // Skip values that look like JS function calls (but allow CSS color functions)
+        if (value.includes('(') && !looksLikeColor(value)) continue;
+
+        results.push({
+          schemaVersion: 1,
+          type: section.tokenType,
+          name,
+          value,
+          origin: 'tailwind-config',
+          group: name.split('.').slice(0, 2).join('.'),
+        });
+      }
+    }
+  }
+
+  // Deduplicate by name (first occurrence wins — theme.extend listed first usually)
+  const seen = new Set<string>();
+  const deduped: DesignToken[] = [];
+  for (const token of results) {
+    if (!seen.has(token.name)) {
+      seen.add(token.name);
+      deduped.push(token);
+    }
+  }
+
+  return deduped;
+}
+
+export async function extractFromTailwindConfig(filePath: string): Promise<DesignToken[]> {
+  const source = await readFile(filePath, 'utf-8');
+
+  if (hasTailwindV4Theme(source)) {
+    return extractFromV4Theme(source);
+  }
+
+  return extractFromV3Config(source);
+}

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -54,17 +54,66 @@ function extractAllSectionBodies(source: string, sectionKey: string): string[] {
 }
 
 // Extract the body of a `{` brace at position `bracePos` in `text`.
+// Quote- and comment-aware so braces inside strings or comments do not
+// terminate blocks early.
 function extractBodyAt(text: string, bracePos: number): string | null {
   if (text[bracePos] !== '{') return null;
+
   let depth = 0;
-  let i = bracePos;
-  while (i < text.length) {
-    if (text[i] === '{') depth++;
-    else if (text[i] === '}') {
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = bracePos; i < text.length; i++) {
+    const ch = text[i]!;
+    const next = text[i + 1];
+
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
       depth--;
       if (depth === 0) return text.slice(bracePos + 1, i);
     }
-    i++;
   }
   return null;
 }
@@ -85,6 +134,15 @@ function stripNestedBlocks(body: string): string {
   return result;
 }
 
+function leafValueFromMatch(m: RegExpMatchArray): string | undefined {
+  const strValue = m[2] ?? m[3];
+  if (strValue !== undefined) return strValue;
+  const arrRaw = m[4];
+  if (arrRaw === undefined) return undefined;
+  const firstEl = arrRaw.match(/['"]?([^'",]+)['"]?/);
+  return firstEl?.[1]?.trim();
+}
+
 // Walk object literal text and collect leaf key→value pairs.
 // Only extracts simple string literals and string arrays; skips functions and spreads.
 function collectLeafPairs(body: string, prefix: string): Array<{ name: string; value: string }> {
@@ -94,35 +152,18 @@ function collectLeafPairs(body: string, prefix: string): Array<{ name: string; v
 
   // Match  key: 'value'  or  key: "value"  or  key: ['a', 'b']  or  key: ["a", "b"]
   const leafRe = /['"]?([\w-]+)['"]?\s*:\s*(?:'([^']+)'|"([^"]+)"|\[(['"]?[^[\]]+['"]?)\])/g;
-  const leafMatches = [...flat.matchAll(leafRe)];
-
-  for (const m of leafMatches) {
+  for (const m of flat.matchAll(leafRe)) {
     const key = m[1];
-    const strValue = m[2] ?? m[3];
-    const arrRaw = m[4];
-
     if (key === undefined) continue;
     if (['DEFAULT', 'screens', 'container'].includes(key)) continue;
-
-    let value: string | undefined;
-    if (strValue !== undefined) {
-      value = strValue;
-    } else if (arrRaw !== undefined) {
-      // Extract first element of the array as the primary value
-      const firstEl = arrRaw.match(/['"]?([^'",]+)['"]?/);
-      value = firstEl?.[1]?.trim();
-    }
-
+    const value = leafValueFromMatch(m);
     if (!value) continue;
-    const name = prefix ? `${prefix}.${key}` : key;
-    results.push({ name, value });
+    results.push({ name: prefix ? `${prefix}.${key}` : key, value });
   }
 
   // Recurse into nested blocks
   const nestedRe = /['"]?([\w-]+)['"]?\s*:\s*\{/g;
-  const nestedMatches = [...body.matchAll(nestedRe)];
-
-  for (const nm of nestedMatches) {
+  for (const nm of body.matchAll(nestedRe)) {
     const subKey = nm[1];
     if (subKey === undefined) continue;
     const subStart = (nm.index ?? 0) + nm[0].length - 1;
@@ -152,65 +193,70 @@ function inferTypeFromCssProp(prop: string, value: string): TokenType | null {
   return null;
 }
 
+function collectV4Declarations(body: string, seen: Set<string>): DesignToken[] {
+  const out: DesignToken[] = [];
+  const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
+  for (const dm of body.matchAll(declRe)) {
+    const prop = dm[1];
+    const rawValue = dm[2]?.trim();
+    if (!prop || !rawValue) continue;
+    if (seen.has(prop)) continue;
+
+    const tokenType = inferTypeFromCssProp(prop, rawValue);
+    if (!tokenType) continue;
+
+    seen.add(prop);
+    out.push({
+      schemaVersion: 1,
+      type: tokenType,
+      name: prop,
+      value: rawValue,
+      origin: 'tailwind-config',
+      group: prop.split('-').slice(0, 2).join('.'),
+    });
+  }
+  return out;
+}
+
 function extractFromV4Theme(source: string): DesignToken[] {
   const results: DesignToken[] = [];
-
-  const themeBlockRe = /@theme\b[^{]*\{/g;
   const seen = new Set<string>();
+  const themeBlockRe = /@theme\b[^{]*\{/g;
 
   for (const m of source.matchAll(themeBlockRe)) {
     const blockStart = (m.index ?? 0) + m[0].length - 1;
     const body = extractBodyAt(source, blockStart);
     if (!body) continue;
-
-    const declRe = /--([\w-]+)\s*:\s*([^;]+);/g;
-    for (const dm of body.matchAll(declRe)) {
-      const prop = dm[1];
-      const rawValue = dm[2]?.trim();
-      if (!prop || !rawValue) continue;
-      if (seen.has(prop)) continue;
-
-      const tokenType = inferTypeFromCssProp(prop, rawValue);
-      if (!tokenType) continue;
-
-      seen.add(prop);
-      results.push({
-        schemaVersion: 1,
-        type: tokenType,
-        name: prop,
-        value: rawValue,
-        origin: 'tailwind-config',
-        group: prop.split('-').slice(0, 2).join('.'),
-      });
-    }
+    results.push(...collectV4Declarations(body, seen));
   }
 
   return results;
 }
 
+function collectV3SectionTokens(section: TailwindThemeSection, source: string): DesignToken[] {
+  const out: DesignToken[] = [];
+  for (const body of extractAllSectionBodies(source, section.key)) {
+    for (const { name, value } of collectLeafPairs(body, section.key)) {
+      if (!value) continue;
+      // Skip values that look like JS function calls (but allow CSS color functions)
+      if (value.includes('(') && !looksLikeColor(value)) continue;
+      out.push({
+        schemaVersion: 1,
+        type: section.tokenType,
+        name,
+        value,
+        origin: 'tailwind-config',
+        group: name.split('.').slice(0, 2).join('.'),
+      });
+    }
+  }
+  return out;
+}
+
 function extractFromV3Config(source: string): DesignToken[] {
   const results: DesignToken[] = [];
-
   for (const section of THEME_SECTIONS) {
-    const bodies = extractAllSectionBodies(source, section.key);
-
-    for (const body of bodies) {
-      const pairs = collectLeafPairs(body, section.key);
-      for (const { name, value } of pairs) {
-        if (!value) continue;
-        // Skip values that look like JS function calls (but allow CSS color functions)
-        if (value.includes('(') && !looksLikeColor(value)) continue;
-
-        results.push({
-          schemaVersion: 1,
-          type: section.tokenType,
-          name,
-          value,
-          origin: 'tailwind-config',
-          group: name.split('.').slice(0, 2).join('.'),
-        });
-      }
-    }
+    results.push(...collectV3SectionTokens(section, source));
   }
 
   // Deduplicate by name (first occurrence wins — theme.extend listed first usually)

--- a/packages/shared/src/design-token.ts
+++ b/packages/shared/src/design-token.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const DesignTokenV1 = z.object({
+  schemaVersion: z.literal(1).default(1),
+  type: z.enum(['color', 'fontFamily', 'fontSize', 'spacing', 'radius', 'shadow', 'lineHeight']),
+  name: z.string().min(1),
+  value: z.string().min(1),
+  origin: z.enum(['tailwind-config', 'css-vars', 'figma', 'manual', 'pdf', 'dtcg-json']),
+  group: z.string().optional(),
+});
+export type DesignToken = z.infer<typeof DesignTokenV1>;
+
+export const DesignTokenSet = z.object({
+  schemaVersion: z.literal(1).default(1),
+  name: z.string().min(1),
+  source: z.string().optional(),
+  tokens: z.array(DesignTokenV1),
+});
+export type DesignTokenSet = z.infer<typeof DesignTokenSet>;

--- a/packages/shared/src/design-token.ts
+++ b/packages/shared/src/design-token.ts
@@ -2,7 +2,16 @@ import { z } from 'zod';
 
 export const DesignTokenV1 = z.object({
   schemaVersion: z.literal(1).default(1),
-  type: z.enum(['color', 'fontFamily', 'fontSize', 'spacing', 'radius', 'shadow', 'lineHeight']),
+  type: z.enum([
+    'color',
+    'fontFamily',
+    'fontSize',
+    'spacing',
+    'radius',
+    'shadow',
+    'lineHeight',
+    'unknown',
+  ]),
   name: z.string().min(1),
   value: z.string().min(1),
   origin: z.enum(['tailwind-config', 'css-vars', 'figma', 'manual', 'pdf', 'dtcg-json']),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -202,3 +202,6 @@ export {
   getPresetById,
 } from './proxy-presets';
 export type { ProxyPresetId } from './proxy-presets';
+
+export { DesignTokenV1, DesignTokenSet } from './design-token';
+export type { DesignToken } from './design-token';


### PR DESCRIPTION
## Summary

First PR of 3 implementing Brand Token Inheritance (research 13). Backend extractors only — no UI, no SQLite, no Figma.

- **W3C DTCG-compatible `DesignToken` schema** (`packages/shared/src/design-token.ts`) — zod v1, `schemaVersion` field, 7 token types
- **Tailwind config text-only parser** (`tailwindExtractor.ts`) — handles both v3 JS object literal and v4 CSS `@theme` block; never `require()`/`eval()` — prevents arbitrary code execution from user-supplied files
- **CSS custom properties extractor** (`cssVarExtractor.ts`) — parses `:root` and `[data-theme]` blocks; heuristic type inference from prop name + value
- **W3C DTCG JSON importer** (`dtcgImporter.ts`) — recursive walker with `$type` inheritance from group nodes; maps `dimension` → `spacing`, etc.
- **Public API barrel** (`packages/core/src/brand/index.ts`)

Follow-up:
- **PR-B**: SQLite storage + Settings → Brand tab + IPC
- **PR-C**: Onboarding step + prompt injection + Figma OAuth

## Security

Tailwind config is parsed as text only (no `require()`, no `eval()`). Prevents arbitrary code execution from user-supplied config files.

## New dependencies

None. Zero new runtime or dev dependencies added.

## License impact

None (no new dependencies).

## Test plan

- [x] `tailwindExtractor`: 8 tests — fixture `tailwind.config.js` → colors, fontSize, fontFamily, borderRadius extracted; v3 theme.colors + theme.extend.colors both collected; no duplicates; correct origin/schemaVersion
- [x] `cssVarExtractor`: 8 tests — `--color-*` → color, `--font-family-*` → fontFamily, `--font-size-*` → fontSize, `--space-*` → spacing, `--radius-*` → radius, `--shadow-*` → shadow; `[data-theme]` overrides collected
- [x] `dtcgImporter`: 12 tests — nested `$value/$type` tree → flat tokens with correct group; `$type` inherited from group nodes; shadow/fontFamily/spacing/color all classified; graceful handling of non-object input

All 53 core tests pass. Full workspace green (`pnpm -r test`, `pnpm -r typecheck`).