### PR TITLE
feat(core): Skills system foundation — loader + 4 starter skills

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,9 @@ export {
   rewriteUpstreamMessage,
 } from './errors.js';
 
+export { loadAllSkills, loadSkillsFromDir } from './skills/index.js';
+export type { LoadAllSkillsOptions } from './skills/index.js';
+
 export interface AttachmentContext {
   name: string;
   path: string;

--- a/packages/core/src/skills/builtin/data-viz-recharts.md
+++ b/packages/core/src/skills/builtin/data-viz-recharts.md
@@ -1,0 +1,54 @@
+---
+schemaVersion: 1
+name: data-viz-recharts
+description: >
+  Guides data visualization design using Recharts. Use when building charts,
+  dashboards, analytics views, or any data-driven UI with Recharts or
+  comparable charting libraries. Enforces brand-consistent colors, readable
+  axes, and accessible chart patterns.
+trigger:
+  providers: ['*']
+  scope: system
+disable_model_invocation: false
+user_invocable: true
+---
+
+## Data Visualization with Recharts
+
+### Color Palette
+Never use Recharts default colors (`#8884d8`, `#82ca9d`, `#ffc658`). They look like every tutorial chart ever made. Define a custom palette as a const array and pass it to `<Cell fill={COLORS[index % COLORS.length]} />`.
+
+Recommended starting palette (adjust to brand):
+```js
+const CHART_COLORS = [
+  'oklch(55% 0.22 260)',  // brand primary
+  'oklch(65% 0.18 30)',   // warm accent
+  'oklch(60% 0.15 155)',  // success green
+  'oklch(55% 0.20 350)',  // alert red
+  'oklch(70% 0.10 260)',  // primary muted
+];
+```
+
+### Chart Type Selection
+- **Comparison over time**: `<AreaChart>` with `fillOpacity={0.15}` (not solid fill)
+- **Part-to-whole (few categories)**: `<BarChart layout="vertical">` — never a pie chart with > 4 slices
+- **Correlation**: `<ScatterChart>` with domain-appropriate dot size
+- **Single KPI trend**: `<LineChart>` with a single series and a `<ReferenceLine>` for target
+
+### Axes and Labels
+Always show `<XAxis>` and `<YAxis>` with `tick={{ fontSize: 12, fill: 'var(--color-text-muted)' }}`. Use `tickFormatter` to abbreviate large numbers (1.2M, 34K). Never show a chart without axis context — raw pixel positions are meaningless to users.
+
+### Tooltip Design
+Override `<Tooltip>` with a `content={<CustomTooltip />}` component. The default Recharts tooltip has poor contrast and generic styling. The custom tooltip should match the app's design system: rounded corners, subtle shadow, brand font.
+
+### Grid and Borders
+Use `<CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />` with low opacity. Remove the chart border (set `<ResponsiveContainer>` wrapper and no explicit border). Minimal grid lines reduce cognitive noise.
+
+### Responsive Sizing
+Always wrap in `<ResponsiveContainer width="100%" height={height}>`. Never hardcode pixel dimensions for the container. Choose height values: 200px (sparkline/compact), 300px (standard), 400px (detailed), 500px (focus chart).
+
+### Accessibility
+Add `aria-label` to the `<ResponsiveContainer>` describing the chart. Include a `<text>` summary for screen readers via an off-screen `<title>` element. Ensure color is never the only differentiator — use shape or pattern fills as a secondary signal.
+
+### Animation
+Disable Recharts default animation for dashboard charts that update frequently: `isAnimationActive={false}` on `<Line>`, `<Bar>`, `<Area>`. Use it only for initial load of report-style charts where the animation aids comprehension.

--- a/packages/core/src/skills/builtin/frontend-design-anti-slop.md
+++ b/packages/core/src/skills/builtin/frontend-design-anti-slop.md
@@ -1,0 +1,41 @@
+---
+schemaVersion: 1
+name: frontend-design-anti-slop
+description: >
+  Creates distinctive, production-grade frontend interfaces with exceptional
+  design quality. Use when building any UI component, landing page, dashboard,
+  prototype, or when styling HTML/CSS. Avoids generic AI aesthetics (Inter font,
+  purple gradients, predictable card layouts).
+trigger:
+  providers: ['*']
+  scope: system
+disable_model_invocation: false
+user_invocable: true
+---
+
+## Frontend Design Quality Guard
+
+You tend to produce "AI slop" by default: Inter or system fonts, purple-on-white gradients, symmetric card grids, flat white backgrounds. Break this pattern deliberately.
+
+### Typography
+Choose unexpected, characterful typefaces. Pair a distinctive display font (e.g. Playfair Display, DM Serif Display, Syne, Bebas Neue, Instrument Serif) with a refined body font. Never use Inter, Roboto, Arial, or Space Grotesk — they signal zero creative investment.
+
+### Color & Theme
+Commit fully to one coherent aesthetic. Use CSS custom properties for every color token. Dominant accent colors with sharp contrast outperform timid palettes. Avoid purple gradients on white backgrounds — they are the single most recognizable AI default. Try: deep navy + warm amber, charcoal + acid green, cream + burgundy + gold, near-black + electric cyan.
+
+Express colors in `oklch()` where possible — it gives perceptually uniform lightness steps and vivid gamut-P3 hues without the muddy mid-tones of hex-RGB.
+
+### Motion
+CSS-only for HTML artifacts. One well-orchestrated page-load with staggered `animation-delay` reveals is better than scattered micro-interactions. Use `@media (prefers-reduced-motion: reduce)` to gate all animations.
+
+### Spatial Composition
+Asymmetry. Overlap. Diagonal rhythm. Grid-breaking hero elements. Resist the urge to center-align everything — left-aligned, offset, or deliberately edge-bleeding layouts feel more crafted.
+
+### Backgrounds
+Never solid white or solid grey. Use CSS gradients, noise/grain overlay (`background-image: url("data:image/svg+xml,...")`), geometric SVG patterns, or subtle radial glows. One grain overlay (`opacity: 0.04`) on a colored background immediately elevates perceived quality.
+
+### Tone Commitment
+Pick **one** tone and execute it with full craft: brutally minimal / maximalist chaos / retro-futuristic / organic warmth / luxury editorial / bold experimental. Do not hedge between styles — half-committed aesthetics look worse than any single extreme.
+
+### Hard Prohibitions
+NEVER use: Inter, Roboto, Arial, system-ui, Space Grotesk as the primary typeface; purple gradients on white; symmetric 3-column card grids as the only layout element; drop shadows that look like Bootstrap defaults; placeholder grey rectangles as "images".

--- a/packages/core/src/skills/builtin/mobile-mock.md
+++ b/packages/core/src/skills/builtin/mobile-mock.md
@@ -1,0 +1,59 @@
+---
+schemaVersion: 1
+name: mobile-mock
+description: >
+  Designs mobile UI mocks and prototypes with correct proportions and touch
+  interactions. Use when building a mobile app screen, responsive mobile
+  layout, or any prototype intended to be viewed on a phone (375px viewport).
+  Enforces 44pt touch targets, proper status bar height, and safe area insets.
+trigger:
+  providers: ['*']
+  scope: system
+disable_model_invocation: false
+user_invocable: true
+---
+
+## Mobile Mock Design Standards
+
+### Viewport and Frame
+Render mobile screens at **375×812px** (iPhone SE / standard size baseline) or **390×844px** (iPhone 14 standard) inside a device frame when showing a standalone mock. For scrollable content mocks, use `max-width: 390px; margin: 0 auto`. Do not render at desktop width and then scale down — it produces wrong touch target proportions.
+
+### Touch Targets
+Every interactive element must have a minimum tap target of **44×44px**. This is Apple HIG and Android Material specification. Apply it to buttons, list items, toggle switches, icon buttons, and navigation tabs. Use padding to extend small visual elements to the minimum tap size — do not enlarge the visual.
+
+```css
+.touch-target {
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+### Status Bar
+Reserve **44–50px** at the top for the status bar (notch phones: 44px safe area + 20px bar = 59px). Use `padding-top: env(safe-area-inset-top, 44px)` in real implementations. In static mocks, show a simple status bar row with time (e.g. "9:41") on the left and battery/signal icons on the right.
+
+### Safe Area Insets
+Bottom: reserve **34px** for the home indicator on notched iPhones. Use `padding-bottom: env(safe-area-inset-bottom, 34px)` on fixed bottom bars. Fixed bottom navigation must never overlap the home indicator.
+
+### Typography Scale
+Mobile type scale (base 16px):
+- Display: 28–34px, weight 700, tight tracking (−0.02em)
+- Headline: 20–24px, weight 600
+- Body: 15–16px, weight 400, line-height 1.5
+- Caption: 12–13px, weight 400, color muted
+
+Never use type smaller than 12px on mobile — it fails WCAG SC 1.4.4 at normal viewing distance.
+
+### Interaction Patterns
+- No hover-only states. Mobile has no hover. Use `:active` for press feedback.
+- Swipe gestures should have visual affordances (drag handles, chevrons).
+- Bottom sheets and modals should be dismissible by swipe-down or background tap.
+- Avoid right-click / long-press as the only way to access features.
+
+### Spacing System
+Use an 8px base grid. Standard padding: 16px (screen edges), 12px (card insets), 8px (between related elements), 4px (tight pairs). List item height: 48–56px for single-line, 64–72px for two-line items.
+
+### Navigation
+Bottom tab bar: 49–56px tall, 3–5 items max. Top navigation bar: 44–56px tall. Avoid hamburger menus — they hide navigation and reduce discoverability on mobile.

--- a/packages/core/src/skills/builtin/pitch-deck.md
+++ b/packages/core/src/skills/builtin/pitch-deck.md
@@ -1,0 +1,39 @@
+---
+schemaVersion: 1
+name: pitch-deck
+description: >
+  Designs polished pitch deck slides and presentation layouts. Use when the
+  user asks for a slide deck, investor pitch, presentation, or multi-slide
+  narrative. Enforces slide structure, whitespace discipline, and one-claim-per-slide rule.
+trigger:
+  providers: ['*']
+  scope: system
+disable_model_invocation: false
+user_invocable: true
+---
+
+## Pitch Deck Design Principles
+
+### One Claim Per Slide
+Every slide communicates exactly one idea. If you find yourself writing "and also..." you need two slides. The claim should be expressible in a single sentence of ≤ 12 words placed at the top of the slide.
+
+### Typographic Hierarchy
+Use a 3-tier scale: headline (56–72px), supporting statement (24–32px), body/caption (14–16px). Never mix more than two font families. Display font for headlines; neutral font for body. Tight letter-spacing (−0.02em to −0.04em) on large headlines reads as confidence.
+
+### Whitespace as Signal
+Leave at least 20% of each slide empty. Crowded slides signal a presenter who does not trust the audience. Generous margins (8–12% of slide width) and vertical padding between elements are non-negotiable.
+
+### Slide Ratio and Dimensions
+Default to 16:9 (1920×1080px or 1280×720px). Avoid 4:3 — it looks dated. For mobile-first contexts (scrollable deck on phone) use 9:16.
+
+### Data Slides
+Every chart needs: a headline that states the insight (not just the metric), axis labels in the same font as the slide body, and a clear color key. Never use 3-D charts or pie charts with more than 4 segments. Bar charts and area charts read fastest. Use a single accent color for the data series you want the audience to notice; grey out the rest.
+
+### Color Discipline
+Limit the palette to 3 colors: background, text, and one accent. If you need a second accent, make it a tint of the first. Every slide in the deck shares the same palette — do not introduce new colors mid-deck.
+
+### Opening and Closing Slides
+The opening slide must make the problem viscerally clear in under 5 seconds of reading. The closing slide must state the single desired action (invest, partner, join) with contact information — not a generic "Thank you" or "Q&A".
+
+### Narrative Arc
+Structure: Problem → Insight → Solution → Evidence → Ask. Each section should be 1–3 slides. Do not spend more than 25% of the deck on product features.

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,0 +1,4 @@
+export { loadAllSkills, loadSkillsFromDir } from './loader.js';
+export type { LoadAllSkillsOptions } from './loader.js';
+export { SkillFrontmatterV1 } from './types.js';
+export type { LoadedSkill } from './types.js';

--- a/packages/core/src/skills/loader.test.ts
+++ b/packages/core/src/skills/loader.test.ts
@@ -1,0 +1,236 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadAllSkills, loadSkillsFromDir } from './loader.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `skills-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(testDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+async function writeSkill(dir: string, filename: string, content: string) {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, filename), content, 'utf-8');
+}
+
+const MINIMAL_SKILL = `---
+schemaVersion: 1
+name: my-skill
+description: A minimal test skill.
+---
+
+Skill body content.
+`;
+
+const FULL_SKILL = `---
+schemaVersion: 1
+name: full-skill
+description: A fully specified test skill.
+trigger:
+  providers: ['anthropic', 'openai']
+  scope: prefix
+disable_model_invocation: false
+user_invocable: true
+allowed_tools: ['read_file', 'write_file']
+---
+
+Full skill body here.
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('loadSkillsFromDir()', () => {
+  it('loads 4 builtin skills from the real builtin directory', async () => {
+    const builtinDir = new URL('./builtin', import.meta.url).pathname;
+    const skills = await loadSkillsFromDir(builtinDir, 'builtin');
+    expect(skills.length).toBe(4);
+    const ids = skills.map((s) => s.id).sort();
+    expect(ids).toContain('frontend-design-anti-slop');
+    expect(ids).toContain('pitch-deck');
+    expect(ids).toContain('data-viz-recharts');
+    expect(ids).toContain('mobile-mock');
+  });
+
+  it('returns empty array when directory does not exist', async () => {
+    const skills = await loadSkillsFromDir(join(testDir, 'nonexistent'), 'user');
+    expect(skills).toHaveLength(0);
+  });
+
+  it('parses minimal frontmatter and body correctly', async () => {
+    await writeSkill(testDir, 'my-skill.md', MINIMAL_SKILL);
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    expect(skills).toHaveLength(1);
+    const skill = skills[0];
+    if (!skill) throw new Error('expected skill');
+    expect(skill.id).toBe('my-skill');
+    expect(skill.source).toBe('user');
+    expect(skill.frontmatter.name).toBe('my-skill');
+    expect(skill.frontmatter.description).toBe('A minimal test skill.');
+    expect(skill.body).toBe('Skill body content.');
+  });
+
+  it('parses full frontmatter including trigger block', async () => {
+    await writeSkill(testDir, 'full-skill.md', FULL_SKILL);
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    expect(skills).toHaveLength(1);
+    const skill = skills[0];
+    if (!skill) throw new Error('expected skill');
+    expect(skill.frontmatter.trigger.providers).toEqual(['anthropic', 'openai']);
+    expect(skill.frontmatter.trigger.scope).toBe('prefix');
+    expect(skill.frontmatter.allowed_tools).toEqual(['read_file', 'write_file']);
+  });
+
+  it('applies defaults for omitted frontmatter fields', async () => {
+    const minimal = `---
+schemaVersion: 1
+name: defaults-test
+description: Testing defaults.
+---
+Body.
+`;
+    await writeSkill(testDir, 'defaults-test.md', minimal);
+    const [skill] = await loadSkillsFromDir(testDir, 'builtin');
+    if (!skill) throw new Error('expected skill');
+    expect(skill.frontmatter.disable_model_invocation).toBe(false);
+    expect(skill.frontmatter.user_invocable).toBe(true);
+    expect(skill.frontmatter.trigger.scope).toBe('system');
+    expect(skill.frontmatter.trigger.providers).toEqual(['*']);
+  });
+
+  it('rejects a skill whose description exceeds 1536 characters', async () => {
+    const longDesc = 'x'.repeat(1537);
+    const content = `---
+schemaVersion: 1
+name: too-long
+description: ${longDesc}
+---
+Body.
+`;
+    await writeSkill(testDir, 'too-long.md', content);
+    // Invalid frontmatter → silently skipped; array is empty
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    expect(skills).toHaveLength(0);
+  });
+
+  it('skips a corrupted .md file without crashing the entire load', async () => {
+    // Valid skill
+    await writeSkill(testDir, 'good.md', MINIMAL_SKILL);
+    // Corrupted file — description exceeds max → validation fails → skipped
+    await writeSkill(
+      testDir,
+      'bad.md',
+      `---\nschemaVersion: 1\nname: bad\ndescription: ${'z'.repeat(2000)}\n---\nBody.`,
+    );
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    // Only the good skill survives
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.id).toBe('good');
+  });
+
+  it('ignores non-.md files in the directory', async () => {
+    await writeSkill(testDir, 'my-skill.md', MINIMAL_SKILL);
+    await writeFile(join(testDir, 'readme.txt'), 'ignore me', 'utf-8');
+    await writeFile(join(testDir, 'config.json'), '{}', 'utf-8');
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    expect(skills).toHaveLength(1);
+  });
+});
+
+describe('loadAllSkills()', () => {
+  it('merges builtin, user, and project tiers', async () => {
+    const builtinDir = join(testDir, 'builtin');
+    const userDir = join(testDir, 'user');
+    await writeSkill(builtinDir, 'shared.md', MINIMAL_SKILL);
+    await writeSkill(
+      builtinDir,
+      'only-builtin.md',
+      MINIMAL_SKILL.replace('my-skill', 'only-builtin').replace(
+        'A minimal test skill.',
+        'Built-in only skill.',
+      ),
+    );
+    await writeSkill(
+      userDir,
+      'user-only.md',
+      MINIMAL_SKILL.replace('my-skill', 'user-only').replace(
+        'A minimal test skill.',
+        'User only skill.',
+      ),
+    );
+
+    const skills = await loadAllSkills({ builtinDir, userDir });
+    const ids = skills.map((s) => s.id).sort();
+    expect(ids).toContain('shared');
+    expect(ids).toContain('only-builtin');
+    expect(ids).toContain('user-only');
+  });
+
+  it('user skill overrides builtin when they share the same id', async () => {
+    const builtinDir = join(testDir, 'builtin');
+    const userDir = join(testDir, 'user');
+    await writeSkill(
+      builtinDir,
+      'shared.md',
+      '---\nschemaVersion: 1\nname: shared\ndescription: Builtin version.\n---\nBuiltin body.',
+    );
+    await writeSkill(
+      userDir,
+      'shared.md',
+      '---\nschemaVersion: 1\nname: shared\ndescription: User version.\n---\nUser body.',
+    );
+
+    const skills = await loadAllSkills({ builtinDir, userDir });
+    const shared = skills.find((s) => s.id === 'shared');
+    if (!shared) throw new Error('expected shared skill');
+    expect(shared.source).toBe('user');
+    expect(shared.body).toBe('User body.');
+  });
+
+  it('project skill overrides user and builtin when they share the same id', async () => {
+    const builtinDir = join(testDir, 'builtin');
+    const userDir = join(testDir, 'user');
+    const projectDir = join(testDir, 'project');
+    await writeSkill(
+      builtinDir,
+      'shared.md',
+      '---\nschemaVersion: 1\nname: shared\ndescription: Builtin version.\n---\nBuiltin body.',
+    );
+    await writeSkill(
+      userDir,
+      'shared.md',
+      '---\nschemaVersion: 1\nname: shared\ndescription: User version.\n---\nUser body.',
+    );
+    await writeSkill(
+      projectDir,
+      'shared.md',
+      '---\nschemaVersion: 1\nname: shared\ndescription: Project version.\n---\nProject body.',
+    );
+
+    const skills = await loadAllSkills({ builtinDir, userDir, projectDir });
+    const shared = skills.find((s) => s.id === 'shared');
+    if (!shared) throw new Error('expected shared skill');
+    expect(shared.source).toBe('project');
+    expect(shared.body).toBe('Project body.');
+  });
+
+  it('works without optional dirs (only builtinDir provided)', async () => {
+    const builtinDir = join(testDir, 'builtin');
+    await writeSkill(builtinDir, 'my-skill.md', MINIMAL_SKILL);
+    const skills = await loadAllSkills({ builtinDir });
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.source).toBe('builtin');
+  });
+});

--- a/packages/core/src/skills/loader.test.ts
+++ b/packages/core/src/skills/loader.test.ts
@@ -70,6 +70,14 @@ describe('loadSkillsFromDir()', () => {
     expect(skills).toHaveLength(0);
   });
 
+  it('propagates non-ENOENT readdir errors (e.g. ENOTDIR)', async () => {
+    const filePath = join(testDir, 'not-a-dir.md');
+    await writeFile(filePath, '---\nname: x\n---\n');
+    await expect(loadSkillsFromDir(filePath, 'user')).rejects.toMatchObject({
+      code: 'ENOTDIR',
+    });
+  });
+
   it('parses minimal frontmatter and body correctly', async () => {
     await writeSkill(testDir, 'my-skill.md', MINIMAL_SKILL);
     const skills = await loadSkillsFromDir(testDir, 'user');

--- a/packages/core/src/skills/loader.test.ts
+++ b/packages/core/src/skills/loader.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { CodesignError } from '@open-codesign/shared';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadAllSkills, loadSkillsFromDir } from './loader.js';
 
@@ -110,7 +111,7 @@ Body.
     expect(skill.frontmatter.trigger.providers).toEqual(['*']);
   });
 
-  it('rejects a skill whose description exceeds 1536 characters', async () => {
+  it('throws SKILL_LOAD_FAILED when a skill has a description exceeding 1536 characters', async () => {
     const longDesc = 'x'.repeat(1537);
     const content = `---
 schemaVersion: 1
