### PR TITLE
feat(desktop): viewport switcher (desktop / tablet / mobile with phone bezel)

### DIFF
--- a/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
+++ b/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
@@ -18,11 +18,9 @@ export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
         position: 'relative',
         borderRadius: 'var(--radius-phone)',
         border: 'var(--border-width-strong) solid var(--color-border-strong)',
-        boxShadow: 'var(--shadow-elevated)',
+        boxShadow: 'var(--shadow-elevated), var(--shadow-inset-soft)',
         background: 'var(--color-surface)',
         overflow: 'hidden',
-        /* extra inner shadow mimicking the screen recess */
-        outline: '1px solid var(--color-border)',
       }}
     >
       {/* Notch */}

--- a/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
+++ b/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
@@ -16,8 +16,8 @@ export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
         display: 'inline-flex',
         flexDirection: 'column',
         position: 'relative',
-        borderRadius: 'var(--radius-phone, 44px)',
-        border: '8px solid var(--color-border-strong)',
+        borderRadius: 'var(--radius-phone)',
+        border: 'var(--border-width-strong) solid var(--color-border-strong)',
         boxShadow: 'var(--shadow-elevated)',
         background: 'var(--color-surface)',
         overflow: 'hidden',
@@ -33,8 +33,8 @@ export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
           top: 0,
           left: '50%',
           transform: 'translateX(-50%)',
-          width: '120px',
-          height: '30px',
+          width: 'var(--size-preview-mobile-notch-width)',
+          height: 'var(--size-preview-mobile-notch-height)',
           background: 'var(--color-border-strong)',
           borderBottomLeftRadius: 'var(--radius-lg)',
           borderBottomRightRadius: 'var(--radius-lg)',
@@ -45,10 +45,10 @@ export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
       <div
         style={{
           position: 'relative',
-          width: '375px',
-          height: '812px',
+          width: 'var(--size-preview-mobile-width)',
+          height: 'var(--size-preview-mobile-height)',
           overflow: 'hidden',
-          borderRadius: 'calc(var(--radius-phone, 44px) - 8px)',
+          borderRadius: 'calc(var(--radius-phone) - var(--border-width-strong))',
         }}
       >
         {children}

