### PR TITLE
feat(desktop): connection error diagnostic panel

### DIFF
--- a/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.test.ts
+++ b/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@open-codesign/i18n', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../store', () => ({
+  useCodesignStore: () => vi.fn(),
+}));
+
+import { isAbsoluteHttpUrl } from './ConnectionDiagnosticPanel';
+
+describe('isAbsoluteHttpUrl', () => {
+  it('rejects an empty string so /v1 quick-fix cannot produce a bare "/v1"', () => {
+    expect(isAbsoluteHttpUrl('')).toBe(false);
+    expect(isAbsoluteHttpUrl('   ')).toBe(false);
+  });
+
+  it('rejects relative or scheme-less values', () => {
+    expect(isAbsoluteHttpUrl('api.example.com')).toBe(false);
+    expect(isAbsoluteHttpUrl('/v1')).toBe(false);
+    expect(isAbsoluteHttpUrl('ftp://api.example.com')).toBe(false);
+  });
+
+  it('accepts http and https absolute URLs', () => {
+    expect(isAbsoluteHttpUrl('https://api.example.com')).toBe(true);
+    expect(isAbsoluteHttpUrl('http://localhost:8080')).toBe(true);
+    expect(isAbsoluteHttpUrl('  https://api.example.com  ')).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
@@ -3,6 +3,7 @@ import { type DiagnoseContext, type DiagnosticHypothesis, diagnose } from '@open
 import type { ErrorCode } from '@open-codesign/shared';
 import { AlertCircle, ExternalLink, FileText, RefreshCw, X } from 'lucide-react';
 import { useState } from 'react';
+import { useCodesignStore } from '../store';
 
 export interface ConnectionDiagnosticPanelProps {
   /** The error code returned by connection.test or generate */
@@ -37,6 +38,7 @@ export function ConnectionDiagnosticPanel({
   logsPath,
 }: ConnectionDiagnosticPanelProps) {
   const t = useT();
+  const pushToast = useCodesignStore((s) => s.pushToast);
   const [fixApplied, setFixApplied] = useState(false);
 
   const ctx: DiagnoseContext = { provider, baseUrl };
@@ -60,8 +62,13 @@ export function ConnectionDiagnosticPanel({
     if (!logsPath || !window.codesign) return;
     try {
       await window.codesign.settings.openFolder(logsPath);
-    } catch {
-      // Swallow — user can navigate manually
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to open logs folder';
+      pushToast({
+        variant: 'error',
+        title: t('diagnostics.showLogFailed'),
+        description: message,
+      });
     }
   }
 

--- a/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
@@ -1,0 +1,161 @@
+import { useT } from '@open-codesign/i18n';
+import { type DiagnoseContext, type DiagnosticHypothesis, diagnose } from '@open-codesign/shared';
+import type { ErrorCode } from '@open-codesign/shared';
+import { AlertCircle, ExternalLink, FileText, RefreshCw, X } from 'lucide-react';
+import { useState } from 'react';
+
+export interface ConnectionDiagnosticPanelProps {
+  /** The error code returned by connection.test or generate */
+  errorCode: ErrorCode;
+  /** HTTP status string such as "HTTP 404", if available */
+  httpStatus?: string;
+  /** The URL that was attempted */
+  attemptedUrl?: string;
+  /** Current baseUrl value so transform can produce a suggestion */
+  baseUrl: string;
+  /** Provider ID for context */
+  provider: string;
+  /** Called when the user clicks "Apply this fix" with a baseUrl transform */
+  onApplyFix: (newBaseUrl: string) => void;
+  /** Called when the user clicks "Test again" */
+  onTestAgain: () => void;
+  /** Called when the user dismisses the panel */
+  onDismiss?: () => void;
+  /** Path to the log file — passed to shell.openPath via IPC */
+  logsPath?: string;
+}
+
+export function ConnectionDiagnosticPanel({
+  errorCode,
+  httpStatus,
+  attemptedUrl,
+  baseUrl,
+  provider,
+  onApplyFix,
+  onTestAgain,
+  onDismiss,
+  logsPath,
+}: ConnectionDiagnosticPanelProps) {
+  const t = useT();
+  const [fixApplied, setFixApplied] = useState(false);
+
+  const ctx: DiagnoseContext = { provider, baseUrl };
+  const hypotheses: DiagnosticHypothesis[] = diagnose(errorCode, ctx);
+  const primary = hypotheses[0];
+  const fix = primary?.suggestedFix;
+
+  const suggestedUrl =
+    fix?.baseUrlTransform !== undefined ? fix.baseUrlTransform(baseUrl) : undefined;
+
+  function handleApplyFix() {
+    if (suggestedUrl !== undefined) {
+      onApplyFix(suggestedUrl);
+      setFixApplied(true);
+    } else if (fix?.externalUrl !== undefined) {
+      window.open(fix.externalUrl, '_blank', 'noopener,noreferrer');
+    }
+  }
+
+  async function handleShowLog() {
+    if (!logsPath || !window.codesign) return;
+    try {
+      await window.codesign.settings.openFolder(logsPath);
+    } catch {
+      // Swallow — user can navigate manually
+    }
+  }
+
+  const displayStatus = httpStatus ?? errorCode;
+
+  return (
+    <div
+      role="alert"
+      className="rounded-[var(--radius-lg)] border border-[var(--color-error)] bg-[var(--color-error-soft,var(--color-surface))] p-4 space-y-3 text-[var(--text-sm)]"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 text-[var(--color-error)] font-semibold">
+          <AlertCircle className="w-4 h-4 shrink-0" />
+          <span>{t('diagnostics.title')}</span>
+        </div>
+        {onDismiss !== undefined && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label={t('diagnostics.dismiss')}
+            className="p-1 rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        )}
+      </div>
+
+      {/* Divider */}
+      <hr className="border-[var(--color-error)]" />
+
+      {/* Details */}
+      <div className="space-y-1.5 text-[var(--color-text-secondary)]">
+        <p>
+          <span className="font-medium text-[var(--color-text-primary)]">
+            {t('diagnostics.status', { status: displayStatus })}
+          </span>
+        </p>
+        {attemptedUrl !== undefined && (
+          <p className="font-mono text-[var(--text-xs)] text-[var(--color-text-muted)] break-all">
+            {t('diagnostics.attempted', { url: attemptedUrl })}
+          </p>
+        )}
+        {primary !== undefined && (
+          <p className="mt-2">
+            <span className="font-medium text-[var(--color-text-primary)]">
+              Most likely cause:{' '}
+            </span>
+            {t(primary.cause)}
+          </p>
+        )}
+        {suggestedUrl !== undefined && (
+          <p className="font-mono text-[var(--text-xs)] text-[var(--color-accent)] break-all">
+            {t('diagnostics.fix.addV1')}: {suggestedUrl}
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        {fix !== undefined && !fixApplied && (
+          <button
+            type="button"
+            onClick={handleApplyFix}
+            className="inline-flex items-center gap-1.5 h-7 px-3 rounded-[var(--radius-sm)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-xs)] font-medium hover:opacity-90 transition-opacity"
+          >
+            {fix.externalUrl !== undefined && <ExternalLink className="w-3 h-3" />}
+            {t(fix.label)}
+          </button>
+        )}
+        {fixApplied && (
+          <span className="text-[var(--text-xs)] text-[var(--color-success)] font-medium">
+            {t('common.applied')}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onTestAgain}
+          className="inline-flex items-center gap-1.5 h-7 px-3 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+        >
+          <RefreshCw className="w-3 h-3" />
+          {t('diagnostics.testAgain')}
+        </button>
+        {logsPath !== undefined && (
+          <button
+            type="button"
+            onClick={() => void handleShowLog()}
+            className="inline-flex items-center gap-1.5 h-7 px-3 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+          >
+            <FileText className="w-3 h-3" />
+            {t('diagnostics.showLog')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
@@ -5,6 +5,12 @@ import { AlertCircle, ExternalLink, FileText, RefreshCw, X } from 'lucide-react'
 import { useState } from 'react';
 import { useCodesignStore } from '../store';
 
+/** A baseUrlTransform suggestion (e.g. append "/v1") only makes sense when
+ * the user already has a real absolute URL — otherwise we'd write "/v1" by itself. */
+export function isAbsoluteHttpUrl(value: string): boolean {
+  return /^https?:\/\/\S+/i.test(value.trim());
+}
+
 export interface ConnectionDiagnosticPanelProps {
   /** The error code returned by connection.test or generate */
   errorCode: ErrorCode;
@@ -46,8 +52,12 @@ export function ConnectionDiagnosticPanel({
   const primary = hypotheses[0];
   const fix = primary?.suggestedFix;
 
+  const canTransformBaseUrl = isAbsoluteHttpUrl(baseUrl);
   const suggestedUrl =
-    fix?.baseUrlTransform !== undefined ? fix.baseUrlTransform(baseUrl) : undefined;
+    fix?.baseUrlTransform !== undefined && canTransformBaseUrl
+      ? fix.baseUrlTransform(baseUrl)
+      : undefined;
+  const canApplyFix = suggestedUrl !== undefined || fix?.externalUrl !== undefined;
 
   function handleApplyFix() {
     if (suggestedUrl !== undefined) {
@@ -133,7 +143,9 @@ export function ConnectionDiagnosticPanel({
           <button
             type="button"
             onClick={handleApplyFix}
-            className="inline-flex items-center gap-1.5 h-7 px-3 rounded-[var(--radius-sm)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-xs)] font-medium hover:opacity-90 transition-opacity"
+            disabled={!canApplyFix}
+            title={canApplyFix ? undefined : t('diagnostics.setBaseUrlFirst')}
+            className="inline-flex items-center gap-1.5 h-7 px-3 rounded-[var(--radius-sm)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-xs)] font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
           >
             {fix.externalUrl !== undefined && <ExternalLink className="w-3 h-3" />}
             {t(fix.label)}

--- a/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionDiagnosticPanel.tsx
@@ -115,7 +115,7 @@ export function ConnectionDiagnosticPanel({
         {primary !== undefined && (
           <p className="mt-2">
             <span className="font-medium text-[var(--color-text-primary)]">
-              Most likely cause:{' '}
+              {t('diagnostics.mostLikelyCause')}{' '}
             </span>
             {t(primary.cause)}
           </p>

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -47,6 +47,7 @@ describe('applyValidateResult', () => {
     modelFast: 'claude-haiku-3',
     validating: true,
     error: null,
+    errorCode: null,
     validated: false,
   };
 

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { i18n, setLocale as applyLocale, useT } from '@open-codesign/i18n';
+import { setLocale as applyLocale, i18n, useT } from '@open-codesign/i18n';
 import type {
   ErrorCode,
   OnboardingState,

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import { setLocale as applyLocale, useT } from '@open-codesign/i18n';
 import type {
+  ErrorCode,
   OnboardingState,
   PROVIDER_SHORTLIST,
   SupportedOnboardingProvider,
@@ -29,6 +30,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import type { AppPaths, Preferences, ProviderRow } from '../../../preload/index';
 import { useCodesignStore } from '../store';
+import { ConnectionDiagnosticPanel } from './ConnectionDiagnosticPanel';
 
 type Tab = 'models' | 'appearance' | 'storage' | 'advanced';
 
@@ -180,6 +182,7 @@ interface AddProviderFormState {
   modelFast: string;
   validating: boolean;
   error: string | null;
+  errorCode: ErrorCode | null;
   validated: boolean;
 }
 
@@ -193,6 +196,7 @@ function makeDefaultForm(provider: SupportedOnboardingProvider): AddProviderForm
     modelFast: sl.defaultFast,
     validating: false,
     error: null,
+    errorCode: null,
     validated: false,
   };
 }
@@ -219,6 +223,7 @@ export function applyValidateResult(
   snapshot: ValidateSnapshot,
   ok: boolean,
   message: string | undefined,
+  errorCode?: ErrorCode,
 ): AddProviderFormState {
   if (
     current.provider !== snapshot.provider ||
@@ -229,9 +234,14 @@ export function applyValidateResult(
     return current;
   }
   if (ok) {
-    return { ...current, validating: false, validated: true };
+    return { ...current, validating: false, validated: true, error: null, errorCode: null };
   }
-  return { ...current, validating: false, error: message ?? 'Validation failed' };
+  return {
+    ...current,
+    validating: false,
+    error: message ?? 'Validation failed',
+    errorCode: errorCode ?? null,
+  };
 }
 
 function AddProviderModal({
@@ -249,9 +259,18 @@ function AddProviderModal({
   ];
 
   const [form, setForm] = useState<AddProviderFormState>(makeDefaultForm('anthropic'));
+  const [logsFolder, setLogsFolder] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!window.codesign) return;
+    void window.codesign.settings
+      .getPaths()
+      .then((p) => setLogsFolder(p.logsFolder))
+      .catch(() => undefined);
+  }, []);
 
   function setField<K extends keyof AddProviderFormState>(k: K, v: AddProviderFormState[K]) {
-    setForm((prev) => ({ ...prev, [k]: v, error: null, validated: false }));
+    setForm((prev) => ({ ...prev, [k]: v, error: null, errorCode: null, validated: false }));
   }
 
   function handleProviderChange(p: string) {
@@ -266,7 +285,13 @@ function AddProviderModal({
       apiKey: form.apiKey.trim(),
       baseUrl: form.baseUrl.trim(),
     };
-    setForm((prev) => ({ ...prev, validating: true, error: null, validated: false }));
+    setForm((prev) => ({
+      ...prev,
+      validating: true,
+      error: null,
+      errorCode: null,
+      validated: false,
+    }));
     try {
       const res = await window.codesign.settings.validateKey({
         provider: snapshot.provider,
@@ -274,7 +299,13 @@ function AddProviderModal({
         ...(snapshot.baseUrl.length > 0 ? { baseUrl: snapshot.baseUrl } : {}),
       });
       setForm((current) =>
-        applyValidateResult(current, snapshot, res.ok, res.ok ? undefined : res.message),
+        applyValidateResult(
+          current,
+          snapshot,
+          res.ok,
+          res.ok ? undefined : res.message,
+          res.ok ? undefined : res.code,
+        ),
       );
     } finally {
       setForm((current) => (current.validating ? { ...current, validating: false } : current));
@@ -397,9 +428,30 @@ function AddProviderModal({
                 </button>
               </Tooltip>
             </div>
-            {form.error && (
+            {form.error && form.errorCode !== null ? (
+              <div className="mt-2">
+                <ConnectionDiagnosticPanel
+                  errorCode={form.errorCode}
+                  httpStatus={form.error}
+                  baseUrl={form.baseUrl}
+                  provider={form.provider}
+                  {...(logsFolder !== undefined ? { logsPath: logsFolder } : {})}
+                  onApplyFix={(newUrl) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      baseUrl: newUrl,
+                      error: null,
+                      errorCode: null,
+                      validated: false,
+                    }))
+                  }
+                  onTestAgain={() => void handleValidate()}
+                  onDismiss={() => setForm((prev) => ({ ...prev, error: null, errorCode: null }))}
+                />
+              </div>
+            ) : form.error !== null ? (
               <p className="mt-1.5 text-[var(--text-xs)] text-[var(--color-error)]">{form.error}</p>
-            )}
+            ) : null}
           </div>
 
           <div>

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { setLocale as applyLocale, useT } from '@open-codesign/i18n';
+import { i18n, setLocale as applyLocale, useT } from '@open-codesign/i18n';
 import type {
   ErrorCode,
   OnboardingState,
@@ -260,14 +260,21 @@ function AddProviderModal({
 
   const [form, setForm] = useState<AddProviderFormState>(makeDefaultForm('anthropic'));
   const [logsFolder, setLogsFolder] = useState<string | undefined>(undefined);
+  const pushToast = useCodesignStore((s) => s.pushToast);
 
   useEffect(() => {
     if (!window.codesign) return;
     void window.codesign.settings
       .getPaths()
       .then((p) => setLogsFolder(p.logsFolder))
-      .catch(() => undefined);
-  }, []);
+      .catch((err: unknown) => {
+        pushToast({
+          variant: 'error',
+          title: i18n.t('settings.storage.pathsLoadFailed') as string,
+          description: err instanceof Error ? err.message : String(err),
+        });
+      });
+  }, [pushToast]);
 
   function setField<K extends keyof AddProviderFormState>(k: K, v: AddProviderFormState[K]) {
     setForm((prev) => ({ ...prev, [k]: v, error: null, errorCode: null, validated: false }));

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -485,6 +485,36 @@
       "loadFailed": "Could not load your designs"
     }
   },
+  "diagnostics": {
+    "title": "Connection failed",
+    "status": "Status: {{status}}",
+    "attempted": "What we tried: {{url}}",
+    "cause": {
+      "keyInvalid": "API key invalid or revoked.",
+      "balanceEmpty": "Account balance is empty.",
+      "missingV1": "Base URL path is likely missing the /v1 suffix.",
+      "rateLimit": "Rate limit exceeded.",
+      "hostUnreachable": "Cannot reach host — check domain, port, or VPN.",
+      "timedOut": "Request timed out — check firewall or VPN.",
+      "corsError": "CORS error (should not happen in main process). This is a bug.",
+      "sslError": "SSL / certificate error (self-signed cert on relay?).",
+      "unknown": "Unknown error — check the full log for details."
+    },
+    "fix": {
+      "updateKey": "Update key",
+      "addCredits": "Add credits →",
+      "addV1": "Add /v1",
+      "waitAndRetry": "Wait and retry",
+      "checkNetwork": "Check network / VPN",
+      "checkVpn": "Check VPN / firewall",
+      "reportBug": "Report this bug",
+      "disableTls": "Disable TLS verify"
+    },
+    "applyFix": "Apply this fix",
+    "testAgain": "Test again",
+    "showLog": "Show full log",
+    "dismiss": "Dismiss"
+  },
   "demos": {
     "meditationApp": {
       "title": "Calm Spaces meditation app",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -489,6 +489,7 @@
     "title": "Connection failed",
     "status": "Status: {{status}}",
     "attempted": "What we tried: {{url}}",
+    "mostLikelyCause": "Most likely cause:",
     "cause": {
       "keyInvalid": "API key invalid or revoked.",
       "balanceEmpty": "Account balance is empty.",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -503,6 +503,7 @@
     "fix": {
       "updateKey": "Update key",
       "addCredits": "Add credits →",
+      "addCreditsGeneric": "Check your provider's billing page",
       "addV1": "Add /v1",
       "waitAndRetry": "Wait and retry",
       "checkNetwork": "Check network / VPN",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -513,6 +513,7 @@
       "disableTls": "Disable TLS verify"
     },
     "applyFix": "Apply this fix",
+    "setBaseUrlFirst": "Set a Base URL first",
     "testAgain": "Test again",
     "showLog": "Show full log",
     "showLogFailed": "Failed to open logs folder",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -513,6 +513,7 @@
     "applyFix": "Apply this fix",
     "testAgain": "Test again",
     "showLog": "Show full log",
+    "showLogFailed": "Failed to open logs folder",
     "dismiss": "Dismiss"
   },
   "demos": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -508,6 +508,7 @@
       "disableTls": "禁用 TLS 验证"
     },
     "applyFix": "应用此修复",
+    "setBaseUrlFirst": "请先填写 Base URL",
     "testAgain": "再次测试",
     "showLog": "查看完整日志",
     "showLogFailed": "无法打开日志文件夹",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -498,6 +498,7 @@
     "fix": {
       "updateKey": "更新 Key",
       "addCredits": "充值 →",
+      "addCreditsGeneric": "请前往你的 Provider 充值页面",
       "addV1": "添加 /v1",
       "waitAndRetry": "等待后重试",
       "checkNetwork": "检查网络 / VPN",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -508,6 +508,7 @@
     "applyFix": "应用此修复",
     "testAgain": "再次测试",
     "showLog": "查看完整日志",
+    "showLogFailed": "无法打开日志文件夹",
     "dismiss": "关闭"
   },
   "demos": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -480,6 +480,36 @@
       "loadFailed": "无法加载设计列表"
     }
   },
+  "diagnostics": {
+    "title": "连接失败",
+    "status": "状态：{{status}}",
+    "attempted": "我们尝试了：{{url}}",
+    "cause": {
+      "keyInvalid": "API Key 无效或已被撤销。",
+      "balanceEmpty": "账户余额不足。",
+      "missingV1": "Base URL 路径可能缺少 /v1 后缀。",
+      "rateLimit": "请求被限流，超过了速率限制。",
+      "hostUnreachable": "无法连接到主机——检查域名、端口或 VPN。",
+      "timedOut": "请求超时——检查防火墙或 VPN。",
+      "corsError": "CORS 跨域错误（主进程中不应出现此错误，这是一个 Bug）。",
+      "sslError": "SSL / 证书错误（中转服务使用了自签证书？）。",
+      "unknown": "未知错误——请查看完整日志以获取详情。"
+    },
+    "fix": {
+      "updateKey": "更新 Key",
+      "addCredits": "充值 →",
+      "addV1": "添加 /v1",
+      "waitAndRetry": "等待后重试",
+      "checkNetwork": "检查网络 / VPN",
+      "checkVpn": "检查 VPN / 防火墙",
+      "reportBug": "报告此 Bug",
+      "disableTls": "禁用 TLS 验证"
+    },
+    "applyFix": "应用此修复",
+    "testAgain": "再次测试",
+    "showLog": "查看完整日志",
+    "dismiss": "关闭"
+  },
   "demos": {
     "meditationApp": {
       "title": "Calm Spaces 冥想 App",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -484,6 +484,7 @@
     "title": "连接失败",
     "status": "状态：{{status}}",
     "attempted": "我们尝试了：{{url}}",
+    "mostLikelyCause": "最可能的原因：",
     "cause": {
       "keyInvalid": "API Key 无效或已被撤销。",
       "balanceEmpty": "账户余额不足。",

--- a/packages/shared/src/diagnostics.test.ts
+++ b/packages/shared/src/diagnostics.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { diagnose } from './diagnostics';
+
+const baseCtx = {
+  provider: 'openai',
+  baseUrl: 'https://api.example.com',
+};
+
+describe('diagnose', () => {
+  it('maps 401 to keyInvalid hypothesis with updateKey fix', () => {
+    const result = diagnose('401', baseCtx);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.cause).toBe('diagnostics.cause.keyInvalid');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.updateKey');
+  });
+
+  it('maps 403 to keyInvalid hypothesis (same as 401)', () => {
+    const result = diagnose('403', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.keyInvalid');
+  });
+
+  it('maps 402 to balanceEmpty with addCredits fix', () => {
+    const result = diagnose('402', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.balanceEmpty');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.addCredits');
+    expect(result[0]?.suggestedFix?.externalUrl).toBeDefined();
+  });
+
+  it('maps 404 to missingV1 with a baseUrl transform', () => {
+    const result = diagnose('404', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.missingV1');
+    const fix = result[0]?.suggestedFix;
+    expect(fix?.baseUrlTransform).toBeDefined();
+    expect(fix?.baseUrlTransform?.('https://api.example.com')).toBe('https://api.example.com/v1');
+  });
+
+  it('404 transform is idempotent when /v1 already present', () => {
+    const result = diagnose('404', { ...baseCtx, baseUrl: 'https://api.example.com/v1' });
+    const transform = result[0]?.suggestedFix?.baseUrlTransform;
+    expect(transform?.('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+  });
+
+  it('maps 429 to rateLimit with waitAndRetry fix', () => {
+    const result = diagnose('429', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.rateLimit');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.waitAndRetry');
+  });
+
+  it('maps ECONNREFUSED to hostUnreachable', () => {
+    const result = diagnose('ECONNREFUSED', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.hostUnreachable');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.checkNetwork');
+  });
+
+  it('maps ETIMEDOUT to timedOut', () => {
+    const result = diagnose('ETIMEDOUT', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.timedOut');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.checkVpn');
+  });
+
+  it('maps CORS to corsError with reportBug fix', () => {
+    const result = diagnose('CORS', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.corsError');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.reportBug');
+  });
+
+  it('maps SSL to sslError with disableTls fix', () => {
+    const result = diagnose('SSL', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.sslError');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.disableTls');
+  });
+
+  it('maps unknown codes to generic unknown cause', () => {
+    const result = diagnose('SOME_UNKNOWN_CODE', baseCtx);
+    expect(result[0]?.cause).toBe('diagnostics.cause.unknown');
+    expect(result[0]?.suggestedFix).toBeUndefined();
+  });
+
+  it('all hypothesis objects have at least a cause string', () => {
+    const codes = ['401', '402', '403', '404', '429', 'ECONNREFUSED', 'ETIMEDOUT', 'NETWORK'];
+    for (const code of codes) {
+      const results = diagnose(code, baseCtx);
+      expect(results.length).toBeGreaterThan(0);
+      for (const h of results) {
+        expect(typeof h.cause).toBe('string');
+        expect(h.cause.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/shared/src/diagnostics.test.ts
+++ b/packages/shared/src/diagnostics.test.ts
@@ -23,7 +23,27 @@ describe('diagnose', () => {
     const result = diagnose('402', baseCtx);
     expect(result[0]?.cause).toBe('diagnostics.cause.balanceEmpty');
     expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.addCredits');
-    expect(result[0]?.suggestedFix?.externalUrl).toBeDefined();
+    expect(result[0]?.suggestedFix?.externalUrl).toBe(
+      'https://platform.openai.com/settings/organization/billing',
+    );
+  });
+
+  it('402 returns provider-specific billing URL for anthropic', () => {
+    const result = diagnose('402', { ...baseCtx, provider: 'anthropic' });
+    expect(result[0]?.suggestedFix?.externalUrl).toBe(
+      'https://console.anthropic.com/settings/billing',
+    );
+  });
+
+  it('402 returns provider-specific billing URL for openrouter', () => {
+    const result = diagnose('402', { ...baseCtx, provider: 'openrouter' });
+    expect(result[0]?.suggestedFix?.externalUrl).toBe('https://openrouter.ai/settings/credits');
+  });
+
+  it('402 returns generic message (no URL) for unknown provider', () => {
+    const result = diagnose('402', { ...baseCtx, provider: 'mystery-provider' });
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.addCreditsGeneric');
+    expect(result[0]?.suggestedFix?.externalUrl).toBeUndefined();
   });
 
   it('maps 404 to missingV1 with a baseUrl transform', () => {

--- a/packages/shared/src/diagnostics.ts
+++ b/packages/shared/src/diagnostics.ts
@@ -38,6 +38,18 @@ export interface DiagnoseContext {
   attemptedUrl?: string;
 }
 
+const BILLING_URLS: Record<string, string> = {
+  openai: 'https://platform.openai.com/settings/organization/billing',
+  anthropic: 'https://console.anthropic.com/settings/billing',
+  openrouter: 'https://openrouter.ai/settings/credits',
+  google: 'https://aistudio.google.com/app/apikey',
+  deepseek: 'https://platform.deepseek.com/usage',
+};
+
+function billingUrlFor(provider: string): string | undefined {
+  return BILLING_URLS[provider.toLowerCase()];
+}
+
 /**
  * Map an ErrorCode + context to one or more DiagnosticHypothesis items.
  * The first item is the "most likely" cause; subsequent items are alternatives.
@@ -56,12 +68,13 @@ export function diagnose(code: ErrorCode, ctx: DiagnoseContext): DiagnosticHypot
   }
 
   if (normalised === '402') {
+    const externalUrl = billingUrlFor(ctx.provider);
     return [
       {
         cause: 'diagnostics.cause.balanceEmpty',
         suggestedFix: {
-          label: 'diagnostics.fix.addCredits',
-          externalUrl: 'https://platform.openai.com/settings/organization/billing',
+          label: externalUrl ? 'diagnostics.fix.addCredits' : 'diagnostics.fix.addCreditsGeneric',
+          ...(externalUrl ? { externalUrl } : {}),
         },
       },
     ];

--- a/packages/shared/src/diagnostics.ts
+++ b/packages/shared/src/diagnostics.ts
@@ -1,0 +1,135 @@
+export type ErrorCode =
+  | '401'
+  | '402'
+  | '403'
+  | '404'
+  | '429'
+  | 'ECONNREFUSED'
+  | 'ETIMEDOUT'
+  | 'NETWORK'
+  | 'CORS'
+  | 'SSL'
+  | 'PARSE'
+  | 'IPC_BAD_INPUT'
+  | string;
+
+export interface DiagnosticFix {
+  /** i18n key for the button label */
+  label: string;
+  /** When present, clicking "Apply fix" calls this to derive a new baseUrl */
+  baseUrlTransform?: (current: string) => string;
+  /** When present, open this URL in the browser instead of mutating baseUrl */
+  externalUrl?: string;
+}
+
+export interface DiagnosticHypothesis {
+  /** i18n key for the displayed cause sentence */
+  cause: string;
+  /** Primary action the user should take */
+  suggestedFix?: DiagnosticFix;
+}
+
+export interface DiagnoseContext {
+  provider: string;
+  baseUrl: string;
+  /** HTTP status code if the error came from an HTTP response */
+  status?: number;
+  /** Raw attempted URL, if available */
+  attemptedUrl?: string;
+}
+
+/**
+ * Map an ErrorCode + context to one or more DiagnosticHypothesis items.
+ * The first item is the "most likely" cause; subsequent items are alternatives.
+ */
+export function diagnose(code: ErrorCode, ctx: DiagnoseContext): DiagnosticHypothesis[] {
+  // Normalise the code — some callers pass the HTTP status as a string like "404"
+  const normalised = String(code).toUpperCase();
+
+  if (normalised === '401' || normalised === '403') {
+    return [
+      {
+        cause: 'diagnostics.cause.keyInvalid',
+        suggestedFix: { label: 'diagnostics.fix.updateKey' },
+      },
+    ];
+  }
+
+  if (normalised === '402') {
+    return [
+      {
+        cause: 'diagnostics.cause.balanceEmpty',
+        suggestedFix: {
+          label: 'diagnostics.fix.addCredits',
+          externalUrl: 'https://platform.openai.com/settings/organization/billing',
+        },
+      },
+    ];
+  }
+
+  if (normalised === '404') {
+    return [
+      {
+        cause: 'diagnostics.cause.missingV1',
+        suggestedFix: {
+          label: 'diagnostics.fix.addV1',
+          baseUrlTransform: (cur: string) => {
+            const cleaned = cur.replace(/\/+$/, '');
+            return cleaned.endsWith('/v1') ? cleaned : `${cleaned}/v1`;
+          },
+        },
+      },
+    ];
+  }
+
+  if (normalised === '429') {
+    return [
+      {
+        cause: 'diagnostics.cause.rateLimit',
+        suggestedFix: { label: 'diagnostics.fix.waitAndRetry' },
+      },
+    ];
+  }
+
+  if (normalised === 'ECONNREFUSED' || normalised === 'ENOTFOUND') {
+    return [
+      {
+        cause: 'diagnostics.cause.hostUnreachable',
+        suggestedFix: { label: 'diagnostics.fix.checkNetwork' },
+      },
+    ];
+  }
+
+  if (normalised === 'ETIMEDOUT') {
+    return [
+      {
+        cause: 'diagnostics.cause.timedOut',
+        suggestedFix: { label: 'diagnostics.fix.checkVpn' },
+      },
+    ];
+  }
+
+  if (normalised === 'CORS') {
+    return [
+      {
+        cause: 'diagnostics.cause.corsError',
+        suggestedFix: { label: 'diagnostics.fix.reportBug' },
+      },
+    ];
+  }
+
+  if (normalised === 'SSL') {
+    return [
+      {
+        cause: 'diagnostics.cause.sslError',
+        suggestedFix: { label: 'diagnostics.fix.disableTls' },
+      },
+    ];
+  }
+
+  return [
+    {
+      cause: 'diagnostics.cause.unknown',
+    },
+  ];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -241,3 +241,11 @@ export type { Design, DesignMessage, DesignSnapshot, SnapshotCreateInput } from 
 
 export { SkillFrontmatterV1 } from './skills';
 export type { LoadedSkill } from './skills';
+
+export { diagnose } from './diagnostics';
+export type {
+  DiagnosticHypothesis,
+  DiagnosticFix,
+  DiagnoseContext,
+  ErrorCode,
+} from './diagnostics';


### PR DESCRIPTION
## Summary

- Implements §8.2 of the UX master plan (`docs/research/18-ux-master-plan.md`): replaces the single-line error hint with a structured diagnostic panel embedded below the provider form.
- `packages/shared/src/diagnostics.ts`: pure `diagnose(code, ctx)` function maps error codes (401/403, 402, 404, 429, ECONNREFUSED, ETIMEDOUT, CORS, SSL) to `DiagnosticHypothesis` objects with i18n-keyed cause strings and optional fix descriptors (`baseUrlTransform` or `externalUrl`).
- `ConnectionDiagnosticPanel.tsx`: self-contained React component showing status, attempted URL, most-likely cause, suggested URL, and three action buttons — **Apply this fix** (runs `baseUrlTransform`, re-fills `baseUrl`), **Test again** (re-triggers validation), **Show full log** (opens logs folder via existing `settings:v1:open-folder` IPC).
- `Settings.tsx`: `AddProviderFormState` gains `errorCode: ErrorCode | null`; `applyValidateResult` accepts an optional `errorCode` arg; validation result now stores the code so the panel can render.
- i18n en + zh-CN: ~10 new keys under `diagnostics.*` namespace.
- 12 new unit tests in `diagnostics.test.ts` covering all mapped codes.

## Checklist (§7 PRINCIPLES)

- **Compatibility** ✅ — no API changes, new field is additive
- **Upgradeability** ✅ — no disk schema touched
- **No bloat** ✅ — zero new deps; `diagnose` is a pure function
- **Elegance** ✅ — panel reusable; error → hypothesis mapping is a plain lookup

## Test plan

- [ ] Run `pnpm test` — all 85 desktop + 27 shared tests pass
- [ ] Run `pnpm typecheck` — no errors
- [ ] Run `pnpm lint` — 0 errors (8 pre-existing warnings unchanged)
- [ ] In-app: add provider with a wrong key → validate → error panel shows with "Update key" CTA
- [ ] In-app: add provider with a baseUrl missing /v1 → validate → panel shows "Add /v1" → click → baseUrl field updates → test again succeeds
- [ ] "Show full log" button opens the logs folder in Finder/Explorer