@@ -120,24 +121,23 @@ description: ${longDesc}
 Body.
 `;
     await writeSkill(testDir, 'too-long.md', content);
-    // Invalid frontmatter → silently skipped; array is empty
-    const skills = await loadSkillsFromDir(testDir, 'user');
-    expect(skills).toHaveLength(0);
+    await expect(loadSkillsFromDir(testDir, 'user')).rejects.toSatisfy(
+      (err: unknown) => err instanceof CodesignError && err.code === 'SKILL_LOAD_FAILED',
+    );
   });
 
-  it('skips a corrupted .md file without crashing the entire load', async () => {
+  it('throws SKILL_LOAD_FAILED when any skill file has invalid frontmatter', async () => {
     // Valid skill
     await writeSkill(testDir, 'good.md', MINIMAL_SKILL);
-    // Corrupted file — description exceeds max → validation fails → skipped
+    // Broken skill — description exceeds max → validation fails → throws
     await writeSkill(
       testDir,
       'bad.md',
       `---\nschemaVersion: 1\nname: bad\ndescription: ${'z'.repeat(2000)}\n---\nBody.`,
     );
-    const skills = await loadSkillsFromDir(testDir, 'user');
-    // Only the good skill survives
-    expect(skills).toHaveLength(1);
-    expect(skills[0]?.id).toBe('good');
+    await expect(loadSkillsFromDir(testDir, 'user')).rejects.toSatisfy(
+      (err: unknown) => err instanceof CodesignError && err.code === 'SKILL_LOAD_FAILED',
+    );
   });
 
   it('ignores non-.md files in the directory', async () => {
@@ -232,5 +232,23 @@ describe('loadAllSkills()', () => {
     const skills = await loadAllSkills({ builtinDir });
     expect(skills).toHaveLength(1);
     expect(skills[0]?.source).toBe('builtin');
+  });
+
+  it('throws SKILL_LOAD_FAILED when a broken skill (missing description) is present', async () => {
+    const builtinDir = join(testDir, 'builtin');
+    // Skill missing required `description` field
+    const brokenSkill = `---
+schemaVersion: 1
+name: broken-skill
+---
+Body without description.
+`;
+    await writeSkill(builtinDir, 'broken-skill.md', brokenSkill);
+    await expect(loadAllSkills({ builtinDir })).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof CodesignError &&
+        err.code === 'SKILL_LOAD_FAILED' &&
+        err.message.includes('broken-skill.md'),
+    );
   });
 });

--- a/packages/core/src/skills/loader.test.ts
+++ b/packages/core/src/skills/loader.test.ts
@@ -155,6 +155,39 @@ Body.
     const skills = await loadSkillsFromDir(testDir, 'user');
     expect(skills).toHaveLength(1);
   });
+
+  it('preserves newlines in literal block scalars (|) and folds them in folded scalars (>)', async () => {
+    const content = `---
+schemaVersion: 1
+name: scalars
+description: |
+  line one
+  line two
+  line three
+---
+Body.
+`;
+    await writeSkill(testDir, 'scalars.md', content);
+    const [skill] = await loadSkillsFromDir(testDir, 'user');
+    if (!skill) throw new Error('expected skill');
+    expect(skill.frontmatter.description).toBe('line one\nline two\nline three');
+
+    const folded = `---
+schemaVersion: 1
+name: folded
+description: >
+  line one
+  line two
+  line three
+---
+Body.
+`;
+    await writeSkill(testDir, 'folded.md', folded);
+    const skills = await loadSkillsFromDir(testDir, 'user');
+    const f = skills.find((s) => s.id === 'folded');
+    if (!f) throw new Error('expected folded skill');
+    expect(f.frontmatter.description).toBe('line one line two line three');
+  });
 });
 
 describe('loadAllSkills()', () => {

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -1,0 +1,268 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+import { type LoadedSkill, SkillFrontmatterV1 } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Inline YAML frontmatter parser
+//
+// Supports the subset of YAML needed for SKILL.md files:
+//   - Top-level key: value pairs
+//   - Folded (>) and literal (|) block scalars
+//   - Nested block mappings (indented sub-keys, e.g. "trigger:")
+//   - Inline sequences: key: [a, b, c]
+//   - Block sequences: "  - item"
+//   - Scalar types: string, number, boolean, null
+//
+// Does NOT support anchors, multi-document streams, or complex types.
+// ---------------------------------------------------------------------------
+
+function parseScalar(s: string): unknown {
+  const t = s.trim();
+  if (t === 'true') return true;
+  if (t === 'false') return false;
+  if (t === 'null' || t === '~') return null;
+  const n = Number(t);
+  if (!Number.isNaN(n) && t !== '') return n;
+  return t;
+}
+
+function unquote(s: string): string {
+  return s.trim().replace(/^['"]|['"]$/g, '');
+}
+
+function indentOf(line: string): number {
+  return line.match(/^(\s*)/)?.[1]?.length ?? 0;
+}
+
+function parseInlineSequence(s: string): unknown[] {
+  const inner = s.slice(1, s.lastIndexOf(']'));
+  return inner
+    .split(',')
+    .map(unquote)
+    .filter((item) => item.length > 0);
+}
+
+function parseBlockScalar(lines: string[], start: number, baseIndent: number): [string, number] {
+  const blockLines: string[] = [];
+  let i = start;
+  while (i < lines.length) {
+    const next = lines[i] ?? '';
+    if (next.trim() === '') {
+      blockLines.push('');
+      i++;
+      continue;
+    }
+    if (indentOf(next) <= baseIndent) break;
+    blockLines.push(next.trim());
+    i++;
+  }
+  return [blockLines.join(' ').trim(), i];
+}
+
+function parseBlockSequence(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+): [unknown[], number] {
+  const items: unknown[] = [];
+  let i = start;
+  while (i < lines.length) {
+    const seqLine = lines[i] ?? '';
+    if (seqLine.trim() === '') {
+      i++;
+      continue;
+    }
+    if (indentOf(seqLine) <= baseIndent) break;
+    if (seqLine.trimStart().startsWith('- ')) {
+      items.push(parseScalar(unquote(seqLine.replace(/^\s*-\s*/, '').trim())));
+    }
+    i++;
+  }
+  return [items, i];
+}
+
+function skipBlankLines(lines: string[], start: number): number {
+  let i = start;
+  while (i < lines.length && (lines[i] ?? '').trim() === '') i++;
+  return i;
+}
+
+function isBlockScalarIndicator(s: string): boolean {
+  return s === '>' || s === '|' || s.startsWith('> ') || s.startsWith('| ');
+}
+
+/** Resolve the value for an empty-after-colon key, returning [value, nextLineIndex]. */
+function resolveEmptyValue(lines: string[], start: number, baseIndent: number): [unknown, number] {
+  const lookAheadIdx = skipBlankLines(lines, start);
+  const nextLine = lines[lookAheadIdx] ?? '';
+  const nextIndent = indentOf(nextLine);
+
+  if (nextIndent <= baseIndent) return [null, start];
+  if (nextLine.trimStart().startsWith('- ')) return parseBlockSequence(lines, start, baseIndent);
+  return parseMapping(lines, start, nextIndent);
+}
+
+/**
+ * Parse a sequence of YAML lines into a plain object.
+ * `baseIndent` is the expected indentation level of keys in this mapping.
+ */
+function parseMapping(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+): [Record<string, unknown>, number] {
+  const result: Record<string, unknown> = {};
+  let i = start;
+
+  while (i < lines.length) {
+    const raw = lines[i] ?? '';
+
+    if (raw.trim() === '' || raw.trimStart().startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = indentOf(raw);
+    if (indent < baseIndent) break;
+    if (indent > baseIndent) {
+      i++;
+      continue;
+    }
+
+    const colonIdx = raw.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = raw.slice(0, colonIdx).trim();
+    const afterTrimmed = raw.slice(colonIdx + 1).trim();
+    i++;
+
+    if (afterTrimmed.startsWith('[')) {
+      result[key] = parseInlineSequence(afterTrimmed);
+    } else if (isBlockScalarIndicator(afterTrimmed)) {
+      const [value, nextI] = parseBlockScalar(lines, i, baseIndent);
+      result[key] = value;
+      i = nextI;
+    } else if (afterTrimmed === '{}') {
+      result[key] = {};
+    } else if (afterTrimmed === '') {
+      const [value, nextI] = resolveEmptyValue(lines, i, baseIndent);
+      result[key] = value;
+      i = nextI;
+    } else {
+      result[key] = parseScalar(unquote(afterTrimmed));
+    }
+  }
+
+  return [result, i];
+}
+
+interface ParsedMd {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+function parseFrontmatter(content: string): ParsedMd {
+  // Match --- delimited frontmatter at the very start of the file
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!m) return { frontmatter: {}, body: content };
+  const yamlSrc = m[1] ?? '';
+  const body = m[2] ?? '';
+  const lines = yamlSrc.split('\n');
+  const [frontmatter] = parseMapping(lines, 0, 0);
+  return { frontmatter, body };
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+export async function loadSkillsFromDir(
+  dir: string,
+  source: LoadedSkill['source'],
+): Promise<LoadedSkill[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // Directory does not exist or is not readable — not an error, just empty.
+    return [];
+  }
+
+  const skills: LoadedSkill[] = [];
+
+  for (const entry of entries) {
+    if (extname(entry) !== '.md') continue;
+    const filePath = join(dir, entry);
+    const id = basename(entry, '.md');
+
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf-8');
+    } catch (err) {
+      // Warn but do not crash the entire loader for one bad file.
+      console.warn(`[skills] Could not read ${filePath}:`, err);
+      continue;
+    }
+
+    let parsed: ParsedMd;
+    try {
+      parsed = parseFrontmatter(raw);
+    } catch (err) {
+      console.warn(`[skills] Could not parse frontmatter in ${filePath}:`, err);
+      continue;
+    }
+
+    // Merge: use filename as name fallback
+    const raw_fm = {
+      name: id,
+      ...parsed.frontmatter,
+    };
+
+    const result = SkillFrontmatterV1.safeParse(raw_fm);
+    if (!result.success) {
+      console.warn(`[skills] Invalid frontmatter in ${filePath}:`, result.error.issues);
+      continue;
+    }
+
+    skills.push({
+      id,
+      source,
+      frontmatter: result.data,
+      body: parsed.body.trim(),
+    });
+  }
+
+  return skills;
+}
+
+export interface LoadAllSkillsOptions {
+  builtinDir: string;
+  /** ~/.config/open-codesign/skills */
+  userDir?: string | undefined;
+  /** <project>/.codesign/skills */
+  projectDir?: string | undefined;
+}
+
+/**
+ * Load skills from all three tiers.
+ * Priority order: project > user > builtin.
+ * When two skills share the same id, the higher-priority one wins.
+ */
+export async function loadAllSkills(opts: LoadAllSkillsOptions): Promise<LoadedSkill[]> {
+  const [builtin, user, project] = await Promise.all([
+    loadSkillsFromDir(opts.builtinDir, 'builtin'),
+    opts.userDir ? loadSkillsFromDir(opts.userDir, 'user') : Promise.resolve([]),
+    opts.projectDir ? loadSkillsFromDir(opts.projectDir, 'project') : Promise.resolve([]),
+  ]);
+
+  // Merge with priority: project overrides user overrides builtin
+  const map = new Map<string, LoadedSkill>();
+  for (const skill of [...builtin, ...user, ...project]) {
+    map.set(skill.id, skill);
+  }
+
+  return [...map.values()];
+}

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -43,7 +43,12 @@ function parseInlineSequence(s: string): unknown[] {
     .filter((item) => item.length > 0);
 }
 
-function parseBlockScalar(lines: string[], start: number, baseIndent: number): [string, number] {
+function parseBlockScalar(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+  style: '>' | '|',
+): [string, number] {
   const blockLines: string[] = [];
   let i = start;
   while (i < lines.length) {
@@ -57,7 +62,9 @@ function parseBlockScalar(lines: string[], start: number, baseIndent: number): [
     blockLines.push(next.trim());
     i++;
   }
-  return [blockLines.join(' ').trim(), i];
+  // Folded (>) joins lines with spaces; literal (|) preserves newlines.
+  const joiner = style === '|' ? '\n' : ' ';
+  return [blockLines.join(joiner).trim(), i];
 }
 
 function parseBlockSequence(
@@ -143,7 +150,8 @@ function parseMapping(
     if (afterTrimmed.startsWith('[')) {
       result[key] = parseInlineSequence(afterTrimmed);
     } else if (isBlockScalarIndicator(afterTrimmed)) {
-      const [value, nextI] = parseBlockScalar(lines, i, baseIndent);
+      const style = afterTrimmed.charAt(0) === '|' ? '|' : '>';
+      const [value, nextI] = parseBlockScalar(lines, i, baseIndent, style);
       result[key] = value;
       i = nextI;
     } else if (afterTrimmed === '{}') {

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -187,9 +187,9 @@ export async function loadSkillsFromDir(
   let entries: string[];
   try {
     entries = await readdir(dir);
-  } catch {
-    // Directory does not exist or is not readable — not an error, just empty.
-    return [];
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
   }
 
   const skills: LoadedSkill[] = [];

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
+import { CodesignError } from '@open-codesign/shared';
 import { type LoadedSkill, SkillFrontmatterV1 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -192,6 +193,7 @@ export async function loadSkillsFromDir(
   }
 
   const skills: LoadedSkill[] = [];
+  const errors: string[] = [];
 
   for (const entry of entries) {
     if (extname(entry) !== '.md') continue;
@@ -202,8 +204,9 @@ export async function loadSkillsFromDir(
     try {
       raw = await readFile(filePath, 'utf-8');
     } catch (err) {
-      // Warn but do not crash the entire loader for one bad file.
-      console.warn(`[skills] Could not read ${filePath}:`, err);
+      errors.push(
+        `Could not read ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
       continue;
     }
 