--- a/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
+++ b/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+
+interface PhoneFrameProps {
+  children: ReactElement;
+}
+
+/**
+ * Renders an iPhone-style bezel around its child iframe.
+ * All measurements are derived from design tokens (CSS custom properties).
+ * No px or color hard-codes — see packages/ui/src/tokens.css.
+ */
+export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        flexDirection: 'column',
+        position: 'relative',
+        borderRadius: 'var(--radius-phone, 44px)',
+        border: '8px solid var(--color-border-strong)',
+        boxShadow: 'var(--shadow-elevated)',
+        background: 'var(--color-surface)',
+        overflow: 'hidden',
+        /* extra inner shadow mimicking the screen recess */
+        outline: '1px solid var(--color-border)',
+      }}
+    >
+      {/* Notch */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: '120px',
+          height: '30px',
+          background: 'var(--color-border-strong)',
+          borderBottomLeftRadius: 'var(--radius-lg)',
+          borderBottomRightRadius: 'var(--radius-lg)',
+          zIndex: 2,
+        }}
+      />
+      {/* Screen area */}
+      <div
+        style={{
+          position: 'relative',
+          width: '375px',
+          height: '812px',
+          overflow: 'hidden',
+          borderRadius: 'calc(var(--radius-phone, 44px) - 8px)',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
+++ b/apps/desktop/src/renderer/src/components/PhoneFrame.tsx
@@ -37,6 +37,7 @@ export function PhoneFrame({ children }: PhoneFrameProps): ReactElement {
           borderBottomLeftRadius: 'var(--radius-lg)',
           borderBottomRightRadius: 'var(--radius-lg)',
           zIndex: 2,
+          pointerEvents: 'none',
         }}
       />
       {/* Screen area */}

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -157,8 +157,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
       );
     } else if (previewViewport === 'tablet') {
       body = (
-        <div className="h-full p-6 flex justify-center overflow-auto">
-          <div className="relative" style={{ width: '768px', flexShrink: 0 }}>
+        <div className="flex justify-center h-full" style={{ width: '100%' }}>
+          <div
+            className="relative h-full"
+            style={{ width: 'var(--size-preview-tablet-width)', flexShrink: 0 }}
+          >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
             <InlineCommentComposer />

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -128,6 +128,12 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
       </div>
 =======
     const isMobile = previewViewport === 'mobile';
+    const viewportStyle: React.CSSProperties | undefined = isMobile
+      ? {
+          width: 'var(--size-preview-mobile-width)',
+          height: 'var(--size-preview-mobile-height)',
+        }
+      : undefined;
     const iframe = (
       <iframe
         ref={iframeRef}
@@ -140,7 +146,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
             ? 'w-full h-full bg-white'
             : 'w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
         }
-        style={isMobile ? { width: '375px', height: '812px' } : undefined}
+        style={viewportStyle}
       />
 >>>>>>> 117e6ee (feat(desktop): mobile/tablet/desktop viewport preview with phone bezel)
     );
@@ -157,10 +163,14 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
       );
     } else if (previewViewport === 'tablet') {
       body = (
-        <div className="flex justify-center h-full" style={{ width: '100%' }}>
+        <div className="h-full p-6 flex flex-col items-center justify-start overflow-auto">
           <div
-            className="relative h-full"
-            style={{ width: 'var(--size-preview-tablet-width)', flexShrink: 0 }}
+            className="relative"
+            style={{
+              width: 'var(--size-preview-tablet-width)',
+              height: 'var(--size-preview-tablet-height)',
+              flexShrink: 0,
+            }}
           >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
@@ -170,8 +180,15 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
       );
     } else {
       body = (
-        <div className="h-full p-6">
-          <div className="relative h-full">
+        <div className="h-full p-6 flex flex-col items-center justify-start overflow-auto">
+          <div
+            className="relative"
+            style={{
+              width: 'min(100%, var(--size-preview-desktop-width))',
+              height: 'min(100%, var(--size-preview-desktop-height))',
+              flexShrink: 0,
+            }}
+          >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
             <InlineCommentComposer />

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -32,7 +32,7 @@ export function isTrustedPreviewMessageSource(
 }
 
 const COMMENT_HINT_CLASS =
-  'absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur';
+  'absolute left-[var(--space-5)] top-[var(--space-5)] z-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-[var(--space-3)] py-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur';
 
 export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const t = useT();
@@ -90,43 +90,6 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   } else if (isGenerating && !previewHtml) {
     body = <LoadingState />;
   } else if (previewHtml) {
-<<<<<<< HEAD
-    body = (
-      <div className="h-full p-6">
-        <div className="relative h-full">
-          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_88%,transparent)] px-3 py-1 text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
-            {t('preview.clickToComment')}
-          </div>
-          <iframe
-            ref={iframeRef}
-            key={previewHtml.length}
-            title="design-preview"
-            sandbox="allow-scripts"
-            srcDoc={buildSrcdoc(previewHtml)}
-            className="w-full h-full bg-[var(--color-surface)] rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
-          />
-          <InlineCommentComposer />
-        </div>
-      </div>
-||||||| parent of 117e6ee (feat(desktop): mobile/tablet/desktop viewport preview with phone bezel)
-    body = (
-      <div className="h-full p-6">
-        <div className="relative h-full">
-          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
-            {t('preview.clickToComment')}
-          </div>
-          <iframe
-            ref={iframeRef}
-            key={previewHtml.length}
-            title="design-preview"
-            sandbox="allow-scripts"
-            srcDoc={buildSrcdoc(previewHtml)}
-            className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
-          />
-          <InlineCommentComposer />
-        </div>
-      </div>
-=======
     const isMobile = previewViewport === 'mobile';
     const viewportStyle: React.CSSProperties | undefined = isMobile
       ? {
@@ -148,7 +111,6 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         }
         style={viewportStyle}
       />
->>>>>>> 117e6ee (feat(desktop): mobile/tablet/desktop viewport preview with phone bezel)
     );
 
     if (isMobile) {

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -106,7 +106,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         srcDoc={buildSrcdoc(previewHtml)}
         className={
           isMobile
-            ? 'w-full h-full bg-white'
+            ? 'w-full h-full bg-[var(--color-artifact-bg)]'
             : 'w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
         }
         style={viewportStyle}

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -7,6 +7,7 @@ import { LoadingState } from '../preview/LoadingState';
 import { useCodesignStore } from '../store';
 import { CanvasErrorBar } from './CanvasErrorBar';
 import { InlineCommentComposer } from './InlineCommentComposer';
+import { PhoneFrame } from './PhoneFrame';
 import { PreviewToolbar } from './PreviewToolbar';
 
 export interface PreviewPaneProps {
@@ -30,6 +31,9 @@ export function isTrustedPreviewMessageSource(
   return source !== null && source === previewWindow;
 }
 
+const COMMENT_HINT_CLASS =
+  'absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur';
+
 export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const t = useT();
   const previewHtml = useCodesignStore((s) => s.previewHtml);
@@ -39,6 +43,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const clearError = useCodesignStore((s) => s.clearError);
   const pushIframeError = useCodesignStore((s) => s.pushIframeError);
   const selectCanvasElement = useCodesignStore((s) => s.selectCanvasElement);
+  const previewViewport = useCodesignStore((s) => s.previewViewport);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
@@ -85,6 +90,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   } else if (isGenerating && !previewHtml) {
     body = <LoadingState />;
   } else if (previewHtml) {
+<<<<<<< HEAD
     body = (
       <div className="h-full p-6">
         <div className="relative h-full">
@@ -102,7 +108,74 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           <InlineCommentComposer />
         </div>
       </div>
+||||||| parent of 117e6ee (feat(desktop): mobile/tablet/desktop viewport preview with phone bezel)
+    body = (
+      <div className="h-full p-6">
+        <div className="relative h-full">
+          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
+            {t('preview.clickToComment')}
+          </div>
+          <iframe
+            ref={iframeRef}
+            key={previewHtml.length}
+            title="design-preview"
+            sandbox="allow-scripts"
+            srcDoc={buildSrcdoc(previewHtml)}
+            className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
+          />
+          <InlineCommentComposer />
+        </div>
+      </div>
+=======
+    const isMobile = previewViewport === 'mobile';
+    const iframe = (
+      <iframe
+        ref={iframeRef}
+        key={previewHtml.length}
+        title="design-preview"
+        sandbox="allow-scripts"
+        srcDoc={buildSrcdoc(previewHtml)}
+        className={
+          isMobile
+            ? 'w-full h-full bg-white'
+            : 'w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
+        }
+        style={isMobile ? { width: '375px', height: '812px' } : undefined}
+      />
+>>>>>>> 117e6ee (feat(desktop): mobile/tablet/desktop viewport preview with phone bezel)
     );
+
+    if (isMobile) {
+      body = (
+        <div className="h-full p-6 flex flex-col items-center justify-start overflow-auto">
+          <div className="relative">
+            <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
+            <PhoneFrame>{iframe}</PhoneFrame>
+            <InlineCommentComposer />
+          </div>
+        </div>
+      );
+    } else if (previewViewport === 'tablet') {
+      body = (
+        <div className="h-full p-6 flex justify-center overflow-auto">
+          <div className="relative" style={{ width: '768px', flexShrink: 0 }}>
+            <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
+            {iframe}
+            <InlineCommentComposer />
+          </div>
+        </div>
+      );
+    } else {
+      body = (
+        <div className="h-full p-6">
+          <div className="relative h-full">
+            <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
+            {iframe}
+            <InlineCommentComposer />
+          </div>
+        </div>
+      );
+    }
   } else {
     body = <EmptyState onPickStarter={onPickStarter} />;
   }

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -107,7 +107,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         className={
           isMobile
             ? 'w-full h-full bg-[var(--color-artifact-bg)]'
-            : 'w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
+            : 'w-full h-full bg-[var(--color-artifact-bg)] rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
         }
         style={viewportStyle}
       />

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -1,8 +1,9 @@
 import { useT } from '@open-codesign/i18n';
 import { Tooltip } from '@open-codesign/ui';
-import { Download } from 'lucide-react';
+import { Download, Monitor, Smartphone, Tablet } from 'lucide-react';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 import type { ExportFormat } from '../../../preload/index';
+import type { PreviewViewport } from '../store';
 import { useCodesignStore } from '../store';
 
 interface ExportItem {
@@ -12,12 +13,20 @@ interface ExportItem {
   ready: boolean;
 }
 
+interface ViewportItem {
+  value: PreviewViewport;
+  label: string;
+  icon: ReactElement;
+}
+
 export function PreviewToolbar(): ReactElement {
   const t = useT();
   const previewHtml = useCodesignStore((s) => s.previewHtml);
   const exportActive = useCodesignStore((s) => s.exportActive);
   const toastMessage = useCodesignStore((s) => s.toastMessage);
   const dismissToast = useCodesignStore((s) => s.dismissToast);
+  const previewViewport = useCodesignStore((s) => s.previewViewport);
+  const setPreviewViewport = useCodesignStore((s) => s.setPreviewViewport);
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -70,6 +79,24 @@ export function PreviewToolbar(): ReactElement {
     },
   ];
 
+  const viewportItems: ViewportItem[] = [
+    {
+      value: 'desktop',
+      label: t('preview.viewport.desktop'),
+      icon: <Monitor className="w-[14px] h-[14px]" aria-hidden="true" />,
+    },
+    {
+      value: 'tablet',
+      label: t('preview.viewport.tablet'),
+      icon: <Tablet className="w-[14px] h-[14px]" aria-hidden="true" />,
+    },
+    {
+      value: 'mobile',
+      label: t('preview.viewport.mobile'),
+      icon: <Smartphone className="w-[14px] h-[14px]" aria-hidden="true" />,
+    },
+  ];
+
   return (
     <div className="flex items-center justify-end gap-2 px-6 py-2 border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)]">
       {toastMessage && (
@@ -77,6 +104,34 @@ export function PreviewToolbar(): ReactElement {
           {toastMessage}
         </output>
       )}
+
+      <fieldset
+        aria-label={t('preview.viewport.label')}
+        className="flex items-center rounded-[var(--radius-md)] border border-[var(--color-border)] overflow-hidden"
+        style={{ margin: 0, padding: 0 }}
+      >
+        <legend className="sr-only">{t('preview.viewport.label')}</legend>
+        {viewportItems.map((item) => {
+          const active = previewViewport === item.value;
+          return (
+            <button
+              key={item.value}
+              type="button"
+              title={item.label}
+              aria-pressed={active}
+              onClick={() => setPreviewViewport(item.value)}
+              className={[
+                'inline-flex items-center justify-center w-[30px] h-[30px] transition-[background-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]',
+                active
+                  ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)]'
+                  : 'bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-secondary)]',
+              ].join(' ')}
+            >
+              {item.icon}
+            </button>
+          );
+        })}
+      </fieldset>
 
       <div className="relative" ref={ref}>
         <Tooltip label={disabled ? t('disabledReason.noDesignToExport') : undefined} side="bottom">

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -127,6 +127,7 @@ export function PreviewToolbar(): ReactElement {
               key={item.value}
               type="button"
               title={item.label}
+              aria-label={item.label}
               aria-pressed={active}
               onClick={() => setPreviewViewport(item.value)}
               className={[

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -83,17 +83,26 @@ export function PreviewToolbar(): ReactElement {
     {
       value: 'desktop',
       label: t('preview.viewport.desktop'),
-      icon: <Monitor className="w-[14px] h-[14px]" aria-hidden="true" />,
+      icon: (
+        <Monitor className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]" aria-hidden="true" />
+      ),
     },
     {
       value: 'tablet',
       label: t('preview.viewport.tablet'),
-      icon: <Tablet className="w-[14px] h-[14px]" aria-hidden="true" />,
+      icon: (
+        <Tablet className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]" aria-hidden="true" />
+      ),
     },
     {
       value: 'mobile',
       label: t('preview.viewport.mobile'),
-      icon: <Smartphone className="w-[14px] h-[14px]" aria-hidden="true" />,
+      icon: (
+        <Smartphone
+          className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]"
+          aria-hidden="true"
+        />
+      ),
     },
   ];
 
@@ -121,7 +130,7 @@ export function PreviewToolbar(): ReactElement {
               aria-pressed={active}
               onClick={() => setPreviewViewport(item.value)}
               className={[
-                'inline-flex items-center justify-center w-[30px] h-[30px] transition-[background-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]',
+                'inline-flex items-center justify-center w-[var(--size-control-xs)] h-[var(--size-control-xs)] transition-[background-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]',
                 active
                   ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)]'
                   : 'bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-secondary)]',
@@ -139,7 +148,7 @@ export function PreviewToolbar(): ReactElement {
             type="button"
             disabled={disabled}
             onClick={() => setOpen((v) => !v)}
-            className="inline-flex items-center gap-1.5 h-[var(--size-control-sm)] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            className="inline-flex items-center gap-1.5 h-[var(--size-control-xs)] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
             aria-haspopup="menu"
             aria-expanded={open}
           >

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -436,3 +436,25 @@ describe('useCodesignStore project storage error surfacing', () => {
     expect(state.generationStage).toBe('idle');
   });
 });
+
+describe('useCodesignStore previewViewport', () => {
+  it('defaults to desktop', () => {
+    expect(useCodesignStore.getState().previewViewport).toBe('desktop');
+  });
+
+  it('switches to tablet via setPreviewViewport', () => {
+    useCodesignStore.getState().setPreviewViewport('tablet');
+    expect(useCodesignStore.getState().previewViewport).toBe('tablet');
+  });
+
+  it('switches to mobile via setPreviewViewport', () => {
+    useCodesignStore.getState().setPreviewViewport('mobile');
+    expect(useCodesignStore.getState().previewViewport).toBe('mobile');
+  });
+
+  it('switches back to desktop via setPreviewViewport', () => {
+    useCodesignStore.getState().setPreviewViewport('mobile');
+    useCodesignStore.getState().setPreviewViewport('desktop');
+    expect(useCodesignStore.getState().previewViewport).toBe('desktop');
+  });
+});

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -51,6 +51,8 @@ export type Theme = 'light' | 'dark';
 export type AppView = 'hub' | 'workspace' | 'settings';
 export type HubTab = 'recent' | 'your' | 'examples' | 'designSystems';
 
+export type PreviewViewport = 'desktop' | 'tablet' | 'mobile';
+
 interface PromptRequest {
   prompt: string;
   attachments: LocalInputFile[];
@@ -77,6 +79,7 @@ interface CodesignState {
   projects: Project[];
   currentProjectId: string | null;
   createProjectModalOpen: boolean;
+  previewViewport: PreviewViewport;
   commandPaletteOpen: boolean;
   toasts: Toast[];
   iframeErrors: string[];
@@ -121,6 +124,7 @@ interface CodesignState {
   closeCreateProjectModal: () => void;
   createProject: (draft: ProjectDraft) => Project;
   openProject: (id: string) => void;
+  setPreviewViewport: (viewport: PreviewViewport) => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
 
@@ -369,6 +373,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   projects: initialProjectsRead.projects,
   currentProjectId: null,
   createProjectModalOpen: false,
+  previewViewport: 'desktop' as PreviewViewport,
   commandPaletteOpen: false,
   toasts: [],
   iframeErrors: [],
@@ -761,6 +766,10 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       errorMessage: null,
       lastError: null,
     });
+  },
+
+  setPreviewViewport(viewport) {
+    set({ previewViewport: viewport });
   },
 
   openCommandPalette() {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -51,7 +51,13 @@
     "noDesign": "No design yet",
     "clickToComment": "Click any element in the preview to leave an inline comment.",
     "runtimeError": "Preview runtime error",
-    "dismissErrors": "Dismiss preview errors"
+    "dismissErrors": "Dismiss preview errors",
+    "viewport": {
+      "label": "Viewport",
+      "desktop": "Desktop",
+      "tablet": "Tablet",
+      "mobile": "Mobile"
+    }
   },
   "chat": {
     "placeholder": "Describe what to design…",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -50,7 +50,13 @@
     "noDesign": "还没有设计",
     "clickToComment": "点击预览中的任意元素即可留下局部评论。",
     "runtimeError": "预览运行时错误",
-    "dismissErrors": "关闭预览错误"
+    "dismissErrors": "关闭预览错误",
+    "viewport": {
+      "label": "视口",
+      "desktop": "桌面",
+      "tablet": "平板",
+      "mobile": "手机"
+    }
   },
   "chat": {
     "placeholder": "想设计什么？",

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -165,6 +165,9 @@
   --size-preview-mobile-notch-width: 120px;
   --size-preview-mobile-notch-height: 30px;
   --size-preview-tablet-width: 768px;
+  --size-preview-tablet-height: 1024px;
+  --size-preview-desktop-width: 1440px;
+  --size-preview-desktop-height: 900px;
 
   /* Motion — subtle, editorial */
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -101,10 +101,6 @@
   --size-control-lg: 48px;
   --size-accent-stripe: 3px;
 
-  /* Icon sizes */
-  --size-icon-sm: 14px;
-  --size-icon-md: 16px;
-
   /* Spacing — strict 4-px scale */
   --space-0_5: 2px;
   --space-1: 4px;

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -15,6 +15,9 @@
   --color-surface-muted: oklch(0.96 0.015 75);
   /* alias used by some components */
   --color-surface-elevated: oklch(0.99 0.008 80);
+  /* Artifact iframe background — user-generated content defaults to white in
+     both themes; artifacts ship their own styles and should not inherit app theme. */
+  --color-artifact-bg: #ffffff;
 
   /* Border */
   --color-border: oklch(0.88 0.012 70);
@@ -212,6 +215,7 @@ pre,
   --color-surface-active: oklch(0.29 0.018 50);
   --color-surface-muted: oklch(0.22 0.015 50);
   --color-surface-elevated: oklch(0.26 0.018 50);
+  --color-artifact-bg: #ffffff;
 
   --color-border: oklch(0.3 0.012 50);
   --color-border-muted: oklch(0.27 0.01 50);

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -92,10 +92,15 @@
   --tracking-label: 0.08em;
 
   /* Control sizes */
+  --size-control-xs: 30px;
   --size-control-sm: 32px;
   --size-control-md: 40px;
   --size-control-lg: 48px;
   --size-accent-stripe: 3px;
+
+  /* Icon sizes */
+  --size-icon-sm: 14px;
+  --size-icon-md: 16px;
 
   /* Spacing — strict 4-px scale */
   --space-0_5: 2px;

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -154,6 +154,17 @@
   --radius-xl: 14px;
   --radius-2xl: 18px;
   --radius-full: 9999px;
+  --radius-phone: 44px;
+
+  /* Border width */
+  --border-width-strong: 8px;
+
+  /* Preview viewport sizes */
+  --size-preview-mobile-width: 375px;
+  --size-preview-mobile-height: 812px;
+  --size-preview-mobile-notch-width: 120px;
+  --size-preview-mobile-notch-height: 30px;
+  --size-preview-tablet-width: 768px;
 
   /* Motion — subtle, editorial */
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);


### PR DESCRIPTION
## Summary
- PreviewToolbar adds a three-button Desktop / Tablet / Mobile switcher (lucide icons, tokenised fieldset for a11y)
- Mobile mode wraps the iframe in a CSS-only `PhoneFrame` component (iPhone bezel with notch, 375 × 812) — no new dependency
- Tablet mode centres iframe in a 768 px container; desktop keeps 100 % width
- `PreviewViewport` type + `previewViewport` / `setPreviewViewport` added to Zustand store
- i18n keys added: `preview.viewport.{label,desktop,tablet,mobile}` in both `en` and `zh-CN`

## Demo coverage
Enables reproduction of Claude Design's Calm Spaces meditation app demo (mobile mock).

## Test plan
- [x] `store.test.ts`: 4 new tests cover `setPreviewViewport` default + all three transitions
- [ ] Switch to mobile — verify bezel + 375 px iframe appears
- [ ] Switch to tablet — verify centred 768 px container
- [ ] Switch back to desktop — verify full-width iframe
- [ ] Run `pnpm -r typecheck && pnpm lint && pnpm test` — all green

## Compatibility / upgradeability / no bloat / elegance
- **Compatibility**: pure CSS feature, no breaking change to any existing prop or IPC
- **Upgradeability**: viewport is ephemeral UI state — no disk schema touched
- **No bloat**: zero new dependencies; `PhoneFrame` is ~40 lines of CSS
- **Elegance**: all colours/radii/shadows reference `var(--*)` tokens; no hard-coded px/colours in component code