### PR TITLE
feat(ui): disabled button tooltip audit

### DIFF
--- a/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
@@ -1,5 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import type { SelectedElement } from '@open-codesign/shared';
+import { Tooltip } from '@open-codesign/ui';
 import { MessageSquareText, X } from 'lucide-react';
 import { useState } from 'react';
 import { useCodesignStore } from '../store';
@@ -22,6 +23,9 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
   const applyInlineComment = useCodesignStore((s) => s.applyInlineComment);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const [draft, setDraft] = useState('');
+  const applyDisabledReason = isGenerating
+    ? t('disabledReason.generatingInProgress')
+    : t('disabledReason.typeDraftToApply');
 
   return (
     <div className="absolute bottom-10 right-10 z-10 w-[min(420px,calc(100%-3rem))] overflow-hidden rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
@@ -68,14 +72,19 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
           >
             {t('common.cancel')}
           </button>
-          <button
-            type="button"
-            disabled={!draft.trim() || isGenerating}
-            onClick={() => void applyInlineComment(draft)}
-            className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent)] px-3 py-2 text-[12px] font-medium text-white shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:pointer-events-none disabled:opacity-40"
+          <Tooltip
+            label={!draft.trim() || isGenerating ? applyDisabledReason : undefined}
+            side="top"
           >
-            {isGenerating ? t('inlineComment.applying') : t('inlineComment.applyChange')}
-          </button>
+            <button
+              type="button"
+              disabled={!draft.trim() || isGenerating}
+              onClick={() => void applyInlineComment(draft)}
+              className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent)] px-3 py-2 text-[12px] font-medium text-white shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:pointer-events-none disabled:opacity-40"
+            >
+              {isGenerating ? t('inlineComment.applying') : t('inlineComment.applyChange')}
+            </button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -1,4 +1,5 @@
 import { useT } from '@open-codesign/i18n';
+import { Tooltip } from '@open-codesign/ui';
 import { Download } from 'lucide-react';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 import type { ExportFormat } from '../../../preload/index';
