### PR TITLE
refactor(desktop): unify validate+test into single ConnectionCheck

### DIFF
--- a/apps/desktop/src/main/onboarding-ipc.test.ts
+++ b/apps/desktop/src/main/onboarding-ipc.test.ts
@@ -11,10 +11,14 @@ import { describe, expect, it, vi } from 'vitest';
 // Collect registered channel names via a mock ipcMain.
 const registeredChannels: string[] = [];
 
+// Track handler implementations so we can call them directly.
+const handlers = new Map<string, (...args: unknown[]) => unknown>();
+
 vi.mock('./electron-runtime', () => ({
   ipcMain: {
-    handle: (channel: string) => {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
       registeredChannels.push(channel);
+      handlers.set(channel, fn);
     },
   },
   shell: { openPath: vi.fn() },
@@ -107,5 +111,36 @@ describe('registerOnboardingIpc — channel versioning', () => {
     for (const ch of legacyChannels) {
       expect(registeredChannels).toContain(ch);
     }
+  });
+});
+
+describe('registerOnboardingIpc — validate-key passes baseUrl to pingProvider', () => {
+  it('forwards baseUrl to pingProvider when provided', async () => {
+    const { pingProvider } = await import('@open-codesign/providers');
+    const handler = handlers.get('onboarding:validate-key');
+    expect(handler).toBeDefined();
+
+    await handler?.({} as unknown, {
+      provider: 'openai',
+      apiKey: 'sk-test',
+      baseUrl: 'https://custom.proxy.example/v1',
+    });
+
+    expect(pingProvider).toHaveBeenCalledWith(
+      'openai',
+      'sk-test',
+      'https://custom.proxy.example/v1',
+    );
+  });
+
+  it('calls pingProvider without baseUrl when not provided', async () => {
+    const { pingProvider } = await import('@open-codesign/providers');
+    vi.mocked(pingProvider).mockClear();
+    const handler = handlers.get('onboarding:validate-key');
+    expect(handler).toBeDefined();
+
+    await handler?.({} as unknown, { provider: 'anthropic', apiKey: 'sk-ant-test' });
+
+    expect(pingProvider).toHaveBeenCalledWith('anthropic', 'sk-ant-test', undefined);
   });
 });

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { classifyDetectError, detectProvider } from './PasteKey';
 
 // ---------------------------------------------------------------------------
 // Unit tests for the unified ConnectionCheck logic in PasteKey.
@@ -176,5 +177,101 @@ describe('handleTest — unified ConnectionCheck', () => {
     expect(checkContinueEnabled({ status: 'testing' })).toBe(false);
     expect(checkContinueEnabled({ status: 'failed', code: 'NETWORK', hint: '' })).toBe(false);
     expect(checkContinueEnabled({ status: 'ok' })).toBe(true);
+  });
+});
+
+describe('detectProvider — discriminated failure kinds', () => {
+  it('returns ok with provider when bridge resolves a known prefix', async () => {
+    const bridge = { detectProvider: vi.fn().mockResolvedValue('openai') };
+    const result = await detectProvider('sk-test', bridge);
+    expect(result).toEqual({ ok: true, provider: 'openai' });
+  });
+
+  it('returns unknown_prefix when bridge resolves null', async () => {
+    const bridge = { detectProvider: vi.fn().mockResolvedValue(null) };
+    const result = await detectProvider('garbage-key', bridge);
+    expect(result).toEqual({ ok: false, kind: 'unknown_prefix' });
+  });
+
+  it('returns unknown_prefix when bridge resolves an unsupported provider string', async () => {
+    const bridge = { detectProvider: vi.fn().mockResolvedValue('made-up-provider') };
+    const result = await detectProvider('sk-x', bridge);
+    expect(result).toEqual({ ok: false, kind: 'unknown_prefix' });
+  });
+
+  it('returns ipc_error when bridge is undefined (renderer not connected)', async () => {
+    const result = await detectProvider('sk-test', undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('ipc_error');
+      if (result.kind === 'ipc_error') {
+        expect(result.message).toContain('not connected');
+      }
+    }
+  });
+
+  it('returns ipc_error when bridge rejects with a non-network Error', async () => {
+    const bridge = {
+      detectProvider: vi.fn().mockRejectedValue(new Error('preload bridge crashed')),
+    };
+    const result = await detectProvider('sk-test', bridge);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('ipc_error');
+      if (result.kind === 'ipc_error') {
+        expect(result.message).toBe('preload bridge crashed');
+      }
+    }
+  });
+
+  it('returns network_error when bridge rejects with a TypeError (fetch failure)', async () => {
+    const bridge = {
+      detectProvider: vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    };
+    const result = await detectProvider('sk-test', bridge);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('network_error');
+    }
+  });
+
+  it('returns network_error when error message contains a network token', async () => {
+    const bridge = {
+      detectProvider: vi.fn().mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:443')),
+    };
+    const result = await detectProvider('sk-test', bridge);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.kind).toBe('network_error');
+    }
+  });
+
+  it('never collapses an IPC failure into unknown_prefix', async () => {
+    const bridge = { detectProvider: vi.fn().mockRejectedValue(new Error('boom')) };
+    const result = await detectProvider('sk-test', bridge);
+    if (!result.ok) {
+      expect(result.kind).not.toBe('unknown_prefix');
+    }
+  });
+});
+
+describe('classifyDetectError', () => {
+  it('classifies TypeError as network_error', () => {
+    expect(classifyDetectError(new TypeError('Failed to fetch'))).toBe('network_error');
+  });
+
+  it('classifies fetch/network/ECONN/ENOTFOUND/ETIMEDOUT/EAI_AGAIN messages as network_error', () => {
+    for (const token of ['fetch', 'network', 'ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN']) {
+      expect(classifyDetectError(new Error(`some ${token} happened`))).toBe('network_error');
+    }
+  });
+
+  it('classifies plain Error as ipc_error', () => {
+    expect(classifyDetectError(new Error('preload missing'))).toBe('ipc_error');
+  });
+
+  it('classifies non-Error throwables as ipc_error', () => {
+    expect(classifyDetectError('weird string')).toBe('ipc_error');
+    expect(classifyDetectError(null)).toBe('ipc_error');
   });
 });

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
@@ -1,130 +1,180 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
-// Unit tests for PasteKey connection guard logic
+// Unit tests for the unified ConnectionCheck logic in PasteKey.
 //