@@ -211,7 +214,9 @@ export async function loadSkillsFromDir(
     try {
       parsed = parseFrontmatter(raw);
     } catch (err) {
-      console.warn(`[skills] Could not parse frontmatter in ${filePath}:`, err);
+      errors.push(
+        `Could not parse frontmatter in ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
       continue;
     }
 
@@ -223,7 +228,8 @@ export async function loadSkillsFromDir(
 
     const result = SkillFrontmatterV1.safeParse(raw_fm);
     if (!result.success) {
-      console.warn(`[skills] Invalid frontmatter in ${filePath}:`, result.error.issues);
+      const issues = result.error.issues.map((i) => i.message).join('; ');
+      errors.push(`Invalid frontmatter in ${filePath}: ${issues}`);
       continue;
     }
 
@@ -233,6 +239,10 @@ export async function loadSkillsFromDir(
       frontmatter: result.data,
       body: parsed.body.trim(),
     });
+  }
+
+  if (errors.length > 0) {
+    throw new CodesignError(`Skill loading failed:\n${errors.join('\n')}`, 'SKILL_LOAD_FAILED');
   }
 
   return skills;

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -1,0 +1,6 @@
+// Canonical definitions live in @open-codesign/shared to avoid a
+// circular dependency: packages/providers needs LoadedSkill but
+// packages/providers is already a dependency of packages/core.
+// Re-export here so skill-internal code can import from './types.js'.
+export { SkillFrontmatterV1 } from '@open-codesign/shared';
+export type { LoadedSkill } from '@open-codesign/shared';

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -202,6 +202,8 @@ export type { ValidateResult } from './validate';
 export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
 export type { CompleteWithRetryOptions, RetryReason } from './retry';
 
+export { injectSkillsIntoMessages } from './skill-injector';
+
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>
 //   streamArtifacts(model, messages, opts): AsyncIterable<ArtifactEvent>

--- a/packages/providers/src/skill-injector.test.ts
+++ b/packages/providers/src/skill-injector.test.ts
@@ -191,7 +191,7 @@ describe('injectSkillsIntoMessages()', () => {
     }
   });
 
-  it('resolves mixed scope deterministically using highest-precedence skill', () => {
+  it('splits mixed-scope skills into separate channels', () => {
     const projectPrefix = makeSkill('proj', {
       source: 'project',
       frontmatter: {
@@ -219,12 +219,98 @@ describe('injectSkillsIntoMessages()', () => {
 
     const a = injectSkillsIntoMessages(BASE_MESSAGES, [projectPrefix, userSystem], 'anthropic');
     const b = injectSkillsIntoMessages(BASE_MESSAGES, [userSystem, projectPrefix], 'anthropic');
+    // Order-independent: same active skill set yields the same messages.
     expect(a).toEqual(b);
-    // Project skill (higher precedence) chose 'prefix' scope, so user message
-    // gets the block and the system message stays untouched.
-    expect(a[0]?.content).toBe('You are a helpful assistant.');
+
+    // System-scope skill lands in the system message.
+    expect(a[0]?.role).toBe('system');
+    expect(a[0]?.content).toContain('User system body.');
+    expect(a[0]?.content).toContain('You are a helpful assistant.');
+    expect(a[0]?.content).not.toContain('Project prefix body.');
+
+    // Prefix-scope skill lands in the user message, untouched by system block.
     expect(a[1]?.role).toBe('user');
     expect(a[1]?.content).toContain('Project prefix body.');
-    expect(a[1]?.content).toContain('User system body.');
+    expect(a[1]?.content).toContain('Design a landing page.');
+    expect(a[1]?.content).not.toContain('User system body.');
+  });
+
+  it('injects three-source mixed-scope set into both channels with canonical order', () => {
+    const projectSystem = makeSkill('p-sys', {
+      source: 'project',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'p-sys',
+        description: 'Project system skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'Project system body.',
+    });
+    const userPrefix = makeSkill('u-pre', {
+      source: 'user',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'u-pre',
+        description: 'User prefix skill.',
+        trigger: { providers: ['*'], scope: 'prefix' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'User prefix body.',
+    });
+    const builtinSystem = makeSkill('b-sys', {
+      source: 'builtin',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'b-sys',
+        description: 'Builtin system skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'Builtin system body.',
+    });
+    const builtinPrefix = makeSkill('b-pre', {
+      source: 'builtin',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'b-pre',
+        description: 'Builtin prefix skill.',
+        trigger: { providers: ['*'], scope: 'prefix' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'Builtin prefix body.',
+    });
+
+    const result = injectSkillsIntoMessages(
+      BASE_MESSAGES,
+      [builtinPrefix, builtinSystem, userPrefix, projectSystem],
+      'anthropic',
+    );
+
+    // Same message count — both blocks merged into existing system + user.
+    expect(result).toHaveLength(BASE_MESSAGES.length);
+
+    const systemContent = result[0]?.content ?? '';
+    const userContent = result[1]?.content ?? '';
+
+    // System block contains only system-scope skills, project before builtin.
+    const projSysIdx = systemContent.indexOf('Project system body.');
+    const builtinSysIdx = systemContent.indexOf('Builtin system body.');
+    expect(projSysIdx).toBeGreaterThanOrEqual(0);
+    expect(builtinSysIdx).toBeGreaterThan(projSysIdx);
+    expect(systemContent).not.toContain('User prefix body.');
+    expect(systemContent).not.toContain('Builtin prefix body.');
+
+    // Prefix block contains only prefix-scope skills, user before builtin.
+    const userPreIdx = userContent.indexOf('User prefix body.');
+    const builtinPreIdx = userContent.indexOf('Builtin prefix body.');
+    expect(userPreIdx).toBeGreaterThanOrEqual(0);
+    expect(builtinPreIdx).toBeGreaterThan(userPreIdx);
+    expect(userContent).not.toContain('Project system body.');
+    expect(userContent).not.toContain('Builtin system body.');
   });
 });

--- a/packages/providers/src/skill-injector.test.ts
+++ b/packages/providers/src/skill-injector.test.ts
@@ -1,0 +1,162 @@
+import type { ChatMessage, LoadedSkill } from '@open-codesign/shared';
+import { describe, expect, it } from 'vitest';
+import { injectSkillsIntoMessages } from './skill-injector.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeSkill(id: string, overrides: Partial<LoadedSkill> = {}): LoadedSkill {
+  return {
+    id,
+    source: 'builtin',
+    frontmatter: {
+      schemaVersion: 1,
+      name: id,
+      description: `Description for ${id}.`,
+      trigger: { providers: ['*'], scope: 'system' },
+      disable_model_invocation: false,
+      user_invocable: true,
+    },
+    body: `Body of ${id}.`,
+    ...overrides,
+  };
+}
+
+const BASE_MESSAGES: ChatMessage[] = [
+  { role: 'system', content: 'You are a helpful assistant.' },
+  { role: 'user', content: 'Design a landing page.' },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('injectSkillsIntoMessages()', () => {
+  it('returns original array unchanged when no skills provided', () => {
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [], 'anthropic');
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('returns original array when all skills are disabled', () => {
+    const disabled = makeSkill('disabled', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'disabled',
+        description: 'Disabled skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: true,
+        user_invocable: true,
+      },
+    });
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [disabled], 'anthropic');
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('produces exactly one extra system message when injecting into existing system message', () => {
+    const skill = makeSkill('test-skill');
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [skill], 'anthropic');
+    // Should still have same number of messages (prepended to existing system)
+    expect(result).toHaveLength(BASE_MESSAGES.length);
+    expect(result[0]?.role).toBe('system');
+    expect(result[0]?.content).toContain('Body of test-skill.');
+    expect(result[0]?.content).toContain('You are a helpful assistant.');
+  });
+
+  it('inserts a new system message when no system message exists', () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'Design a landing page.' }];
+    const skill = makeSkill('test-skill');
+    const result = injectSkillsIntoMessages(messages, [skill], 'anthropic');
+    expect(result).toHaveLength(2);
+    expect(result[0]?.role).toBe('system');
+    expect(result[0]?.content).toContain('Body of test-skill.');
+    expect(result[1]?.role).toBe('user');
+  });
+
+  it('injects multiple skills into a single system message in order', () => {
+    const projectSkill = makeSkill('proj', {
+      source: 'project',
+      body: 'Project skill body.',
+    });
+    const builtinSkill = makeSkill('builtin', {
+      source: 'builtin',
+      body: 'Builtin skill body.',
+    });
+    // Pass in priority order: project first, then builtin
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [projectSkill, builtinSkill], 'openai');
+    expect(result[0]?.role).toBe('system');
+    const content = result[0]?.content ?? '';
+    const projIdx = content.indexOf('Project skill body.');
+    const builtinIdx = content.indexOf('Builtin skill body.');
+    expect(projIdx).toBeGreaterThanOrEqual(0);
+    expect(builtinIdx).toBeGreaterThanOrEqual(0);
+    // Project skill comes first (higher priority)
+    expect(projIdx).toBeLessThan(builtinIdx);
+  });
+
+  it('filters skills that do not match the provider', () => {
+    const anthropicOnly = makeSkill('anthropic-only', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'anthropic-only',
+        description: 'Anthropic only.',
+        trigger: { providers: ['anthropic'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+    });
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [anthropicOnly], 'openai');
+    // No match → original array returned unchanged
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('matches wildcard provider to any provider string', () => {
+    const wildcard = makeSkill('wildcard', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'wildcard',
+        description: 'Wildcard skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+    });
+    const forGoogle = injectSkillsIntoMessages(BASE_MESSAGES, [wildcard], 'google');
+    expect(forGoogle[0]?.content).toContain('Body of wildcard.');
+    const forGroq = injectSkillsIntoMessages(BASE_MESSAGES, [wildcard], 'groq');
+    expect(forGroq[0]?.content).toContain('Body of wildcard.');
+  });
+
+  it('uses prefix scope to prepend to first user message', () => {
+    const prefixSkill = makeSkill('prefix-skill', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'prefix-skill',
+        description: 'Prefix skill.',
+        trigger: { providers: ['*'], scope: 'prefix' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+    });
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [prefixSkill], 'anthropic');
+    // Message count stays the same
+    expect(result).toHaveLength(BASE_MESSAGES.length);
+    // System prompt is untouched
+    expect(result[0]?.content).toBe('You are a helpful assistant.');
+    // Skill block prepended to user message
+    expect(result[1]?.role).toBe('user');
+    expect(result[1]?.content).toContain('Body of prefix-skill.');
+    expect(result[1]?.content).toContain('Design a landing page.');
+  });
+
+  it('does not mutate the original messages array', () => {
+    const original = [
+      { role: 'system' as const, content: 'System prompt.' },
+      { role: 'user' as const, content: 'User message.' },
+    ];
+    const originalSnapshot = original.map((m) => ({ ...m }));
+    injectSkillsIntoMessages(original, [makeSkill('skill')], 'anthropic');
+    expect(original[0]?.content).toBe(originalSnapshot[0]?.content);
+    expect(original[1]?.content).toBe(originalSnapshot[1]?.content);
+  });
+});

--- a/packages/providers/src/skill-injector.test.ts
+++ b/packages/providers/src/skill-injector.test.ts
@@ -159,4 +159,72 @@ describe('injectSkillsIntoMessages()', () => {
     expect(original[0]?.content).toBe(originalSnapshot[0]?.content);
     expect(original[1]?.content).toBe(originalSnapshot[1]?.content);
   });
+
+  it('produces a byte-identical prompt regardless of input skill order', () => {
+    const skills: LoadedSkill[] = [
+      makeSkill('zeta', { source: 'builtin', body: 'Zeta body.' }),
+      makeSkill('alpha', { source: 'user', body: 'Alpha body.' }),
+      makeSkill('mango', { source: 'project', body: 'Mango body.' }),
+      makeSkill('beta', { source: 'project', body: 'Beta body.' }),
+      makeSkill('gamma', { source: 'user', body: 'Gamma body.' }),
+    ];
+
+    const canonical = injectSkillsIntoMessages(BASE_MESSAGES, skills, 'anthropic');
+    const canonicalContent = canonical[0]?.content ?? '';
+
+    // Project skills (alphabetical) come first, then user, then builtin.
+    const expectedOrder = ['Beta body.', 'Mango body.', 'Alpha body.', 'Gamma body.', 'Zeta body.'];
+    const indices = expectedOrder.map((needle) => canonicalContent.indexOf(needle));
+    expect(indices.every((i) => i >= 0)).toBe(true);
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i - 1]).toBeLessThan(indices[i] as number);
+    }
+
+    const permutations: LoadedSkill[][] = [
+      [skills[1], skills[0], skills[2], skills[4], skills[3]] as LoadedSkill[],
+      [skills[4], skills[3], skills[2], skills[1], skills[0]] as LoadedSkill[],
+      [skills[2], skills[4], skills[0], skills[3], skills[1]] as LoadedSkill[],
+    ];
+    for (const perm of permutations) {
+      const result = injectSkillsIntoMessages(BASE_MESSAGES, perm, 'anthropic');
+      expect(result[0]?.content).toBe(canonicalContent);
+    }
+  });
+
+  it('resolves mixed scope deterministically using highest-precedence skill', () => {
+    const projectPrefix = makeSkill('proj', {
+      source: 'project',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'proj',
+        description: 'Project prefix skill.',
+        trigger: { providers: ['*'], scope: 'prefix' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'Project prefix body.',
+    });
+    const userSystem = makeSkill('user', {
+      source: 'user',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'user',
+        description: 'User system skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'User system body.',
+    });
+
+    const a = injectSkillsIntoMessages(BASE_MESSAGES, [projectPrefix, userSystem], 'anthropic');
+    const b = injectSkillsIntoMessages(BASE_MESSAGES, [userSystem, projectPrefix], 'anthropic');
+    expect(a).toEqual(b);
+    // Project skill (higher precedence) chose 'prefix' scope, so user message
+    // gets the block and the system message stays untouched.
+    expect(a[0]?.content).toBe('You are a helpful assistant.');
+    expect(a[1]?.role).toBe('user');
+    expect(a[1]?.content).toContain('Project prefix body.');
+    expect(a[1]?.content).toContain('User system body.');
+  });
 });

--- a/packages/providers/src/skill-injector.ts
+++ b/packages/providers/src/skill-injector.ts
@@ -44,10 +44,8 @@ const SOURCE_RANK: Record<LoadedSkill['source'], number> = {
  * return them. Order: source precedence (project > user > builtin), then
  * alphabetical by frontmatter name within each source.
  *
- * Determinism here is load-bearing: it stabilises the scope chosen for mixed
- * `system`/`prefix` skills (highest-precedence skill wins) and makes the
- * concatenated body block byte-identical across runs, which keeps prompt
- * caching and snapshot tests reliable.
+ * Determinism here makes the concatenated body block byte-identical across
+ * runs, which keeps prompt caching and snapshot tests reliable.
  */
 function sortCanonical(skills: LoadedSkill[]): LoadedSkill[] {
   return [...skills].sort((a, b) => {
@@ -91,6 +89,11 @@ function prependUserContent(messages: ChatMessage[], block: string): ChatMessage
  * - `prefix`: skill block is prepended to the first user message. Useful for
  *   providers that do not accept a system role.
  *
+ * Mixed-scope skill sets are split by `trigger.scope` and injected into both
+ * channels independently, so each skill lands in the channel it declared. The
+ * canonical sort (project > user > builtin, then alphabetical) is preserved
+ * within each channel.
+ *
  * The function is pure (no mutation) and returns the original array unchanged
  * when no active skills match `providerId`.
  */
@@ -102,16 +105,17 @@ export function injectSkillsIntoMessages(
   const active = sortCanonical(filterActive(enabledSkills, provider));
   if (active.length === 0) return baseMessages;
 
-  const block = buildSkillBlock(active);
+  const systemSkills = active.filter(
+    (s) => (s.frontmatter.trigger?.scope ?? 'system') === 'system',
+  );
+  const prefixSkills = active.filter((s) => s.frontmatter.trigger?.scope === 'prefix');
 
-  // Mixed `system`/`prefix` scopes resolve to the highest-precedence skill
-  // (project > user > builtin, then alphabetical), so the chosen channel is a
-  // function of the skill set rather than caller array order.
-  const scope = active[0]?.frontmatter.trigger?.scope ?? 'system';
-
-  if (scope === 'prefix') {
-    return prependUserContent(baseMessages, block);
+  let out = baseMessages;
+  if (systemSkills.length > 0) {
+    out = prependSystemContent(out, buildSkillBlock(systemSkills));
   }
-
-  return prependSystemContent(baseMessages, block);
+  if (prefixSkills.length > 0) {
+    out = prependUserContent(out, buildSkillBlock(prefixSkills));
+  }
+  return out;
 }

--- a/packages/providers/src/skill-injector.ts
+++ b/packages/providers/src/skill-injector.ts
@@ -21,8 +21,6 @@ function matchesProvider(providers: string[] | undefined, providerId: string): b
 
 /**
  * Filter to skills that are relevant to `providerId` and not disabled.
- * Priority order is assumed to already be encoded in the `skills` array
- * by the loader (project > user > builtin).
  */
 function filterActive(skills: LoadedSkill[], providerId: string): LoadedSkill[] {
   return skills.filter(
@@ -30,6 +28,33 @@ function filterActive(skills: LoadedSkill[], providerId: string): LoadedSkill[] 
       !s.frontmatter.disable_model_invocation &&
       matchesProvider(s.frontmatter.trigger?.providers, providerId),
   );
+}
+
+// Source precedence: project overrides user, user overrides builtin. Encoded
+// as a numeric rank so a stable sort can place higher-priority skills first.
+const SOURCE_RANK: Record<LoadedSkill['source'], number> = {
+  project: 0,
+  user: 1,
+  builtin: 2,
+};
+
+/**
+ * Sort skills into a canonical order so the injected prompt blob is purely a
+ * function of the active skill set, never of how `loadSkills*` happened to
+ * return them. Order: source precedence (project > user > builtin), then
+ * alphabetical by frontmatter name within each source.
+ *
+ * Determinism here is load-bearing: it stabilises the scope chosen for mixed
+ * `system`/`prefix` skills (highest-precedence skill wins) and makes the
+ * concatenated body block byte-identical across runs, which keeps prompt
+ * caching and snapshot tests reliable.
+ */
+function sortCanonical(skills: LoadedSkill[]): LoadedSkill[] {
+  return [...skills].sort((a, b) => {
+    const rankDelta = SOURCE_RANK[a.source] - SOURCE_RANK[b.source];
+    if (rankDelta !== 0) return rankDelta;
+    return a.frontmatter.name.localeCompare(b.frontmatter.name, 'en');
+  });
 }
 
 function prependSystemContent(messages: ChatMessage[], block: string): ChatMessage[] {
@@ -74,14 +99,14 @@ export function injectSkillsIntoMessages(
   enabledSkills: LoadedSkill[],
   provider: string,
 ): ChatMessage[] {
-  const active = filterActive(enabledSkills, provider);
+  const active = sortCanonical(filterActive(enabledSkills, provider));
   if (active.length === 0) return baseMessages;
 
   const block = buildSkillBlock(active);
 
-  // Use the scope of the first active skill as the injection strategy.
-  // All skills in a single generation share one scope; mixing scopes is not
-  // supported — the system setting wins.
+  // Mixed `system`/`prefix` scopes resolve to the highest-precedence skill
+  // (project > user > builtin, then alphabetical), so the chosen channel is a
+  // function of the skill set rather than caller array order.
   const scope = active[0]?.frontmatter.trigger?.scope ?? 'system';
 
   if (scope === 'prefix') {

--- a/packages/providers/src/skill-injector.ts
+++ b/packages/providers/src/skill-injector.ts
@@ -1,0 +1,92 @@
+import type { ChatMessage, LoadedSkill } from '@open-codesign/shared';
+
+// ---------------------------------------------------------------------------
+// Provider-agnostic skill injector
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise the bodies of all enabled skills into a single block of text,
+ * separated by a markdown hr so the model can distinguish skill boundaries.
+ */
+function buildSkillBlock(skills: LoadedSkill[]): string {
+  return skills
+    .map((s) => `### Skill: ${s.frontmatter.name}\n\n${s.body.trim()}`)
+    .join('\n\n---\n\n');
+}
+
+function matchesProvider(providers: string[] | undefined, providerId: string): boolean {
+  if (!providers || providers.length === 0) return true;
+  return providers.includes('*') || providers.includes(providerId);
+}
+
+/**
+ * Filter to skills that are relevant to `providerId` and not disabled.
+ * Priority order is assumed to already be encoded in the `skills` array
+ * by the loader (project > user > builtin).
+ */
+function filterActive(skills: LoadedSkill[], providerId: string): LoadedSkill[] {
+  return skills.filter(
+    (s) =>
+      !s.frontmatter.disable_model_invocation &&
+      matchesProvider(s.frontmatter.trigger?.providers, providerId),
+  );
+}
+
+function prependSystemContent(messages: ChatMessage[], block: string): ChatMessage[] {
+  const [first, ...rest] = messages;
+  if (first?.role === 'system') {
+    return [{ role: 'system', content: `${block}\n\n${first.content}` }, ...rest];
+  }
+  return [{ role: 'system', content: block }, ...messages];
+}
+
+function prependUserContent(messages: ChatMessage[], block: string): ChatMessage[] {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg?.role === 'user') {
+      const updated: ChatMessage[] = [
+        ...messages.slice(0, i),
+        { role: 'user', content: `${block}\n\n${msg.content}` },
+        ...messages.slice(i + 1),
+      ];
+      return updated;
+    }
+  }
+  // No user message found — append as user message
+  return [...messages, { role: 'user', content: block }];
+}
+
+/**
+ * Inject enabled skills into a message array for a given provider.
+ *
+ * Scope semantics:
+ * - `system`: skill block is prepended to the system prompt (or inserted as a
+ *   new system message at position 0 when none exists). This is the default
+ *   and works for all provider message formats handled here.
+ * - `prefix`: skill block is prepended to the first user message. Useful for
+ *   providers that do not accept a system role.
+ *
+ * The function is pure (no mutation) and returns the original array unchanged
+ * when no active skills match `providerId`.
+ */
+export function injectSkillsIntoMessages(
+  baseMessages: ChatMessage[],
+  enabledSkills: LoadedSkill[],
+  provider: string,
+): ChatMessage[] {
+  const active = filterActive(enabledSkills, provider);
+  if (active.length === 0) return baseMessages;
+
+  const block = buildSkillBlock(active);
+
+  // Use the scope of the first active skill as the injection strategy.
+  // All skills in a single generation share one scope; mixing scopes is not
+  // supported — the system setting wins.
+  const scope = active[0]?.frontmatter.trigger?.scope ?? 'system';
+
+  if (scope === 'prefix') {
+    return prependUserContent(baseMessages, block);
+  }
+
+  return prependSystemContent(baseMessages, block);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -207,3 +207,6 @@ export type { DesignToken } from './design-token';
 
 export { DesignSnapshotV1, DesignV1 } from './snapshot';
 export type { Design, DesignSnapshot, SnapshotCreateInput } from './snapshot';
+
+export { SkillFrontmatterV1 } from './skills';
+export type { LoadedSkill } from './skills';

--- a/packages/shared/src/skills.ts
+++ b/packages/shared/src/skills.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const SkillFrontmatterV1 = z.object({
+  schemaVersion: z.literal(1).default(1),
+  name: z.string().min(1),
+  description: z.string().min(1).max(1536),
+  trigger: z
+    .object({
+      providers: z.array(z.string()).default(['*']),
+      scope: z.enum(['system', 'prefix']).default('system'),
+    })
+    .default({}),
+  disable_model_invocation: z.boolean().default(false),
+  user_invocable: z.boolean().default(true),
+  allowed_tools: z.array(z.string()).optional(),
+});
+
+export type SkillFrontmatterV1 = z.infer<typeof SkillFrontmatterV1>;
+
+export interface LoadedSkill {
+  /** File slug — filename minus extension (e.g. "frontend-design-anti-slop"). */
+  id: string;
+  source: 'builtin' | 'user' | 'project';
+  frontmatter: SkillFrontmatterV1;
+  /** Markdown body after the closing --- delimiter. */
+  body: string;
+}


### PR DESCRIPTION
## Summary

First PR of 3 implementing the Skills system (research 12).

This PR delivers the **backend foundation only**:
- SKILL.md loader (file-based, no new deps; tiny inline frontmatter parser)
- Schema + types (zod, schemaVersion 1)
- 4 built-in starter skills (Apache-2.0 self-written, no Anthropic SKILL.md text copied)
- Provider-agnostic skill injector (packages/providers)

Not in scope (follow-up PRs):
- Settings → Skills tab UI (PR-B)
- Wiring loaded skills into the actual generation pipeline (PR-C)

## Architecture note

`SkillFrontmatterV1` and `LoadedSkill` are defined in `packages/shared` (not `packages/core`) to avoid a circular dependency (`core` depends on `providers`; `providers` now depends on `shared` for the skill types). `packages/core/src/skills/types.ts` re-exports from shared for convenience.

## Built-in starters
- `frontend-design-anti-slop` — design quality guard (oklch / no Inter / asymmetry)
- `pitch-deck` — slide ratio, whitespace, one-claim-per-slide
- `data-viz-recharts` — chart palette + recharts patterns
- `mobile-mock` — viewport ratio + 44pt touch targets

## No new dependencies
Inline YAML subset parser (~100 lines) handles: folded/literal block scalars, nested block mappings, inline + block sequences. No `gray-matter` added.

## Test plan
- [x] loader: 4 starters load with correct frontmatter
- [x] loader: project overrides user overrides builtin (same id)
- [x] loader: missing frontmatter fields get zod defaults
- [x] loader: description > 1536 chars → skill silently skipped
- [x] loader: malformed .md doesn't crash; other skills still load
- [x] injector: produces single system message block; correct order
- [x] injector: wildcard provider matches any provider
- [x] injector: prefix scope prepends to first user message
- [x] injector: returns original array when no active skills
- [x] injector: does not mutate the original messages array

## Compatibility
- Compat: builds on existing providers/shared/core packages, no breaking changes
- Upgradeability: schemaVersion 1 on frontmatter + LoadedSkill for forward migration
- No bloat: zero new runtime deps
- Elegant: pure functions throughout, no global state