@@ -72,17 +73,19 @@ export function PreviewToolbar(): ReactElement {
       )}
 
       <div className="relative" ref={ref}>
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={() => setOpen((v) => !v)}
-          className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-[var(--radius-md)] text-[13px] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
-          aria-haspopup="menu"
-          aria-expanded={open}
-        >
-          <Download className="w-[14px] h-[14px]" aria-hidden="true" />
-          {t('export.button')}
-        </button>
+        <Tooltip label={disabled ? t('disabledReason.noDesignToExport') : undefined} side="bottom">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setOpen((v) => !v)}
+            className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-[var(--radius-md)] text-[13px] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            aria-haspopup="menu"
+            aria-expanded={open}
+          >
+            <Download className="w-[14px] h-[14px]" aria-hidden="true" />
+            {t('export.button')}
+          </button>
+        </Tooltip>
 
         {open && (
           <div

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -8,7 +8,7 @@ import {
   PROVIDER_SHORTLIST as SHORTLIST,
   isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
-import { Button } from '@open-codesign/ui';
+import { Button, Tooltip } from '@open-codesign/ui';
 import {
   AlertTriangle,
   ArrowLeft,
@@ -370,23 +370,32 @@ function AddProviderModal({
                 placeholder={t('settings.providers.modal.apiKeyPlaceholder')}
                 className="flex-1"
               />
-              <button
-                type="button"
-                onClick={handleValidate}
-                disabled={form.apiKey.trim().length === 0 || form.validating}
-                className="h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
+              <Tooltip
+                label={
+                  form.apiKey.trim().length === 0 || form.validating
+                    ? 'Enter an API key to validate'
+                    : undefined
+                }
+                side="top"
               >
-                {form.validating ? (
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                ) : form.validated ? (
-                  <CheckCircle className="w-3.5 h-3.5 text-[var(--color-success)]" />
-                ) : null}
-                {form.validating
-                  ? t('settings.providers.modal.validating')
-                  : form.validated
-                    ? t('settings.providers.modal.valid')
-                    : t('settings.providers.modal.validate')}
-              </button>
+                <button
+                  type="button"
+                  onClick={handleValidate}
+                  disabled={form.apiKey.trim().length === 0 || form.validating}
+                  className="h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
+                >
+                  {form.validating ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : form.validated ? (
+                    <CheckCircle className="w-3.5 h-3.5 text-[var(--color-success)]" />
+                  ) : null}
+                  {form.validating
+                    ? t('settings.providers.modal.validating')
+                    : form.validated
+                      ? t('settings.providers.modal.valid')
+                      : t('settings.providers.modal.validate')}
+                </button>
+              </Tooltip>
             </div>
             {form.error && (
               <p className="mt-1.5 text-[var(--text-xs)] text-[var(--color-error)]">{form.error}</p>
@@ -436,9 +445,11 @@ function AddProviderModal({
           <Button variant="secondary" size="sm" onClick={onClose}>
             {t('common.cancel')}
           </Button>
-          <Button size="sm" onClick={handleSave} disabled={!canSave}>
-            {t('settings.providers.modal.save')}
-          </Button>
+          <Tooltip label={!canSave ? 'Validate the key first' : undefined} side="top">
+            <Button size="sm" onClick={handleSave} disabled={!canSave}>
+              {t('settings.providers.modal.save')}
+            </Button>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -373,7 +373,7 @@ function AddProviderModal({
               <Tooltip
                 label={
                   form.apiKey.trim().length === 0 || form.validating
-                    ? 'Enter an API key to validate'
+                    ? t('disabledReason.enterApiKeyToValidate')
                     : undefined
                 }
                 side="top"
@@ -445,7 +445,7 @@ function AddProviderModal({
           <Button variant="secondary" size="sm" onClick={onClose}>
             {t('common.cancel')}
           </Button>
-          <Tooltip label={!canSave ? 'Validate the key first' : undefined} side="top">
+          <Tooltip label={!canSave ? t('disabledReason.validateKeyFirst') : undefined} side="top">
             <Button size="sm" onClick={handleSave} disabled={!canSave}>
               {t('settings.providers.modal.save')}
             </Button>

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useT } from '@open-codesign/i18n';
-import { IconButton } from '@open-codesign/ui';
+import { IconButton, Tooltip } from '@open-codesign/ui';
 import { ArrowUp, FolderOpen, Link2, Paperclip, Square, X } from 'lucide-react';
 import { type FormEvent, type KeyboardEvent, useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
@@ -66,6 +66,9 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
   }
 
   const canSend = prompt.trim().length > 0 && !isGenerating;
+  const sendDisabledReason = isGenerating
+    ? t('disabledReason.generatingInProgress')
+    : t('disabledReason.typePromptToSend');
 
   return (
     <aside
@@ -226,18 +229,20 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
                 />
               </IconButton>
             ) : (
-              <IconButton
-                size="sm"
-                type="submit"
-                label={t('chat.send')}
-                disabled={!canSend}
-                className="bg-[var(--color-accent)] text-[var(--color-on-accent)] shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[var(--scale-hover-up)] active:scale-[var(--scale-press-down)] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-[var(--duration-faster)] ease-[var(--ease-out)]"
-              >
-                <ArrowUp
-                  className="w-[var(--size-icon-md)] h-[var(--size-icon-md)]"
-                  strokeWidth={2.4}
-                />
-              </IconButton>
+              <Tooltip label={!canSend ? sendDisabledReason : undefined} side="top">
+                <IconButton
+                  size="sm"
+                  type="submit"
+                  label={t('chat.send')}
+                  disabled={!canSend}
+                  className="bg-[var(--color-accent)] text-[var(--color-on-accent)] shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:text-[var(--color-on-accent)] hover:scale-[var(--scale-hover-up)] active:scale-[var(--scale-press-down)] disabled:opacity-30 disabled:hover:scale-100 transition-[transform,background-color,opacity,color] duration-[var(--duration-faster)] ease-[var(--ease-out)]"
+                >
+                  <ArrowUp
+                    className="w-[var(--size-icon-md)] h-[var(--size-icon-md)]"
+                    strokeWidth={2.4}
+                  />
+                </IconButton>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
@@ -96,7 +96,7 @@ export function ChooseModel({
       ) : null}
 
       <div className="flex justify-between gap-2 pt-2">
-        <Tooltip label={saving ? 'Saving in progress' : undefined} side="top">
+        <Tooltip label={saving ? t('disabledReason.savingInProgress') : undefined} side="top">
           <Button type="button" variant="ghost" onClick={onBack} disabled={saving}>
             {t('onboarding.choose.back')}
           </Button>
@@ -105,8 +105,8 @@ export function ChooseModel({
           label={
             !canFinish
               ? saving
-                ? 'Saving in progress'
-                : 'Both model fields are required'
+                ? t('disabledReason.savingInProgress')
+                : t('disabledReason.enterBothModels')
               : undefined
           }
           side="top"

--- a/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { PROVIDER_SHORTLIST, type SupportedOnboardingProvider } from '@open-codesign/shared';
-import { Button } from '@open-codesign/ui';
+import { Button, Tooltip } from '@open-codesign/ui';
 import { useEffect, useId, useState } from 'react';
 
 const OPENROUTER_FREE_MODEL = 'openrouter/free';
@@ -96,17 +96,30 @@ export function ChooseModel({
       ) : null}
 
       <div className="flex justify-between gap-2 pt-2">
-        <Button type="button" variant="ghost" onClick={onBack} disabled={saving}>
-          {t('onboarding.choose.back')}
-        </Button>
-        <Button
-          type="button"
-          variant="primary"
-          onClick={() => onConfirm(trimmedPrimary, trimmedFast)}
-          disabled={!canFinish}
+        <Tooltip label={saving ? 'Saving in progress' : undefined} side="top">
+          <Button type="button" variant="ghost" onClick={onBack} disabled={saving}>
+            {t('onboarding.choose.back')}
+          </Button>
+        </Tooltip>
+        <Tooltip
+          label={
+            !canFinish
+              ? saving
+                ? 'Saving in progress'
+                : 'Both model fields are required'
+              : undefined
+          }
+          side="top"
         >
-          {saving ? t('onboarding.choose.saving') : t('onboarding.choose.finish')}
-        </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => onConfirm(trimmedPrimary, trimmedFast)}
+            disabled={!canFinish}
+          >
+            {saving ? t('onboarding.choose.saving') : t('onboarding.choose.finish')}
+          </Button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -6,7 +6,7 @@ import {
   type SupportedOnboardingProvider,
   isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
-import { Button } from '@open-codesign/ui';
+import { Button, Tooltip } from '@open-codesign/ui';
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2, Wifi, WifiOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ConnectionTestError } from '../../../preload/index';
@@ -276,7 +276,15 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   const selectedPreset = PROXY_PRESETS.find((p) => p.id === selectedPresetId);
   const testDisabled =
     connCheck.status === 'testing' || detectedProvider === null || trimmed.length === 0;
+  const testDisabledReason = testDisabled
+    ? connCheck.status === 'testing'
+      ? 'Testing connection…'
+      : 'Enter provider and API key to test'
+    : undefined;
   const continueDisabled = connCheck.status !== 'ok';
+  const continueDisabledReason = continueDisabled
+    ? 'Run Test to verify your connection first'
+    : undefined;
 
   return (
     <div className="flex flex-col gap-5">
@@ -379,25 +387,27 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
 
       {/* Test button + connection status — the sole authority for key+endpoint verification */}
       <div className="flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => void handleTest()}
-          disabled={testDisabled}
-          className="self-start h-[var(--size-control-md)] px-[var(--space-4)] rounded-[var(--radius-md)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
-        >
-          {connCheck.status === 'testing' ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : connCheck.status === 'ok' ? (
-            <Wifi className="w-4 h-4 text-[var(--color-success)]" />
-          ) : connCheck.status === 'failed' ? (
-            <WifiOff className="w-4 h-4 text-[var(--color-error)]" />
-          ) : (
-            <Wifi className="w-4 h-4" />
-          )}
-          {connCheck.status === 'testing'
-            ? t('onboarding.paste.connectionTest.testing')
-            : t('onboarding.paste.connectionTest.button')}
-        </button>
+        <Tooltip label={testDisabledReason} side="top">
+          <button
+            type="button"
+            onClick={() => void handleTest()}
+            disabled={testDisabled}
+            className="self-start h-[var(--size-control-md)] px-[var(--space-4)] rounded-[var(--radius-md)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+          >
+            {connCheck.status === 'testing' ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : connCheck.status === 'ok' ? (
+              <Wifi className="w-4 h-4 text-[var(--color-success)]" />
+            ) : connCheck.status === 'failed' ? (
+              <WifiOff className="w-4 h-4 text-[var(--color-error)]" />
+            ) : (
+              <Wifi className="w-4 h-4" />
+            )}
+            {connCheck.status === 'testing'
+              ? t('onboarding.paste.connectionTest.testing')
+              : t('onboarding.paste.connectionTest.button')}
+          </button>
+        </Tooltip>
 
         {connCheck.status === 'ok' && (
           <span className="text-[var(--text-sm)] text-[var(--color-success)] flex items-center gap-2">
@@ -422,15 +432,16 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         <Button type="button" variant="ghost" onClick={onBack}>
           {t('onboarding.paste.back')}
         </Button>
-        <Button
-          type="button"
-          variant="primary"
-          onClick={handleContinue}
-          disabled={continueDisabled}
-          title={continueDisabled ? t('onboarding.paste.connectionTest.runFirst') : undefined}
-        >
-          {t('onboarding.paste.continue')}
-        </Button>
+        <Tooltip label={continueDisabledReason} side="top">
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleContinue}
+            disabled={continueDisabled}
+          >
+            {t('onboarding.paste.continue')}
+          </Button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -278,12 +278,12 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
     connCheck.status === 'testing' || detectedProvider === null || trimmed.length === 0;
   const testDisabledReason = testDisabled
     ? connCheck.status === 'testing'
-      ? 'Testing connection…'
-      : 'Enter provider and API key to test'
+      ? t('disabledReason.testingConnection')
+      : t('disabledReason.fillAllFieldsToTest')
     : undefined;
   const continueDisabled = connCheck.status !== 'ok';
   const continueDisabledReason = continueDisabled
-    ? 'Run Test to verify your connection first'
+    ? t('disabledReason.validateKeyToContinue')
     : undefined;
 
   return (

--- a/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
@@ -37,7 +37,7 @@ export function Welcome({ onPickKey, onPickFreeTier, ollamaDetected }: WelcomePr
           onClick={onPickKey}
         />
         {ollamaDetected ? (
-          <Tooltip label="Ollama integration is coming in v0.2" side="bottom">
+          <Tooltip label={t('disabledReason.ollamaComingSoon')} side="bottom">
             <PathButton
               icon={<Server className="w-[18px] h-[18px]" />}
               title={t('onboarding.welcome.useOllama')}

--- a/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
@@ -1,5 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { PROVIDER_SHORTLIST, type SupportedOnboardingProvider } from '@open-codesign/shared';
+import { Tooltip } from '@open-codesign/ui';
 import { ArrowRight, ExternalLink, KeyRound, Rocket, Server } from 'lucide-react';
 
 interface WelcomeProps {
@@ -36,12 +37,14 @@ export function Welcome({ onPickKey, onPickFreeTier, ollamaDetected }: WelcomePr
           onClick={onPickKey}
         />
         {ollamaDetected ? (
-          <PathButton
-            icon={<Server className="w-[18px] h-[18px]" />}
-            title={t('onboarding.welcome.useOllama')}
-            subtitle={t('onboarding.welcome.useOllamaSubtitle')}
-            disabled
-          />
+          <Tooltip label="Ollama integration is coming in v0.2" side="bottom">
+            <PathButton
+              icon={<Server className="w-[18px] h-[18px]" />}
+              title={t('onboarding.welcome.useOllama')}
+              subtitle={t('onboarding.welcome.useOllamaSubtitle')}
+              disabled
+            />
+          </Tooltip>
         ) : null}
       </div>
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -357,6 +357,20 @@
     "applying": "Applying…",
     "applyChange": "Apply change"
   },
+  "disabledReason": {
+    "typePromptToSend": "Type a prompt to start",
+    "generatingInProgress": "Generation in progress",
+    "typeDraftToApply": "Type a comment to apply",
+    "noDesignToExport": "Generate a design first",
+    "enterApiKeyToValidate": "Enter an API key to validate",
+    "validateKeyFirst": "Validate the key first",
+    "fillAllFieldsToTest": "Enter provider, key and base URL to test",
+    "testingConnection": "Testing connection…",
+    "validateKeyToContinue": "Validate your API key to continue",
+    "savingInProgress": "Saving in progress",
+    "enterBothModels": "Both model fields are required",
+    "ollamaComingSoon": "Ollama integration is coming in v0.2"
+  },
   "errors": {
     "generic": "Something went wrong.",
     "providerAuthMissing": "No API key configured. Open Settings to add one.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -356,6 +356,20 @@
     "applying": "应用中…",
     "applyChange": "应用修改"
   },
+  "disabledReason": {
+    "typePromptToSend": "输入提示词以开始",
+    "generatingInProgress": "生成中，请稍候",
+    "typeDraftToApply": "输入评论内容后才能应用",
+    "noDesignToExport": "先生成一个设计再导出",
+    "enterApiKeyToValidate": "请输入 API Key 进行验证",
+    "validateKeyFirst": "请先验证 API Key",
+    "fillAllFieldsToTest": "请填写 provider、key 和 Base URL",
+    "testingConnection": "正在测试连接…",
+    "validateKeyToContinue": "验证 API Key 后才能继续",
+    "savingInProgress": "正在保存",
+    "enterBothModels": "两个模型字段均为必填",
+    "ollamaComingSoon": "Ollama 集成将在 v0.2 中支持"
+  },
   "errors": {
     "generic": "出错了。",
     "providerAuthMissing": "还没配置 API Key。打开设置去添加一个。",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,8 +25,13 @@
     "@fontsource-variable/jetbrains-mono": "^5.1.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "happy-dom": "^15.11.7",
     "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/packages/ui/src/components/Tooltip.test.tsx
+++ b/packages/ui/src/components/Tooltip.test.tsx
@@ -77,4 +77,69 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
     expect(tooltip.className).toContain('top-full');
   });
+
+  it('exposes a focusable wrapper so keyboard users can reach disabled controls', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">Before</button>
+        <Tooltip label="Disabled because no API key">
+          <button type="button" disabled>
+            Send
+          </button>
+        </Tooltip>
+      </>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = tooltip.parentElement as HTMLElement;
+    expect(wrapper.getAttribute('tabindex')).toBe('0');
+
+    screen.getByRole('button', { name: 'Before' }).focus();
+    await user.tab();
+    expect(document.activeElement).toBe(wrapper);
+  });
+
+  it('wires aria-describedby on the wrapper to the tooltip text id', () => {
+    render(
+      <Tooltip label="Reason">
+        <button type="button" disabled>
+          Send
+        </button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = tooltip.parentElement as HTMLElement;
+    const describedBy = wrapper.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(tooltip.id).toBe(describedBy);
+  });
+
+  it('reveals tooltip when wrapper receives focus and hides on blur', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">Before</button>
+        <Tooltip label="Focus me">
+          <button type="button" disabled>
+            Send
+          </button>
+        </Tooltip>
+        <button type="button">After</button>
+      </>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('group-focus-within:opacity-100');
+    expect(tooltip.className).toContain('group-focus:opacity-100');
+
+    screen.getByRole('button', { name: 'Before' }).focus();
+    await user.tab();
+    const wrapper = tooltip.parentElement as HTMLElement;
+    expect(document.activeElement).toBe(wrapper);
+
+    await user.tab();
+    expect(document.activeElement).not.toBe(wrapper);
+  });
 });

--- a/packages/ui/src/components/Tooltip.test.tsx
+++ b/packages/ui/src/components/Tooltip.test.tsx
@@ -78,9 +78,49 @@ describe('Tooltip', () => {
     expect(tooltip.className).toContain('top-full');
   });
 
-  it('exposes a focusable wrapper so keyboard users can reach disabled controls', async () => {
-    const user = userEvent.setup();
+  it('makes wrapper focusable (tabindex=0) only when the wrapped child is disabled', () => {
     render(
+      <Tooltip label="Disabled because no API key">
+        <button type="button" disabled>
+          Send
+        </button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = tooltip.parentElement as HTMLElement;
+    expect(wrapper.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('omits tabindex on the wrapper when the wrapped child is enabled', () => {
+    render(
+      <Tooltip label="Hint">
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    const wrapper = tooltip.parentElement as HTMLElement;
+    expect(wrapper.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('tab lands on inner button when enabled, on wrapper when disabled', async () => {
+    const user = userEvent.setup();
+
+    const enabled = render(
+      <>
+        <button type="button">Before</button>
+        <Tooltip label="Hint">
+          <button type="button">Send</button>
+        </Tooltip>
+      </>,
+    );
+    enabled.getByRole('button', { name: 'Before' }).focus();
+    await user.tab();
+    expect(document.activeElement).toBe(enabled.getByRole('button', { name: 'Send' }));
+    enabled.unmount();
+
+    const disabled = render(
       <>
         <button type="button">Before</button>
         <Tooltip label="Disabled because no API key">
@@ -90,12 +130,9 @@ describe('Tooltip', () => {
         </Tooltip>
       </>,
     );
-
-    const tooltip = screen.getByRole('tooltip');
+    const tooltip = disabled.getByRole('tooltip');
     const wrapper = tooltip.parentElement as HTMLElement;
-    expect(wrapper.getAttribute('tabindex')).toBe('0');
-
-    screen.getByRole('button', { name: 'Before' }).focus();
+    disabled.getByRole('button', { name: 'Before' }).focus();
     await user.tab();
     expect(document.activeElement).toBe(wrapper);
   });

--- a/packages/ui/src/components/Tooltip.test.tsx
+++ b/packages/ui/src/components/Tooltip.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Tooltip } from './Tooltip';
+
+describe('Tooltip', () => {
+  it('renders children alone when label is undefined', () => {
+    const { container } = render(
+      <Tooltip label={undefined}>
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDefined();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expect(container.querySelector('span.relative')).toBeNull();
+  });
+
+  it('renders children alone when label is empty string', () => {
+    render(
+      <Tooltip label="">
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('wraps children with tooltip element when label is provided', () => {
+    render(
+      <Tooltip label="Disabled because no API key">
+        <button type="button" disabled>
+          Send
+        </button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.textContent).toBe('Disabled because no API key');
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDefined();
+  });
+
+  it('reveals tooltip on hover via group-hover class', async () => {
+    const user = userEvent.setup();
+    render(
+      <Tooltip label="Hover me">
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('opacity-0');
+    expect(tooltip.className).toContain('group-hover:opacity-100');
+
+    await user.hover(screen.getByRole('button', { name: 'Send' }));
+    expect(screen.getByRole('tooltip')).toBeDefined();
+  });
+
+  it('applies side="top" positioning classes', () => {
+    render(
+      <Tooltip label="Top tip" side="top">
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('bottom-full');
+  });
+
+  it('defaults to side="bottom" positioning classes', () => {
+    render(
+      <Tooltip label="Bottom tip">
+        <button type="button">Send</button>
+      </Tooltip>,
+    );
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('top-full');
+  });
+});

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 export interface TooltipProps {
-  label: string;
+  label: string | undefined;
   side?: 'top' | 'bottom';
   children: ReactNode;
 }
@@ -12,6 +12,7 @@ const sideClass: Record<NonNullable<TooltipProps['side']>, string> = {
 };
 
 export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
+  if (!label) return <>{children}</>;
   return (
     <span className="relative inline-flex group">
       {children}

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 
 export interface TooltipProps {
   label: string | undefined;
@@ -12,13 +12,23 @@ const sideClass: Record<NonNullable<TooltipProps['side']>, string> = {
 };
 
 export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
+  const tooltipId = useId();
   if (!label) return <>{children}</>;
+  // Wrapper is focusable so keyboard users can land on it even when the
+  // wrapped control is disabled (disabled buttons cannot receive focus).
+  // aria-describedby points at the visible tooltip text so screen readers
+  // announce the reason on focus.
   return (
-    <span className="relative inline-flex group">
+    <span
+      className="relative inline-flex group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] rounded-[var(--radius-sm)]"
+      tabIndex={0}
+      aria-describedby={tooltipId}
+    >
       {children}
       <span
+        id={tooltipId}
         role="tooltip"
-        className={`pointer-events-none absolute ${sideClass[side]} z-50 whitespace-nowrap rounded-[var(--radius-sm)] bg-[var(--color-text-primary)] px-2 py-1 text-[11px] font-medium text-[var(--color-background)] opacity-0 transition-opacity duration-150 delay-[400ms] group-hover:opacity-100 group-focus-within:opacity-100 shadow-[var(--shadow-card)]`}
+        className={`pointer-events-none absolute ${sideClass[side]} z-50 whitespace-nowrap rounded-[var(--radius-sm)] bg-[var(--color-text-primary)] px-2 py-1 text-[11px] font-medium text-[var(--color-background)] opacity-0 transition-opacity duration-150 delay-[400ms] group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100 shadow-[var(--shadow-card)]`}
       >
         {label}
       </span>

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useId, type ReactNode } from 'react';
+import { type ReactNode, isValidElement, useId } from 'react';
 
 export interface TooltipProps {
   label: string | undefined;
@@ -14,14 +14,18 @@ const sideClass: Record<NonNullable<TooltipProps['side']>, string> = {
 export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
   const tooltipId = useId();
   if (!label) return <>{children}</>;
-  // Wrapper is focusable so keyboard users can land on it even when the
-  // wrapped control is disabled (disabled buttons cannot receive focus).
-  // aria-describedby points at the visible tooltip text so screen readers
-  // announce the reason on focus.
+  // Only the wrapper needs to be keyboard-focusable when the wrapped control
+  // is disabled (disabled buttons cannot receive focus). For enabled controls
+  // the inner element is already in the tab order, so making the wrapper
+  // focusable would create a redundant extra tab stop. aria-describedby stays
+  // on the wrapper either way so screen readers announce the reason whether
+  // focus lands on the wrapper or on the inner control.
+  const childDisabled =
+    isValidElement<{ disabled?: boolean }>(children) && Boolean(children.props.disabled);
   return (
     <span
       className="relative inline-flex group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] rounded-[var(--radius-sm)]"
-      tabIndex={0}
+      tabIndex={childDisabled ? 0 : undefined}
       aria-describedby={tooltipId}
     >
       {children}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
         version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/artifacts:
     dependencies:
@@ -129,7 +129,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/core:
     dependencies:
@@ -148,7 +148,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/exporters:
     dependencies:
@@ -173,7 +173,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/i18n:
     dependencies:
@@ -195,7 +195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/providers:
     dependencies:
@@ -211,7 +211,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/runtime:
     dependencies:
@@ -224,7 +224,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/shared:
     dependencies:
@@ -237,7 +237,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/templates:
     dependencies:
@@ -253,7 +253,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/ui:
     dependencies:
@@ -267,12 +267,27 @@ importers:
         specifier: ^5.1.0
         version: 5.2.8
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
@@ -281,7 +296,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   website:
     devDependencies:
@@ -1656,6 +1671,31 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -1692,6 +1732,9 @@ packages:
     resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
     cpu: [arm64]
     os: [win32]
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1977,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2016,6 +2063,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -2451,6 +2501,9 @@ packages:
     os: [darwin]
     hasBin: true
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -2533,6 +2586,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -2828,6 +2885,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3233,6 +3294,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3599,6 +3664,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -3676,6 +3745,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -4253,6 +4325,14 @@ packages:
 
   webdriver-bidi-protocol@0.4.1:
     resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6095,6 +6175,31 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -6116,6 +6221,8 @@ snapshots:
 
   '@turbo/windows-arm64@2.9.6':
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6454,6 +6561,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   app-builder-bin@5.0.0-alpha.10: {}
@@ -6546,6 +6655,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -6987,6 +7100,8 @@ snapshots:
       verror: 1.10.1
     optional: true
 
+  dom-accessibility-api@0.5.16: {}
+
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.6.1
@@ -7110,6 +7225,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   entities@7.0.1: {}
 
@@ -7514,6 +7631,12 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -7874,6 +7997,8 @@ snapshots:
   lucide-react@0.460.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -8237,6 +8362,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
@@ -8327,6 +8458,8 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       typescript: 5.9.3
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -8919,7 +9052,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
@@ -8943,6 +9076,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      happy-dom: 15.11.7
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -8973,6 +9107,10 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webdriver-bidi-protocol@0.4.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Implements §9 P1 of `docs/research/18-ux-master-plan.md`: every `disabled` button now explains *why* on hover
- 9 distinct disabled scenarios covered across 7 component files (see commit message for full list)
- Added `disabledReason.*` i18n namespace with 12 keys in both `en` and `zh-CN` locales
- `Tooltip` component updated to accept `label?: string` and skip rendering when `undefined`, so enabled buttons stay clean

## Compatibility checklist

- Compatibility ✅ — no interface changes, Tooltip `label` widens to `string | undefined` (backward compatible)
- Upgradeability ✅ — no disk schema touched
- No bloat ✅ — zero new dependencies; reuses existing `Tooltip` primitive from `packages/ui`
- Elegance ✅ — tooltip only wraps disabled state; enabled buttons render unchanged via early-return in `Tooltip`

## Test plan

- [ ] All 85 existing unit tests pass (`pnpm -r test`)
- [ ] Typecheck clean (`pnpm -r typecheck`)
- [ ] Lint clean (`pnpm lint`)
- [ ] Manual: hover the Send arrow when textarea is empty — tooltip "Type a prompt to start" appears
- [ ] Manual: hover the Send arrow while generating — tooltip "Generation in progress" appears
- [ ] Manual: hover the Export button before any generation — tooltip "Generate a design first" appears
- [ ] Manual: hover the "Validate" button in Add Provider modal with empty key — tooltip appears
- [ ] Manual: hover "Save provider" button before validation — tooltip "Validate the key first" appears
- [ ] Manual: in onboarding, hover "Continue" before key validates — tooltip appears
- [ ] Manual: in onboarding, hover Ollama option if detected — tooltip "coming in v0.2" appears
- [ ] Manual: switch to zh-CN locale and verify all tooltip strings render in Chinese