-// PasteKey cannot be imported directly because it depends on React and
-// Electron-specific globals. Instead we inline the guard logic and test it
-// in isolation, mirroring the pattern used in connection-ipc.test.ts.
+// The component no longer has a separate ValidationState — the Test button is
+// the single authority for both key validity and endpoint reachability.
+// These tests mirror the handleTest guard logic extracted from PasteKey.tsx.
 // ---------------------------------------------------------------------------
 
-type ConnectionState =
-  | { kind: 'idle' }
-  | { kind: 'testing' }
-  | { kind: 'ok' }
-  | { kind: 'error'; code: string; hint: string };
+type ConnectionCheck =
+  | { status: 'idle' }
+  | { status: 'testing' }
+  | { status: 'ok' }
+  | { status: 'failed'; code: string; hint: string };
 
-// Mirrors handleConnectionTest from PasteKey.tsx
-async function handleConnectionTest(
+// Default base URLs — mirrors defaultBaseUrl() in PasteKey.tsx and
+// buildDefaultBaseUrl() in connection-ipc.ts. They must stay in sync.
+function defaultBaseUrl(provider: 'anthropic' | 'openai' | 'openrouter'): string {
+  switch (provider) {
+    case 'anthropic':
+      return 'https://api.anthropic.com';
+    case 'openai':
+      return 'https://api.openai.com/v1';
+    case 'openrouter':
+      return 'https://openrouter.ai/api/v1';
+  }
+}
+
+// Mirrors handleTest from PasteKey.tsx
+async function handleTest(
   provider: string | null,
   trimmed: string,
   trimmedBaseUrl: string,
-  connectionBridge: { test: (payload: unknown) => Promise<{ ok: boolean }> } | undefined,
-  setConnState: (s: ConnectionState) => void,
+  connectionBridge:
+    | { test: (payload: unknown) => Promise<{ ok: boolean; code?: string; hint?: string }> }
+    | undefined,
+  setConnCheck: (s: ConnectionCheck) => void,
 ): Promise<void> {
-  if (!provider || trimmed.length === 0 || trimmedBaseUrl.length === 0) return;
+  if (!provider || trimmed.length === 0) return;
+  const baseUrlForTest =
+    trimmedBaseUrl.length > 0
+      ? trimmedBaseUrl
+      : defaultBaseUrl(provider as 'anthropic' | 'openai' | 'openrouter');
+  if (baseUrlForTest.length === 0) return;
+
   if (!connectionBridge) {
-    setConnState({
-      kind: 'error',
+    setConnCheck({
+      status: 'failed',
       code: 'NETWORK',
       hint: 'Renderer is not connected to the main process.',
     });
     return;
   }
-  setConnState({ kind: 'testing' });
+
+  setConnCheck({ status: 'testing' });
   try {
     const result = await connectionBridge.test({
       provider,
       apiKey: trimmed,
-      baseUrl: trimmedBaseUrl,
+      baseUrl: baseUrlForTest,
     });
     if (result.ok) {
-      setConnState({ kind: 'ok' });
+      setConnCheck({ status: 'ok' });
     } else {
-      setConnState({ kind: 'error', code: 'NETWORK', hint: 'Connection test failed.' });
+      setConnCheck({
+        status: 'failed',
+        code: result.code ?? 'NETWORK',
+        hint: result.hint ?? 'Connection test failed.',
+      });
     }
   } catch (err) {
-    setConnState({
-      kind: 'error',
+    setConnCheck({
+      status: 'failed',
       code: 'NETWORK',
       hint: err instanceof Error ? err.message : 'Connection test failed.',
     });
   }
 }
 
-describe('handleConnectionTest — connection bridge guard', () => {
-  it('sets NETWORK error when connection bridge is undefined (bridge not yet injected)', async () => {
-    const setConnState = vi.fn();
-    await handleConnectionTest(
-      'openai',
-      'sk-test',
-      'https://api.openai.com/v1',
-      undefined,
-      setConnState,
-    );
-    expect(setConnState).toHaveBeenCalledOnce();
-    const firstArg = setConnState.mock.calls[0]?.[0] as ConnectionState | undefined;
-    expect(firstArg?.kind).toBe('error');
-    if (firstArg?.kind === 'error') {
-      expect(firstArg.code).toBe('NETWORK');
-      expect(firstArg.hint).toContain('not connected');
+describe('handleTest — unified ConnectionCheck', () => {
+  it('sets failed when connection bridge is undefined', async () => {
+    const setConnCheck = vi.fn();
+    await handleTest('openai', 'sk-test', 'https://api.openai.com/v1', undefined, setConnCheck);
+    expect(setConnCheck).toHaveBeenCalledOnce();
+    const arg = setConnCheck.mock.calls[0]?.[0] as ConnectionCheck;
+    expect(arg.status).toBe('failed');
+    if (arg.status === 'failed') {
+      expect(arg.code).toBe('NETWORK');
+      expect(arg.hint).toContain('not connected');
     }
   });
 
-  it('does not call setConnState when provider is null', async () => {
-    const setConnState = vi.fn();
-    await handleConnectionTest(
-      null,
-      'sk-test',
-      'https://api.openai.com/v1',
-      undefined,
-      setConnState,
-    );
-    expect(setConnState).not.toHaveBeenCalled();
+  it('does not call setConnCheck when provider is null', async () => {
+    const setConnCheck = vi.fn();
+    await handleTest(null, 'sk-test', 'https://api.openai.com/v1', undefined, setConnCheck);
+    expect(setConnCheck).not.toHaveBeenCalled();
   });
 
-  it('does not call setConnState when trimmed apiKey is empty', async () => {
-    const setConnState = vi.fn();
-    await handleConnectionTest('openai', '', 'https://api.openai.com/v1', undefined, setConnState);
-    expect(setConnState).not.toHaveBeenCalled();
+  it('does not call setConnCheck when trimmed apiKey is empty', async () => {
+    const setConnCheck = vi.fn();
+    await handleTest('openai', '', 'https://api.openai.com/v1', undefined, setConnCheck);
+    expect(setConnCheck).not.toHaveBeenCalled();
   });
 
-  it('does not call setConnState when baseUrl is empty', async () => {
-    const setConnState = vi.fn();
-    await handleConnectionTest('openai', 'sk-test', '', undefined, setConnState);
-    expect(setConnState).not.toHaveBeenCalled();
-  });
-
-  it('proceeds to testing state when bridge is available', async () => {
-    const setConnState = vi.fn();
+  it('falls back to official default baseUrl when trimmedBaseUrl is empty', async () => {
+    const setConnCheck = vi.fn();
     const bridge = { test: vi.fn().mockResolvedValue({ ok: true }) };
-    await handleConnectionTest(
-      'openai',
-      'sk-test',
-      'https://api.openai.com/v1',
-      bridge,
-      setConnState,
-    );
-    expect(setConnState).toHaveBeenCalledTimes(2);
-    expect(setConnState.mock.calls[0]?.[0]).toEqual({ kind: 'testing' });
-    expect(setConnState.mock.calls[1]?.[0]).toEqual({ kind: 'ok' });
+    await handleTest('openai', 'sk-test', '', bridge, setConnCheck);
+    expect(bridge.test).toHaveBeenCalledWith({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.com/v1',
+    });
+    expect(setConnCheck).toHaveBeenLastCalledWith({ status: 'ok' });
   });
 
-  it('sets NETWORK error when bridge.test throws', async () => {
-    const setConnState = vi.fn();
-    const bridge = { test: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) };
-    await handleConnectionTest(
-      'openai',
-      'sk-test',
-      'https://api.openai.com/v1',
-      bridge,
-      setConnState,
-    );
-    const lastArg = setConnState.mock.calls.at(-1)?.[0] as ConnectionState | undefined;
-    expect(lastArg?.kind).toBe('error');
-    if (lastArg?.kind === 'error') {
-      expect(lastArg.code).toBe('NETWORK');
-      expect(lastArg.hint).toContain('ECONNREFUSED');
+  it('uses anthropic default baseUrl when trimmedBaseUrl is empty', async () => {
+    const setConnCheck = vi.fn();
+    const bridge = { test: vi.fn().mockResolvedValue({ ok: true }) };
+    await handleTest('anthropic', 'sk-ant-test', '', bridge, setConnCheck);
+    expect(bridge.test).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-test',
+      baseUrl: 'https://api.anthropic.com',
+    });
+  });
+
+  it('uses user-supplied baseUrl when provided', async () => {
+    const setConnCheck = vi.fn();
+    const bridge = { test: vi.fn().mockResolvedValue({ ok: true }) };
+    await handleTest('openai', 'sk-test', 'https://my-proxy.example.com/v1', bridge, setConnCheck);
+    expect(bridge.test).toHaveBeenCalledWith({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      baseUrl: 'https://my-proxy.example.com/v1',
+    });
+  });
+
+  it('transitions testing → ok on success', async () => {
+    const setConnCheck = vi.fn();
+    const bridge = { test: vi.fn().mockResolvedValue({ ok: true }) };
+    await handleTest('openai', 'sk-test', 'https://api.openai.com/v1', bridge, setConnCheck);
+    expect(setConnCheck).toHaveBeenCalledTimes(2);
+    expect(setConnCheck.mock.calls[0]?.[0]).toEqual({ status: 'testing' });
+    expect(setConnCheck.mock.calls[1]?.[0]).toEqual({ status: 'ok' });
+  });
+
+  it('transitions testing → failed on 401 response', async () => {
+    const setConnCheck = vi.fn();
+    const bridge = {
+      test: vi.fn().mockResolvedValue({ ok: false, code: '401', hint: 'API key invalid' }),
+    };
+    await handleTest('openai', 'sk-test', 'https://api.openai.com/v1', bridge, setConnCheck);
+    const last = setConnCheck.mock.calls.at(-1)?.[0] as ConnectionCheck;
+    expect(last.status).toBe('failed');
+    if (last.status === 'failed') {
+      expect(last.code).toBe('401');
     }
+  });
+
+  it('sets failed when bridge.test throws', async () => {
+    const setConnCheck = vi.fn();
+    const bridge = { test: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) };
+    await handleTest('openai', 'sk-test', 'https://api.openai.com/v1', bridge, setConnCheck);
+    const last = setConnCheck.mock.calls.at(-1)?.[0] as ConnectionCheck;
+    expect(last.status).toBe('failed');
+    if (last.status === 'failed') {
+      expect(last.hint).toContain('ECONNREFUSED');
+    }
+  });
+
+  it('Continue is gated: only enabled when status is ok', () => {
+    const checkContinueEnabled = (s: ConnectionCheck) => s.status === 'ok';
+    expect(checkContinueEnabled({ status: 'idle' })).toBe(false);
+    expect(checkContinueEnabled({ status: 'testing' })).toBe(false);
+    expect(checkContinueEnabled({ status: 'failed', code: 'NETWORK', hint: '' })).toBe(false);
+    expect(checkContinueEnabled({ status: 'ok' })).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.test.ts
@@ -261,7 +261,14 @@ describe('classifyDetectError', () => {
   });
 
   it('classifies fetch/network/ECONN/ENOTFOUND/ETIMEDOUT/EAI_AGAIN messages as network_error', () => {
-    for (const token of ['fetch', 'network', 'ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EAI_AGAIN']) {
+    for (const token of [
+      'fetch',
+      'network',
+      'ECONNREFUSED',
+      'ENOTFOUND',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+    ]) {
       expect(classifyDetectError(new Error(`some ${token} happened`))).toBe('network_error');
     }
   });

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -496,8 +496,8 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
       <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
         <AlertCircle className="w-4 h-4 shrink-0" />
         <span>
-          Provider detection failed (main process unreachable): {state.message}. Restart the app
-          and try again.
+          Provider detection failed (main process unreachable): {state.message}. Restart the app and
+          try again.
         </span>
       </div>
     );

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -18,7 +18,35 @@ type DetectState =
   | { kind: 'idle' }
   | { kind: 'detecting' }
   | { kind: 'detected'; provider: SupportedOnboardingProvider }
-  | { kind: 'unknown' };
+  | { kind: 'unknown_prefix' }
+  | { kind: 'ipc_error'; message: string }
+  | { kind: 'network_error'; message: string };
+
+// Result returned by the detectProvider IPC wrapper. Distinguishing the
+// failure modes is required by the no-silent-fallback constraint: an IPC
+// crash or network outage must not be reported to the user as a
+// "key prefix unrecognized" message.
+export type DetectResult =
+  | { ok: true; provider: SupportedOnboardingProvider }
+  | { ok: false; kind: 'unknown_prefix' }
+  | { ok: false; kind: 'ipc_error'; message: string }
+  | { ok: false; kind: 'network_error'; message: string };
+
+// Heuristic: detect-provider IPC is purely local (prefix match, no
+// network), so any caught error is almost always an IPC failure. We still
+// inspect the message in case Electron or a future remote backend surfaces
+// a fetch-style error — those should be reported as a network failure.
+export function classifyDetectError(err: unknown): 'ipc_error' | 'network_error' {
+  if (err instanceof TypeError) return 'network_error';
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  if (/fetch|network|ECONN|ENOTFOUND|ETIMEDOUT|EAI_AGAIN/i.test(msg)) return 'network_error';
+  return 'ipc_error';
+}
+
+function detectErrorMessage(err: unknown): string {
+  if (err instanceof Error && err.message.length > 0) return err.message;
+  return 'Provider detection failed.';
+}
 
 // Single authoritative connection state — no separate ValidationState.
 type ConnectionCheck =
@@ -76,33 +104,54 @@ function connectionHint(code: ConnectionTestError['code']): string {
 // Provider detection helper (extracted to keep useEffect complexity low)
 // ---------------------------------------------------------------------------
 
-async function detectProvider(
+export async function detectProvider(
   trimmed: string,
+  bridge: { detectProvider: (key: string) => Promise<string | null> } | undefined,
+): Promise<DetectResult> {
+  if (!bridge) {
+    return {
+      ok: false,
+      kind: 'ipc_error',
+      message: 'Renderer is not connected to the main process.',
+    };
+  }
+  let detected: string | null;
+  try {
+    detected = await bridge.detectProvider(trimmed);
+  } catch (err) {
+    return { ok: false, kind: classifyDetectError(err), message: detectErrorMessage(err) };
+  }
+  if (detected !== null && isSupportedOnboardingProvider(detected)) {
+    return { ok: true, provider: detected };
+  }
+  return { ok: false, kind: 'unknown_prefix' };
+}
+
+function applyDetectResult(
+  result: DetectResult,
   reqId: number,
   reqIdRef: { current: number },
   setDetectState: (s: DetectState) => void,
   setConnCheck: (s: ConnectionCheck) => void,
-): Promise<void> {
-  if (!window.codesign) {
-    setDetectState({ kind: 'unknown' });
-    return;
-  }
-  let detected: string | null;
-  try {
-    detected = await window.codesign.detectProvider(trimmed);
-  } catch {
-    if (reqId !== reqIdRef.current) return;
-    setDetectState({ kind: 'unknown' });
-    return;
-  }
+): void {
   if (reqId !== reqIdRef.current) return;
-  if (detected !== null && isSupportedOnboardingProvider(detected)) {
-    setDetectState({ kind: 'detected', provider: detected });
-  } else {
-    setDetectState({ kind: 'unknown' });
+  if (result.ok) {
+    setDetectState({ kind: 'detected', provider: result.provider });
+    setConnCheck({ status: 'idle' });
+    return;
   }
-  // Changing the key always resets the connection check.
-  setConnCheck({ status: 'idle' });
+  if (result.kind === 'unknown_prefix') {
+    setDetectState({ kind: 'unknown_prefix' });
+    setConnCheck({ status: 'idle' });
+    return;
+  }
+  // IPC / network failures must surface — never silently downgrade to unknown_prefix.
+  setDetectState({ kind: result.kind, message: result.message });
+  setConnCheck({
+    status: 'failed',
+    code: result.kind === 'network_error' ? 'NETWORK' : 'IPC_BAD_INPUT',
+    hint: result.message,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -138,10 +187,11 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
     }
     setDetectState({ kind: 'detecting' });
     const reqId = ++detectReqRef.current;
-    const handle = window.setTimeout(
-      () => void detectProvider(trimmed, reqId, detectReqRef, setDetectState, setConnCheck),
-      300,
-    );
+    const handle = window.setTimeout(() => {
+      void detectProvider(trimmed, window.codesign).then((result) =>
+        applyDetectResult(result, reqId, detectReqRef, setDetectState, setConnCheck),
+      );
+    }, 300);
     return () => window.clearTimeout(handle);
   }, [trimmed]);
 
@@ -430,11 +480,34 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
       </div>
     );
   }
+  if (state.kind === 'unknown_prefix') {
+    return (
+      <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>
+          Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or-
+          (OpenRouter).
+        </span>
+      </div>
+    );
+  }
+  if (state.kind === 'ipc_error') {
+    return (
+      <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span>
+          Provider detection failed (main process unreachable): {state.message}. Restart the app
+          and try again.
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
       <AlertCircle className="w-4 h-4 shrink-0" />
       <span>
-        Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or- (OpenRouter).
+        Provider detection failed (network error): {state.message}. Check your connection and try
+        again.
       </span>
     </div>
   );

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -8,27 +8,24 @@ import {
 import { Button } from '@open-codesign/ui';
 import { AlertCircle, CheckCircle2, ExternalLink, Loader2, Wifi, WifiOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type {
-  ConnectionTestError,
-  ConnectionTestResult,
-  ValidateKeyError,
-  ValidateKeyResult,
-} from '../../../preload/index';
+import type { ConnectionTestError } from '../../../preload/index';
 
-const VALIDATE_DEBOUNCE_MS = 500;
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
-type ValidationState =
+type DetectState =
   | { kind: 'idle' }
   | { kind: 'detecting' }
-  | { kind: 'validating' }
-  | { kind: 'ok'; modelCount: number }
-  | { kind: 'error'; code: ValidateKeyError['code'] | 'unsupported'; message: string };
+  | { kind: 'detected'; provider: SupportedOnboardingProvider }
+  | { kind: 'unknown' };
 
-type ConnectionState =
-  | { kind: 'idle' }
-  | { kind: 'testing' }
-  | { kind: 'ok' }
-  | { kind: 'error'; code: ConnectionTestError['code']; hint: string };
+// Single authoritative connection state — no separate ValidationState.
+type ConnectionCheck =
+  | { status: 'idle' }
+  | { status: 'testing' }
+  | { status: 'ok' }
+  | { status: 'failed'; code: ConnectionTestError['code']; hint: string };
 
 interface PasteKeyProps {
   onValidated: (
@@ -39,14 +36,33 @@ interface PasteKeyProps {
   onBack: () => void;
 }
 
-function getErrorHint(code: ConnectionTestError['code']): string {
+// ---------------------------------------------------------------------------
+// Default base URLs — must mirror buildDefaultBaseUrl in connection-ipc.ts
+// ---------------------------------------------------------------------------
+
+function defaultBaseUrl(provider: SupportedOnboardingProvider): string {
+  switch (provider) {
+    case 'anthropic':
+      return 'https://api.anthropic.com';
+    case 'openai':
+      return 'https://api.openai.com/v1';
+    case 'openrouter':
+      return 'https://openrouter.ai/api/v1';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error hint for connection failures
+// ---------------------------------------------------------------------------
+
+function connectionHint(code: ConnectionTestError['code']): string {
   switch (code) {
     case '401':
-      return 'API key invalid or unauthorized.';
+      return 'API key invalid or unauthorized. Check it in your provider dashboard.';
     case '404':
       return 'Base URL path wrong. Try adding /v1 suffix (e.g. https://your-host/v1).';
     case 'ECONNREFUSED':
-      return 'Cannot reach base URL. Check domain/port/network.';
+      return 'Cannot reach base URL. Check domain / port / network.';
     case 'NETWORK':
       return 'Network error. Check your connection.';
     case 'PARSE':
@@ -56,15 +72,51 @@ function getErrorHint(code: ConnectionTestError['code']): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Provider detection helper (extracted to keep useEffect complexity low)
+// ---------------------------------------------------------------------------
+
+async function detectProvider(
+  trimmed: string,
+  reqId: number,
+  reqIdRef: { current: number },
+  setDetectState: (s: DetectState) => void,
+  setConnCheck: (s: ConnectionCheck) => void,
+): Promise<void> {
+  if (!window.codesign) {
+    setDetectState({ kind: 'unknown' });
+    return;
+  }
+  let detected: string | null;
+  try {
+    detected = await window.codesign.detectProvider(trimmed);
+  } catch {
+    if (reqId !== reqIdRef.current) return;
+    setDetectState({ kind: 'unknown' });
+    return;
+  }
+  if (reqId !== reqIdRef.current) return;
+  if (detected !== null && isSupportedOnboardingProvider(detected)) {
+    setDetectState({ kind: 'detected', provider: detected });
+  } else {
+    setDetectState({ kind: 'unknown' });
+  }
+  // Changing the key always resets the connection check.
+  setConnCheck({ status: 'idle' });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [selectedPresetId, setSelectedPresetId] = useState<ProxyPresetId | ''>('');
-  const [provider, setProvider] = useState<SupportedOnboardingProvider | null>(null);
-  const [state, setState] = useState<ValidationState>({ kind: 'idle' });
-  const [connState, setConnState] = useState<ConnectionState>({ kind: 'idle' });
-  const reqIdRef = useRef(0);
+  const [detectState, setDetectState] = useState<DetectState>({ kind: 'idle' });
+  const [connCheck, setConnCheck] = useState<ConnectionCheck>({ status: 'idle' });
+  const detectReqRef = useRef(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -74,131 +126,84 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   const trimmed = apiKey.trim();
   const trimmedBaseUrl = baseUrl.trim();
 
+  // Derived: the provider from detect state (if known)
+  const detectedProvider = detectState.kind === 'detected' ? detectState.provider : null;
+
+  // Detect provider on key change (lightweight prefix-match IPC, no network auth)
+  useEffect(() => {
+    if (trimmed.length === 0) {
+      setDetectState({ kind: 'idle' });
+      setConnCheck({ status: 'idle' });
+      return;
+    }
+    setDetectState({ kind: 'detecting' });
+    const reqId = ++detectReqRef.current;
+    const handle = window.setTimeout(
+      () => void detectProvider(trimmed, reqId, detectReqRef, setDetectState, setConnCheck),
+      300,
+    );
+    return () => window.clearTimeout(handle);
+  }, [trimmed]);
+
+  function handleBaseUrlChange(value: string) {
+    setBaseUrl(value);
+    setConnCheck({ status: 'idle' });
+  }
+
   function handlePresetChange(presetId: string) {
     if (presetId === '') {
       setSelectedPresetId('');
       setBaseUrl('');
+      setConnCheck({ status: 'idle' });
       return;
     }
     const preset = PROXY_PRESETS.find((p) => p.id === presetId);
     if (!preset) return;
     setSelectedPresetId(preset.id as ProxyPresetId);
     setBaseUrl(preset.baseUrl);
-    if (preset.id !== 'custom') {
-      setAdvancedOpen(true);
-    }
-    setConnState({ kind: 'idle' });
+    if (preset.id !== 'custom') setAdvancedOpen(true);
+    setConnCheck({ status: 'idle' });
   }
 
-  useEffect(() => {
-    if (trimmed.length === 0) {
-      setProvider(null);
-      setState({ kind: 'idle' });
-      return;
-    }
+  // The effective base URL passed to connection.test:
+  // – if user typed something, use that
+  // – otherwise fall back to the provider's official default (same as main-process default)
+  function effectiveBaseUrl(): string {
+    if (trimmedBaseUrl.length > 0) return trimmedBaseUrl;
+    if (detectedProvider !== null) return defaultBaseUrl(detectedProvider);
+    return '';
+  }
 
-    setState({ kind: 'detecting' });
-    const reqId = ++reqIdRef.current;
+  async function handleTest() {
+    if (!detectedProvider || trimmed.length === 0) return;
+    const baseUrlForTest = effectiveBaseUrl();
+    if (baseUrlForTest.length === 0) return;
 
-    const handle = window.setTimeout(async () => {
-      if (!window.codesign) {
-        setState({
-          kind: 'error',
-          code: 'network',
-          message: 'Renderer is not connected to the main process.',
-        });
-        return;
-      }
-      let detected: string | null;
-      try {
-        detected = await window.codesign.detectProvider(trimmed);
-      } catch (err) {
-        if (reqId !== reqIdRef.current) return;
-        setState({
-          kind: 'error',
-          code: 'network',
-          message: err instanceof Error ? err.message : 'Provider detection failed.',
-        });
-        return;
-      }
-      if (reqId !== reqIdRef.current) return;
-
-      if (detected === null) {
-        setProvider(null);
-        setState({
-          kind: 'error',
-          code: 'unsupported',
-          message:
-            'Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or- (OpenRouter).',
-        });
-        return;
-      }
-      if (!isSupportedOnboardingProvider(detected)) {
-        setProvider(null);
-        setState({
-          kind: 'error',
-          code: 'unsupported',
-          message: `${detected} is not supported in v0.1. Use Anthropic, OpenAI, or OpenRouter.`,
-        });
-        return;
-      }
-      setProvider(detected);
-      setState({ kind: 'validating' });
-
-      let result: ValidateKeyResult | ValidateKeyError;
-      try {
-        result = await window.codesign.onboarding.validateKey({
-          provider: detected,
-          apiKey: trimmed,
-          ...(trimmedBaseUrl.length > 0 ? { baseUrl: trimmedBaseUrl } : {}),
-        });
-      } catch (err) {
-        if (reqId !== reqIdRef.current) return;
-        setState({
-          kind: 'error',
-          code: 'network',
-          message: err instanceof Error ? err.message : 'Validation request failed.',
-        });
-        return;
-      }
-      if (reqId !== reqIdRef.current) return;
-
-      if (result.ok) {
-        setState({ kind: 'ok', modelCount: result.modelCount });
-      } else {
-        setState({ kind: 'error', code: result.code, message: result.message });
-      }
-    }, VALIDATE_DEBOUNCE_MS);
-
-    return () => window.clearTimeout(handle);
-  }, [trimmed, trimmedBaseUrl]);
-
-  async function handleConnectionTest() {
-    if (!provider || trimmed.length === 0 || trimmedBaseUrl.length === 0) return;
     if (!window.codesign?.connection) {
-      setConnState({
-        kind: 'error',
+      setConnCheck({
+        status: 'failed',
         code: 'NETWORK',
         hint: 'Renderer is not connected to the main process.',
       });
       return;
     }
-    setConnState({ kind: 'testing' });
+
+    setConnCheck({ status: 'testing' });
     try {
       const result = await window.codesign.connection.test({
-        provider,
+        provider: detectedProvider,
         apiKey: trimmed,
-        baseUrl: trimmedBaseUrl,
+        baseUrl: baseUrlForTest,
       });
       if (result.ok) {
-        setConnState({ kind: 'ok' });
+        setConnCheck({ status: 'ok' });
       } else {
         const err = result as ConnectionTestError;
-        setConnState({ kind: 'error', code: err.code, hint: getErrorHint(err.code) });
+        setConnCheck({ status: 'failed', code: err.code, hint: connectionHint(err.code) });
       }
     } catch (err) {
-      setConnState({
-        kind: 'error',
+      setConnCheck({
+        status: 'failed',
         code: 'NETWORK',
         hint: err instanceof Error ? err.message : 'Connection test failed.',
       });
@@ -206,16 +211,19 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   }
 
   const helpUrl = useMemo(() => {
-    if (provider === null) return null;
-    return PROVIDER_SHORTLIST[provider].keyHelpUrl;
-  }, [provider]);
+    if (detectedProvider === null) return null;
+    return PROVIDER_SHORTLIST[detectedProvider].keyHelpUrl;
+  }, [detectedProvider]);
 
   function handleContinue() {
-    if (state.kind !== 'ok' || provider === null) return;
-    onValidated(provider, trimmed, trimmedBaseUrl.length > 0 ? trimmedBaseUrl : null);
+    if (connCheck.status !== 'ok' || detectedProvider === null) return;
+    onValidated(detectedProvider, trimmed, trimmedBaseUrl.length > 0 ? trimmedBaseUrl : null);
   }
 
   const selectedPreset = PROXY_PRESETS.find((p) => p.id === selectedPresetId);
+  const testDisabled =
+    connCheck.status === 'testing' || detectedProvider === null || trimmed.length === 0;
+  const continueDisabled = connCheck.status !== 'ok';
 
   return (
     <div className="flex flex-col gap-5">
@@ -224,8 +232,8 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           Paste your API key
         </h2>
         <p className="text-[var(--text-base)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
-          We auto-detect the provider and validate against /v1/models. Your key is encrypted with
-          the OS keychain.
+          Auto-detects your provider. Click <strong>Test</strong> to verify the key and endpoint
+          before continuing. Your key is encrypted with the OS keychain.
         </p>
       </div>
 
@@ -251,11 +259,12 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           ))}
         </select>
         <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
-          Not sure which to pick? Choose OpenAI Official for official endpoint, or pick by relay
+          Not sure which to pick? Choose OpenAI Official for the official endpoint, or pick by relay
           name.
         </span>
       </label>
 
+      {/* API key input */}
       <label className="flex flex-col gap-2">
         <span
           className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
@@ -277,8 +286,9 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         </div>
       </label>
 
-      <StatusLine provider={provider} state={state} helpUrl={helpUrl} />
+      <DetectLine state={detectState} helpUrl={helpUrl} />
 
+      {/* Advanced: custom base URL */}
       <details
         open={advancedOpen}
         onToggle={(e) => setAdvancedOpen((e.currentTarget as HTMLDetailsElement).open)}
@@ -297,64 +307,64 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           >
             Base URL
           </span>
-          <div className="flex gap-2 items-center">
-            <input
-              type="url"
-              value={baseUrl}
-              onChange={(e) => {
-                setBaseUrl(e.target.value);
-                setConnState({ kind: 'idle' });
-              }}
-              placeholder={
-                selectedPreset && selectedPreset.id !== 'custom'
-                  ? selectedPreset.baseUrl
-                  : 'https://your-proxy.example.com/v1'
-              }
-              spellCheck={false}
-              style={{ fontFamily: 'var(--font-mono)' }}
-              className="flex-1 h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
-            />
-            <button
-              type="button"
-              onClick={handleConnectionTest}
-              disabled={
-                connState.kind === 'testing' ||
-                provider === null ||
-                trimmed.length === 0 ||
-                trimmedBaseUrl.length === 0
-              }
-              className="h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 whitespace-nowrap"
-            >
-              {connState.kind === 'testing' ? (
-                <Loader2 className="w-3.5 h-3.5 animate-spin" />
-              ) : connState.kind === 'ok' ? (
-                <Wifi className="w-3.5 h-3.5 text-[var(--color-success)]" />
-              ) : connState.kind === 'error' ? (
-                <WifiOff className="w-3.5 h-3.5 text-[var(--color-error)]" />
-              ) : (
-                <Wifi className="w-3.5 h-3.5" />
-              )}
-              {connState.kind === 'testing' ? 'Testing...' : 'Test'}
-            </button>
-          </div>
-          {connState.kind === 'ok' && (
-            <span className="text-[var(--text-xs)] text-[var(--color-success)] flex items-center gap-1.5">
-              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
-              Connected
-            </span>
-          )}
-          {connState.kind === 'error' && (
-            <span className="text-[var(--text-xs)] text-[var(--color-error)] flex items-center gap-1.5">
-              <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-              {connState.hint}
-            </span>
-          )}
+          <input
+            type="url"
+            value={baseUrl}
+            onChange={(e) => handleBaseUrlChange(e.target.value)}
+            placeholder={
+              selectedPreset && selectedPreset.id !== 'custom'
+                ? selectedPreset.baseUrl
+                : 'https://your-proxy.example.com/v1'
+            }
+            spellCheck={false}
+            style={{ fontFamily: 'var(--font-mono)' }}
+            className="w-full h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
+          />
           <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
-            Override the default endpoint for your provider. Useful for relay services (e.g.
-            third-party AI gateways) and self-hosted proxies. Leave empty for the official endpoint.
+            Override the default endpoint for your provider. Useful for relay services and
+            self-hosted proxies. Leave empty to use the official endpoint.
           </span>
         </label>
       </details>
+
+      {/* Test button + connection status — the sole authority for key+endpoint verification */}
+      <div className="flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={() => void handleTest()}
+          disabled={testDisabled}
+          className="self-start h-[var(--size-control-md)] px-[var(--space-4)] rounded-[var(--radius-md)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+        >
+          {connCheck.status === 'testing' ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : connCheck.status === 'ok' ? (
+            <Wifi className="w-4 h-4 text-[var(--color-success)]" />
+          ) : connCheck.status === 'failed' ? (
+            <WifiOff className="w-4 h-4 text-[var(--color-error)]" />
+          ) : (
+            <Wifi className="w-4 h-4" />
+          )}
+          {connCheck.status === 'testing' ? 'Testing...' : 'Test'}
+        </button>
+
+        {connCheck.status === 'ok' && (
+          <span className="text-[var(--text-sm)] text-[var(--color-success)] flex items-center gap-2">
+            <CheckCircle2 className="w-4 h-4 shrink-0" />
+            Connected — key and endpoint verified
+          </span>
+        )}
+        {connCheck.status === 'failed' && (
+          <span className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            {connCheck.hint}
+          </span>
+        )}
+        {connCheck.status === 'idle' && detectedProvider !== null && (
+          <span className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
+            Run Test to verify your key and connection before continuing.
+          </span>
+        )}
+      </div>
 
       <div className="flex justify-between gap-2 pt-2">
         <Button type="button" variant="ghost" onClick={onBack}>
@@ -364,7 +374,8 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           type="button"
           variant="primary"
           onClick={handleContinue}
-          disabled={state.kind !== 'ok'}
+          disabled={continueDisabled}
+          title={continueDisabled ? 'Run Test to verify your connection first' : undefined}
         >
           Continue
         </Button>
@@ -373,84 +384,58 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
   );
 }
 
-interface StatusLineProps {
-  provider: SupportedOnboardingProvider | null;
-  state: ValidationState;
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface DetectLineProps {
+  state: DetectState;
   helpUrl: string | null;
 }
 
-function StatusLine({ provider, state, helpUrl }: StatusLineProps) {
+function DetectLine({ state, helpUrl }: DetectLineProps) {
   if (state.kind === 'idle') {
     return (
-      <p className="text-xs text-[var(--color-text-muted)]">
-        Paste a key to detect the provider and validate live.
+      <p className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
+        Paste a key above — provider is auto-detected from the prefix.
       </p>
     );
   }
   if (state.kind === 'detecting') {
-    return <Pending text="Detecting provider..." />;
-  }
-  if (state.kind === 'validating') {
     return (
-      <Pending
-        text={`Recognized: ${provider ? PROVIDER_SHORTLIST[provider].label : 'unknown'} — validating...`}
-      />
-    );
-  }
-  if (state.kind === 'ok') {
-    return (
-      <div className="text-sm text-[var(--color-success)] flex items-center gap-2">
-        <CheckCircle2 className="w-4 h-4 shrink-0" />
-        <span>
-          Recognized: {provider ? PROVIDER_SHORTLIST[provider].label : 'provider'} — Connected (
-          {state.modelCount} models)
-        </span>
+      <div className="text-[var(--text-sm)] text-[var(--color-text-secondary)] flex items-center gap-2">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        <span>Detecting provider...</span>
       </div>
     );
   }
-  const errorMessage = getValidationErrorMessage(state.code, state.message);
-  return (
-    <div className="text-sm text-[var(--color-error)] flex flex-col gap-1">
-      <span className="flex items-start gap-2">
-        <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
-        <span>{errorMessage}</span>
-      </span>
-      {helpUrl !== null ? (
-        <a
-          href={helpUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="ml-6 inline-flex items-center gap-1 text-xs text-[var(--color-accent)] hover:underline"
-        >
-          How to get a key <ExternalLink className="w-3 h-3" />
-        </a>
-      ) : null}
-    </div>
-  );
-}
-
-function getValidationErrorMessage(
-  code: ValidateKeyError['code'] | 'unsupported',
-  originalMessage: string,
-): string {
-  switch (code) {
-    case '401':
-    case '402':
-      return 'API key invalid or unauthorized. Check it in your provider dashboard.';
-    case '429':
-      return 'Rate limited. Wait a moment and try again.';
-    case 'network':
-      return 'Cannot reach base URL. Check domain/port/network.';
-    default:
-      return originalMessage;
+  if (state.kind === 'detected') {
+    return (
+      <div className="text-[var(--text-sm)] text-[var(--color-text-secondary)] flex items-center gap-2">
+        <CheckCircle2 className="w-4 h-4 text-[var(--color-success)] shrink-0" />
+        <span>
+          Recognized: <strong>{PROVIDER_SHORTLIST[state.provider].label}</strong> — click Test to
+          verify
+        </span>
+        {helpUrl !== null ? (
+          <a
+            href={helpUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-accent)] hover:underline ml-1"
+          >
+            Get key <ExternalLink className="w-3 h-3" />
+          </a>
+        ) : null}
+      </div>
+    );
   }
-}
-
-function Pending({ text }: { text: string }) {
   return (
-    <div className="text-sm text-[var(--color-text-secondary)] flex items-center gap-2">
-      <Loader2 className="w-4 h-4 animate-spin" />
-      <span>{text}</span>
+    <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
+      <AlertCircle className="w-4 h-4 shrink-0" />
+      <span>
+        Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or- (OpenRouter).
+      </span>
     </div>
   );
 }

--- a/packages/providers/src/validate.test.ts
+++ b/packages/providers/src/validate.test.ts
@@ -86,12 +86,31 @@ describe('pingProvider', () => {
     expect(result).toEqual({ ok: true, modelCount: 0 });
   });
 
-  it('respects custom baseUrl', async () => {
+  it('respects custom baseUrl without /v1 suffix', async () => {
     mockFetch(async (url) => {
       expect(url).toBe('https://proxy.example/v1/models');
       return new Response(JSON.stringify({ data: [{ id: 'x' }] }), { status: 200 });
     });
     const result = await pingProvider('openrouter', 'sk-or-test', 'https://proxy.example');
+    expect(result).toEqual({ ok: true, modelCount: 1 });
+  });
+
+  it('normalizes baseUrl with /v1 suffix — no double /v1/v1/ in URL', async () => {
+    mockFetch(async (url) => {
+      // Must hit /v1/models exactly once, not /v1/v1/models
+      expect(url).toBe('https://proxy.duckcoding.com/v1/models');
+      return new Response(JSON.stringify({ data: [{ id: 'gpt-4o' }] }), { status: 200 });
+    });
+    const result = await pingProvider('openai', 'sk-test', 'https://proxy.duckcoding.com/v1');
+    expect(result).toEqual({ ok: true, modelCount: 1 });
+  });
+
+  it('normalizes baseUrl with trailing slash — no double /v1/ in URL', async () => {
+    mockFetch(async (url) => {
+      expect(url).toBe('https://proxy.duckcoding.com/v1/models');
+      return new Response(JSON.stringify({ data: [{ id: 'gpt-4o' }] }), { status: 200 });
+    });
+    const result = await pingProvider('openai', 'sk-test', 'https://proxy.duckcoding.com/v1/');
     expect(result).toEqual({ ok: true, modelCount: 1 });
   });
 });

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -13,26 +13,43 @@ interface ProviderEndpoint {
   headers: (apiKey: string) => Record<string, string>;
 }
 
+/**
+ * Normalize a user-supplied baseUrl so that appending /v1/models never
+ * produces a double /v1/ segment.
+ *
+ * - openai / openrouter: strip trailing /v1 — we append /v1/models below
+ * - anthropic: strip trailing /v1 — we append /v1/models below
+ */
+function normalizeValidateBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
 function endpoint(provider: SupportedOnboardingProvider, baseUrl?: string): ProviderEndpoint {
   switch (provider) {
-    case 'anthropic':
+    case 'anthropic': {
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'https://api.anthropic.com';
       return {
-        url: `${baseUrl ?? 'https://api.anthropic.com'}/v1/models`,
+        url: `${root}/v1/models`,
         headers: (apiKey) => ({
           'x-api-key': apiKey,
           'anthropic-version': '2023-06-01',
         }),
       };
-    case 'openai':
+    }
+    case 'openai': {
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'https://api.openai.com';
       return {
-        url: `${baseUrl ?? 'https://api.openai.com'}/v1/models`,
+        url: `${root}/v1/models`,
         headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
       };
-    case 'openrouter':
+    }
+    case 'openrouter': {
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'https://openrouter.ai/api';
       return {
-        url: `${baseUrl ?? 'https://openrouter.ai/api'}/v1/models`,
+        url: `${root}/v1/models`,
         headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
       };
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

The onboarding `PasteKey` component had two parallel, inconsistent validation flows:

1. **Auto-validate on key change** (via `onboarding.validateKey` → `pingProvider` in `packages/providers/validate.ts`): built URLs by naively appending `/v1/models` to whatever `baseUrl` the user typed — no normalization.
2. **Test button** (via `connection:v1:test` in `connection-ipc.ts`): used `normalizeBaseUrl` + provider-aware path construction before hitting the endpoint.

Result: with an OpenAI-compat proxy at `https://host/v1`, auto-validate would hit `https://host/v1/v1/models` (404) while the Test button correctly hit `https://host/v1/models` (200). The two flows disagreed on the same inputs, producing confusing UX and silent failures.

## Solution

Delete the split-state architecture. Replace `ValidationState` + `ConnectionState` with a single unified type:

\`\`\`ts
type ConnectionCheck =
  | { status: 'idle' }
  | { status: 'testing' }
  | { status: 'ok' }
  | { status: 'failed'; code: ErrorCode; hint: string };
\`\`\`

### What changed

- **Removed** the `ValidationState` type and the auto-validate `useEffect` that called `onboarding.validateKey` / `pingProvider`.
- **Kept** provider detection (lightweight prefix-match IPC, no network auth, 300ms debounce).
- **Test button** is now the ONLY authority. It always calls `connection:v1:test` which uses `normalizeBaseUrl` + correct per-provider path logic.
- **Default base URL fallback**: when no custom `baseUrl` is entered, the renderer falls back to the same defaults as `buildDefaultBaseUrl` in `connection-ipc.ts` (`https://api.anthropic.com`, `https://api.openai.com/v1`, `https://openrouter.ai/api/v1`). The Test button works for the official endpoint without requiring the advanced section.
- **Continue button gated** on `connectionCheck.status === 'ok'` with tooltip hint "Run Test to verify your connection first".
- **`onboarding.validateKey` / `providers.validate` IPC** no longer called from `PasteKey` (the IPC handler still exists for `Settings` usage).

### Deleted paths

| Removed | Replaced by |
|---|---|
| `ValidationState` (idle/detecting/validating/ok/error) | `ConnectionCheck` (idle/testing/ok/failed) |
| `connState` (ConnectionState) | merged into `ConnectionCheck` |
| `useEffect` → `onboarding.validateKey` call | Test button → `connection.test` |
| Auto-trigger on key change/blur | Explicit user action only |

### Principles check

- **Compatibility** ✅ — IPC contract unchanged; `onboarding:validate-key` still registered
- **Upgradeability** ✅ — simpler state, easier to extend
- **No bloat** ✅ — removed ~80 lines of duplicate logic
- **Elegance** ✅ — single source of truth for connection status

## Test plan

- [ ] `pnpm -r typecheck` passes
- [ ] `pnpm lint` — no new errors in changed files
- [ ] `pnpm test` — 104/104 tests pass including new `PasteKey.test.ts` cases covering default-baseUrl fallback, 401/ECONNREFUSED errors, and Continue gate
- [ ] Manual: paste Anthropic key → detect shows "Recognized: Anthropic Claude" → click Test → success → Continue enabled
- [ ] Manual: paste key with custom proxy URL `https://host/v1` → Test hits correct endpoint → no double `/v1`
- [ ] Manual: Continue button is disabled before Test runs; tooltip shown