### PR TITLE
fix(desktop): onboarding i18n audit + locale-reactive switching

### DIFF
--- a/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/ChooseModel.tsx
@@ -1,3 +1,4 @@
+import { useT } from '@open-codesign/i18n';
 import { PROVIDER_SHORTLIST, type SupportedOnboardingProvider } from '@open-codesign/shared';
 import { Button } from '@open-codesign/ui';
 import { useEffect, useId, useState } from 'react';
@@ -23,6 +24,7 @@ export function ChooseModel({
   onConfirm,
   onBack,
 }: ChooseModelProps) {
+  const t = useT();
   const shortlist = PROVIDER_SHORTLIST[provider];
   const useFreeTierDefaults = provider === 'openrouter' && preferFreeTier;
   const primaryOptions = withFreeTierSuggestion(shortlist.primary, useFreeTierDefaults);
@@ -47,31 +49,30 @@ export function ChooseModel({
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
         <h2 className="text-[20px] font-semibold text-[var(--color-text-primary)] tracking-[-0.01em] leading-[1.2]">
-          Pick default models
+          {t('onboarding.choose.title')}
         </h2>
         <p className="text-[14px] text-[var(--color-text-secondary)] leading-[1.55]">
-          Start with a recommendation or enter any provider-specific model ID. You can switch these
-          per design later.
+          {t('onboarding.choose.description')}
         </p>
       </div>
 
       <ModelPicker
-        label="Primary design model"
+        label={t('onboarding.choose.primary')}
         hint={
           useFreeTierDefaults
-            ? 'Free path starts on openrouter/free, but you can enter any OpenRouter model ID.'
-            : 'Used for full design generation.'
+            ? t('onboarding.choose.primaryHintFree')
+            : t('onboarding.choose.primaryHint')
         }
         value={modelPrimary}
         options={primaryOptions}
         onChange={setModelPrimary}
       />
       <ModelPicker
-        label="Fast completion model"
+        label={t('onboarding.choose.fast')}
         hint={
           useFreeTierDefaults
-            ? 'Keep openrouter/free for lowest cost, or replace it with a faster custom choice.'
-            : 'Used for quick edits and inline tweaks.'
+            ? t('onboarding.choose.fastHintFree')
+            : t('onboarding.choose.fastHint')
         }
         value={modelFast}
         options={fastOptions}
@@ -80,14 +81,14 @@ export function ChooseModel({
 
       {baseUrl !== null ? (
         <p className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
-          Custom base URL: <span style={{ fontFamily: 'var(--font-mono)' }}>{baseUrl}</span>
+          {t('onboarding.choose.customBaseUrl', { url: baseUrl })}
         </p>
       ) : null}
 
       <p className="text-[12px] text-[var(--color-text-muted)] leading-[1.5]">
         {useFreeTierDefaults
-          ? 'OpenRouter free routing availability can change. If a free route is unavailable, type another model ID here.'
-          : 'Estimated cost varies by provider, chosen model, and prompt length.'}
+          ? t('onboarding.choose.costNoteFree')
+          : t('onboarding.choose.costNote')}
       </p>
 
       {errorMessage !== null ? (
@@ -96,7 +97,7 @@ export function ChooseModel({
 
       <div className="flex justify-between gap-2 pt-2">
         <Button type="button" variant="ghost" onClick={onBack} disabled={saving}>
-          Back
+          {t('onboarding.choose.back')}
         </Button>
         <Button
           type="button"
@@ -104,7 +105,7 @@ export function ChooseModel({
           onClick={() => onConfirm(trimmedPrimary, trimmedFast)}
           disabled={!canFinish}
         >
-          {saving ? 'Saving...' : 'Finish'}
+          {saving ? t('onboarding.choose.saving') : t('onboarding.choose.finish')}
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -496,18 +496,14 @@ function DetectLine({ state, helpUrl, t }: DetectLineProps) {
     return (
       <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
         <AlertCircle className="w-4 h-4 shrink-0" />
-        <span>
-          {t('onboarding.paste.errors.detectIpc', { message: state.message })}
-        </span>
+        <span>{t('onboarding.paste.errors.detectIpc', { message: state.message })}</span>
       </div>
     );
   }
   return (
     <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
       <AlertCircle className="w-4 h-4 shrink-0" />
-      <span>
-        {t('onboarding.paste.errors.detectNetwork', { message: state.message })}
-      </span>
+      <span>{t('onboarding.paste.errors.detectNetwork', { message: state.message })}</span>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/PasteKey.tsx
@@ -1,3 +1,4 @@
+import { useT } from '@open-codesign/i18n';
 import {
   PROVIDER_SHORTLIST,
   PROXY_PRESETS,
@@ -83,20 +84,20 @@ function defaultBaseUrl(provider: SupportedOnboardingProvider): string {
 // Error hint for connection failures
 // ---------------------------------------------------------------------------
 
-function connectionHint(code: ConnectionTestError['code']): string {
+function connectionHint(code: ConnectionTestError['code'], t: (key: string) => string): string {
   switch (code) {
     case '401':
-      return 'API key invalid or unauthorized. Check it in your provider dashboard.';
+      return t('onboarding.paste.connectionTest.errors.401');
     case '404':
-      return 'Base URL path wrong. Try adding /v1 suffix (e.g. https://your-host/v1).';
+      return t('onboarding.paste.connectionTest.errors.404');
     case 'ECONNREFUSED':
-      return 'Cannot reach base URL. Check domain / port / network.';
+      return t('onboarding.paste.connectionTest.errors.ECONNREFUSED');
     case 'NETWORK':
-      return 'Network error. Check your connection.';
+      return t('onboarding.paste.connectionTest.errors.NETWORK');
     case 'PARSE':
-      return 'Unexpected response. View logs at ~/Library/Logs/open-codesign/main.log';
+      return t('onboarding.paste.connectionTest.errors.PARSE');
     case 'IPC_BAD_INPUT':
-      return 'Invalid input sent to connection test. Check provider / API key / base URL fields.';
+      return t('onboarding.paste.connectionTest.errors.IPC_BAD_INPUT');
   }
 }
 
@@ -159,6 +160,7 @@ function applyDetectResult(
 // ---------------------------------------------------------------------------
 
 export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
+  const t = useT();
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -233,7 +235,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
       setConnCheck({
         status: 'failed',
         code: 'NETWORK',
-        hint: 'Renderer is not connected to the main process.',
+        hint: t('onboarding.paste.errors.rendererDisconnected'),
       });
       return;
     }
@@ -249,13 +251,14 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         setConnCheck({ status: 'ok' });
       } else {
         const err = result as ConnectionTestError;
-        setConnCheck({ status: 'failed', code: err.code, hint: connectionHint(err.code) });
+        setConnCheck({ status: 'failed', code: err.code, hint: connectionHint(err.code, t) });
       }
     } catch (err) {
       setConnCheck({
         status: 'failed',
         code: 'NETWORK',
-        hint: err instanceof Error ? err.message : 'Connection test failed.',
+        hint:
+          err instanceof Error ? err.message : t('onboarding.paste.connectionTest.errors.NETWORK'),
       });
     }
   }
@@ -279,11 +282,10 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
         <h2 className="text-[var(--text-lg)] font-semibold text-[var(--color-text-primary)] tracking-[var(--tracking-heading)] leading-[var(--leading-heading)]">
-          Paste your API key
+          {t('onboarding.paste.title')}
         </h2>
         <p className="text-[var(--text-base)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
-          Auto-detects your provider. Click <strong>Test</strong> to verify the key and endpoint
-          before continuing. Your key is encrypted with the OS keychain.
+          {t('onboarding.paste.description')}
         </p>
       </div>
 
@@ -293,14 +295,14 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
-          Preset
+          {t('onboarding.paste.preset.label')}
         </span>
         <select
           value={selectedPresetId}
           onChange={(e) => handlePresetChange(e.target.value)}
           className="w-full h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)] appearance-none cursor-pointer"
         >
-          <option value="">-- choose a preset --</option>
+          <option value="">{t('onboarding.paste.preset.placeholder')}</option>
           {PROXY_PRESETS.map((preset) => (
             <option key={preset.id} value={preset.id}>
               {preset.label}
@@ -309,8 +311,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           ))}
         </select>
         <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
-          Not sure which to pick? Choose OpenAI Official for the official endpoint, or pick by relay
-          name.
+          {t('onboarding.paste.preset.hint')}
         </span>
       </label>
 
@@ -320,7 +321,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
-          API key
+          {t('onboarding.paste.apiKey.label')}
         </span>
         <div className="relative">
           <input
@@ -336,7 +337,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         </div>
       </label>
 
-      <DetectLine state={detectState} helpUrl={helpUrl} />
+      <DetectLine state={detectState} helpUrl={helpUrl} t={t} />
 
       {/* Advanced: custom base URL */}
       <details
@@ -348,14 +349,14 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           className="cursor-pointer select-none text-[var(--text-xs)] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
-          Advanced — custom base URL (proxy / relay)
+          {t('onboarding.paste.advanced.toggle')}
         </summary>
         <label className="flex flex-col gap-2 mt-3">
           <span
             className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium"
             style={{ fontFamily: 'var(--font-mono)' }}
           >
-            Base URL
+            {t('onboarding.paste.baseUrl.label')}
           </span>
           <input
             type="url"
@@ -371,8 +372,7 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
             className="w-full h-[var(--size-control-md)] px-[var(--space-3)] rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
           />
           <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]">
-            Override the default endpoint for your provider. Useful for relay services and
-            self-hosted proxies. Leave empty to use the official endpoint.
+            {t('onboarding.paste.advanced.description')}
           </span>
         </label>
       </details>
@@ -394,13 +394,15 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
           ) : (
             <Wifi className="w-4 h-4" />
           )}
-          {connCheck.status === 'testing' ? 'Testing...' : 'Test'}
+          {connCheck.status === 'testing'
+            ? t('onboarding.paste.connectionTest.testing')
+            : t('onboarding.paste.connectionTest.button')}
         </button>
 
         {connCheck.status === 'ok' && (
           <span className="text-[var(--text-sm)] text-[var(--color-success)] flex items-center gap-2">
             <CheckCircle2 className="w-4 h-4 shrink-0" />
-            Connected — key and endpoint verified
+            {t('onboarding.paste.connectionTest.okVerified')}
           </span>
         )}
         {connCheck.status === 'failed' && (
@@ -411,23 +413,23 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
         )}
         {connCheck.status === 'idle' && detectedProvider !== null && (
           <span className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
-            Run Test to verify your key and connection before continuing.
+            {t('onboarding.paste.connectionTest.idleHint')}
           </span>
         )}
       </div>
 
       <div className="flex justify-between gap-2 pt-2">
         <Button type="button" variant="ghost" onClick={onBack}>
-          Back
+          {t('onboarding.paste.back')}
         </Button>
         <Button
           type="button"
           variant="primary"
           onClick={handleContinue}
           disabled={continueDisabled}
-          title={continueDisabled ? 'Run Test to verify your connection first' : undefined}
+          title={continueDisabled ? t('onboarding.paste.connectionTest.runFirst') : undefined}
         >
-          Continue
+          {t('onboarding.paste.continue')}
         </Button>
       </div>
     </div>
@@ -441,13 +443,14 @@ export function PasteKey({ onValidated, onBack }: PasteKeyProps) {
 interface DetectLineProps {
   state: DetectState;
   helpUrl: string | null;
+  t: (key: string, options?: Record<string, unknown>) => string;
 }
 
-function DetectLine({ state, helpUrl }: DetectLineProps) {
+function DetectLine({ state, helpUrl, t }: DetectLineProps) {
   if (state.kind === 'idle') {
     return (
       <p className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
-        Paste a key above — provider is auto-detected from the prefix.
+        {t('onboarding.paste.statusIdle')}
       </p>
     );
   }
@@ -455,7 +458,7 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
     return (
       <div className="text-[var(--text-sm)] text-[var(--color-text-secondary)] flex items-center gap-2">
         <Loader2 className="w-4 h-4 animate-spin" />
-        <span>Detecting provider...</span>
+        <span>{t('onboarding.paste.statusDetecting')}</span>
       </div>
     );
   }
@@ -464,8 +467,9 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
       <div className="text-[var(--text-sm)] text-[var(--color-text-secondary)] flex items-center gap-2">
         <CheckCircle2 className="w-4 h-4 text-[var(--color-success)] shrink-0" />
         <span>
-          Recognized: <strong>{PROVIDER_SHORTLIST[state.provider].label}</strong> — click Test to
-          verify
+          {t('onboarding.paste.statusDetected', {
+            provider: PROVIDER_SHORTLIST[state.provider].label,
+          })}
         </span>
         {helpUrl !== null ? (
           <a
@@ -474,7 +478,7 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
             rel="noreferrer"
             className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-accent)] hover:underline ml-1"
           >
-            Get key <ExternalLink className="w-3 h-3" />
+            {t('onboarding.paste.getKey')} <ExternalLink className="w-3 h-3" />
           </a>
         ) : null}
       </div>
@@ -484,10 +488,7 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
     return (
       <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
         <AlertCircle className="w-4 h-4 shrink-0" />
-        <span>
-          Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or-
-          (OpenRouter).
-        </span>
+        <span>{t('onboarding.paste.errors.unsupported')}</span>
       </div>
     );
   }
@@ -496,8 +497,7 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
       <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
         <AlertCircle className="w-4 h-4 shrink-0" />
         <span>
-          Provider detection failed (main process unreachable): {state.message}. Restart the app and
-          try again.
+          {t('onboarding.paste.errors.detectIpc', { message: state.message })}
         </span>
       </div>
     );
@@ -506,8 +506,7 @@ function DetectLine({ state, helpUrl }: DetectLineProps) {
     <div className="text-[var(--text-sm)] text-[var(--color-error)] flex items-center gap-2">
       <AlertCircle className="w-4 h-4 shrink-0" />
       <span>
-        Provider detection failed (network error): {state.message}. Check your connection and try
-        again.
+        {t('onboarding.paste.errors.detectNetwork', { message: state.message })}
       </span>
     </div>
   );

--- a/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
+++ b/apps/desktop/src/renderer/src/onboarding/Welcome.tsx
@@ -1,3 +1,4 @@
+import { useT } from '@open-codesign/i18n';
 import { PROVIDER_SHORTLIST, type SupportedOnboardingProvider } from '@open-codesign/shared';
 import { ArrowRight, ExternalLink, KeyRound, Rocket, Server } from 'lucide-react';
 
@@ -8,35 +9,37 @@ interface WelcomeProps {
 }
 
 export function Welcome({ onPickKey, onPickFreeTier, ollamaDetected }: WelcomeProps) {
+  const t = useT();
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
         <h1 className="text-[24px] font-semibold text-[var(--color-text-primary)] tracking-[-0.01em] leading-[1.2]">
-          Design with any model.
+          {t('onboarding.welcome.title')}
         </h1>
         <p className="text-[14px] text-[var(--color-text-secondary)] leading-[1.55]">
-          Pick how you want to power your designs. You can change this later in Settings.
+          {t('onboarding.welcome.subtitle')}
         </p>
       </div>
 
       <div className="flex flex-col gap-3">
         <PathButton
           icon={<Rocket className="w-[18px] h-[18px]" />}
-          title="Try free now"
-          subtitle="OpenRouter free tier - paste an OpenRouter key, then start with openrouter/free or type any model ID."
+          title={t('onboarding.welcome.tryFree')}
+          subtitle={t('onboarding.welcome.tryFreeSubtitle')}
           onClick={onPickFreeTier}
         />
         <PathButton
           icon={<KeyRound className="w-[18px] h-[18px]" />}
-          title="Use my API key"
-          subtitle="Anthropic, OpenAI, or OpenRouter. Auto-detected from the key prefix."
+          title={t('onboarding.welcome.useKey')}
+          subtitle={t('onboarding.welcome.useKeySubtitle')}
           onClick={onPickKey}
         />
         {ollamaDetected ? (
           <PathButton
             icon={<Server className="w-[18px] h-[18px]" />}
-            title="Use local model (Ollama detected)"
-            subtitle="Coming in v0.2 - Ollama integration is on the roadmap."
+            title={t('onboarding.welcome.useOllama')}
+            subtitle={t('onboarding.welcome.useOllamaSubtitle')}
             disabled
           />
         ) : null}
@@ -47,7 +50,7 @@ export function Welcome({ onPickKey, onPickFreeTier, ollamaDetected }: WelcomePr
           className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-text-muted)] font-medium"
           style={{ fontFamily: 'var(--font-mono)' }}
         >
-          Where to get a key
+          {t('onboarding.welcome.whereToGetKey')}
         </span>
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           {(

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -92,3 +92,55 @@ describe('initI18n + setLocale (live switching)', () => {
     expect(i18n.t('common.send')).toBe('Send');
   });
 });
+
+describe('onboarding i18n keys (Welcome / PasteKey / ChooseModel)', () => {
+  it('returns correct English strings for all onboarding screens', async () => {
+    const { i18n } = await import('./index');
+    await initI18n('en');
+
+    // Welcome
+    expect(i18n.t('onboarding.welcome.title')).toBe('Design with any model.');
+    expect(i18n.t('onboarding.welcome.tryFree')).toBe('Try free now');
+    expect(i18n.t('onboarding.welcome.useKey')).toBe('Use my API key');
+    expect(i18n.t('onboarding.welcome.whereToGetKey')).toBe('Where to get a key');
+
+    // PasteKey
+    expect(i18n.t('onboarding.paste.title')).toBe('Paste your API key');
+    expect(i18n.t('onboarding.paste.back')).toBe('Back');
+    expect(i18n.t('onboarding.paste.continue')).toBe('Continue');
+    expect(i18n.t('onboarding.paste.connectionTest.button')).toBe('Test');
+    expect(i18n.t('onboarding.paste.connectionTest.ok')).toBe('Connected');
+
+    // ChooseModel
+    expect(i18n.t('onboarding.choose.title')).toBe('Pick default models');
+    expect(i18n.t('onboarding.choose.finish')).toBe('Finish');
+    expect(i18n.t('onboarding.choose.back')).toBe('Back');
+  });
+
+  it('switches all onboarding strings to Chinese when locale is zh-CN', async () => {
+    const { i18n } = await import('./index');
+    await initI18n('en');
+    await setLocale('zh-CN');
+
+    // Welcome
+    expect(i18n.t('onboarding.welcome.title')).toBe('选择你的设计模型。');
+    expect(i18n.t('onboarding.welcome.tryFree')).toBe('免费试用');
+    expect(i18n.t('onboarding.welcome.useKey')).toBe('使用我的 API Key');
+    expect(i18n.t('onboarding.welcome.whereToGetKey')).toBe('在哪里获取 Key');
+
+    // PasteKey
+    expect(i18n.t('onboarding.paste.title')).toBe('粘贴你的 API Key');
+    expect(i18n.t('onboarding.paste.back')).toBe('返回');
+    expect(i18n.t('onboarding.paste.continue')).toBe('继续');
+    expect(i18n.t('onboarding.paste.connectionTest.button')).toBe('测试连通');
+    expect(i18n.t('onboarding.paste.connectionTest.ok')).toBe('连接成功');
+
+    // ChooseModel
+    expect(i18n.t('onboarding.choose.title')).toBe('选择默认模型');
+    expect(i18n.t('onboarding.choose.finish')).toBe('完成设置');
+    expect(i18n.t('onboarding.choose.back')).toBe('返回');
+
+    // Reset to en for other tests
+    await setLocale('en');
+  });
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -13,6 +13,7 @@
  */
 
 import i18next from 'i18next';
+import { useCallback } from 'react';
 import { initReactI18next, useTranslation } from 'react-i18next';
 import en from './locales/en.json';
 import zhCN from './locales/zh-CN.json';
@@ -104,8 +105,13 @@ export function getCurrentLocale(): Locale {
 }
 
 export function useT(): (key: string, options?: Record<string, unknown>) => string {
-  const { t } = useTranslation();
-  return (key, options) => t(key, options ?? {}) as string;
+  const { t, i18n } = useTranslation();
+  // Memoize keyed on the active language so that `useEffect` dependency
+  // arrays holding this function only re-run when the locale actually
+  // changes, not on every render (react-i18next's `t` identity is not
+  // stable across renders).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identity must track locale, not `t`.
+  return useCallback((key, options) => t(key, options ?? {}) as string, [i18n.language]);
 }
 
 export { i18next as i18n };

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -83,53 +83,93 @@
   },
   "onboarding": {
     "welcome": {
-      "title": "Welcome to open-codesign",
-      "subtitle": "Turn natural-language prompts into design artifacts. Pick how you want to start.",
-      "tryFree": "Try a free model",
+      "title": "Design with any model.",
+      "subtitle": "Pick how you want to power your designs. You can change this later in Settings.",
+      "tryFree": "Try free now",
+      "tryFreeSubtitle": "OpenRouter free tier - paste an OpenRouter key, then start with openrouter/free or type any model ID.",
       "useKey": "Use my API key",
-      "useOllama": "Use a local model (Ollama)"
+      "useKeySubtitle": "Anthropic, OpenAI, or OpenRouter. Auto-detected from the key prefix.",
+      "useOllama": "Use local model (Ollama detected)",
+      "useOllamaSubtitle": "Coming in v0.2 - Ollama integration is on the roadmap.",
+      "whereToGetKey": "Where to get a key"
     },
     "paste": {
       "title": "Paste your API key",
+      "description": "Auto-detects your provider. Click Test to verify the key and endpoint before continuing. Your key is encrypted with the OS keychain.",
       "placeholder": "sk-\u2026",
       "recognized": "Detected provider: {{provider}}",
       "connected_one": "Connected {{count}} model",
       "connected_other": "Connected {{count}} models",
-      "howToGet": "How do I get a key?",
+      "howToGet": "How to get a key",
+      "getKey": "Get key",
+      "statusIdle": "Paste a key above — provider is auto-detected from the prefix.",
+      "statusDetecting": "Detecting provider...",
+      "statusValidating": "Recognized: {{provider}} — validating...",
+      "statusDetected": "Recognized: {{provider}} — click Test to verify",
+      "statusOk": "Recognized: {{provider}} — Connected ({{count}} models)",
       "errors": {
-        "401": "That key was rejected. Check it in your provider dashboard.",
+        "401": "API key invalid or unauthorized. Check it in your provider dashboard.",
         "402": "Your account has no credit. Top up and retry.",
         "429": "Rate limited. Wait a moment and try again.",
-        "network": "Network error reaching the provider. Check your connection."
+        "network": "Cannot reach base URL. Check domain/port/network.",
+        "unsupported": "Unrecognized key prefix. Supported: sk-ant- (Anthropic), sk- (OpenAI), sk-or- (OpenRouter).",
+        "notSupportedProvider": "{{provider}} is not supported in v0.1. Use Anthropic, OpenAI, or OpenRouter.",
+        "rendererDisconnected": "Renderer is not connected to the main process.",
+        "detectIpc": "Provider detection failed (main process unreachable): {{message}}. Restart the app and try again.",
+        "detectNetwork": "Provider detection failed (network error): {{message}}. Check your connection and try again."
       },
       "advanced": {
+        "toggle": "Advanced — custom base URL (proxy / relay)",
         "title": "Advanced — custom base URL",
-        "description": "If you use a proxy or relay, paste the full base URL (must include /v1)."
+        "description": "Override the default endpoint for your provider. Useful for relay services and self-hosted proxies. Leave empty to use the official endpoint."
       },
       "preset": {
         "label": "Preset",
-        "hint": "Not sure which to pick? Choose the first one for OpenAI official, or pick by relay name.",
+        "placeholder": "-- choose a preset --",
+        "hint": "Not sure which to pick? Choose OpenAI Official for the official endpoint, or pick by relay name.",
         "custom": "Custom"
+      },
+      "apiKey": {
+        "label": "API key"
+      },
+      "baseUrl": {
+        "label": "Base URL"
       },
       "connectionTest": {
         "button": "Test",
         "testing": "Testing...",
         "ok": "Connected",
+        "okVerified": "Connected — key and endpoint verified",
+        "idleHint": "Run Test to verify your key and connection before continuing.",
+        "runFirst": "Run Test to verify your connection first",
         "errors": {
           "401": "API key invalid or unauthorized.",
           "404": "Base URL path wrong. Try adding /v1 suffix (e.g. https://your-host/v1).",
           "ECONNREFUSED": "Cannot reach base URL. Check domain/port/network.",
           "NETWORK": "Network error. Check your connection.",
-          "PARSE": "Unexpected response format."
+          "PARSE": "Unexpected response. View logs at ~/Library/Logs/open-codesign/main.log",
+          "IPC_BAD_INPUT": "Invalid input sent to connection test. Check provider / API key / base URL fields."
         }
-      }
+      },
+      "back": "Back",
+      "continue": "Continue"
     },
     "choose": {
-      "title": "Pick a default model",
-      "primary": "Primary",
-      "fast": "Fast",
+      "title": "Pick default models",
+      "description": "Start with a recommendation or enter any provider-specific model ID. You can switch these per design later.",
+      "primary": "Primary design model",
+      "fast": "Fast completion model",
+      "primaryHint": "Used for full design generation.",
+      "fastHint": "Used for quick edits and inline tweaks.",
+      "primaryHintFree": "Free path starts on openrouter/free, but you can enter any OpenRouter model ID.",
+      "fastHintFree": "Keep openrouter/free for lowest cost, or replace it with a faster custom choice.",
+      "customBaseUrl": "Custom base URL: {{url}}",
+      "costNote": "Estimated cost varies by provider, chosen model, and prompt length.",
+      "costNoteFree": "OpenRouter free routing availability can change. If a free route is unavailable, type another model ID here.",
       "estimatedCost": "Estimated cost: {{amount}}",
-      "start": "Start designing"
+      "back": "Back",
+      "saving": "Saving...",
+      "finish": "Finish"
     }
   },
   "topbar": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -83,53 +83,93 @@
   },
   "onboarding": {
     "welcome": {
-      "title": "欢迎来到 open-codesign",
-      "subtitle": "用一句话生成可交互的设计稿。挑一种方式开始吧。",
-      "tryFree": "试用免费模型",
+      "title": "选择你的设计模型。",
+      "subtitle": "选一种方式来驱动你的设计。之后可以在设置里随时更改。",
+      "tryFree": "免费试用",
+      "tryFreeSubtitle": "使用 OpenRouter 免费额度 — 粘贴一个 OpenRouter Key，然后选 openrouter/free 或输入任意模型 ID。",
       "useKey": "使用我的 API Key",
-      "useOllama": "用本地模型（Ollama）"
+      "useKeySubtitle": "支持 Anthropic、OpenAI 或 OpenRouter，自动识别 Key 前缀。",
+      "useOllama": "使用本地模型（已检测到 Ollama）",
+      "useOllamaSubtitle": "将在 v0.2 中推出 — Ollama 集成已列入路线图。",
+      "whereToGetKey": "在哪里获取 Key"
     },
     "paste": {
       "title": "粘贴你的 API Key",
+      "description": "自动识别提供商。点击\"测试连通\"验证 Key 与端点后再继续。你的 Key 会使用系统钥匙串加密存储。",
       "placeholder": "sk-\u2026",
       "recognized": "已识别提供商：{{provider}}",
       "connected_one": "已连接 {{count}} 个模型",
       "connected_other": "已连接 {{count}} 个模型",
       "howToGet": "怎么获取 API Key？",
+      "getKey": "获取 Key",
+      "statusIdle": "在上方粘贴 Key — 系统会根据前缀自动识别提供商。",
+      "statusDetecting": "正在识别提供商...",
+      "statusValidating": "已识别：{{provider}} — 验证中...",
+      "statusDetected": "已识别：{{provider}} — 点击\"测试连通\"验证",
+      "statusOk": "已识别：{{provider}} — 连接成功（{{count}} 个模型）",
       "errors": {
         "401": "Key 被拒绝了。去提供商后台核对一下。",
         "402": "账户余额不足，充值后重试。",
         "429": "请求被限流，稍等片刻再试。",
-        "network": "连接提供商失败，检查一下网络。"
+        "network": "无法连接到 Base URL，检查域名 / 端口 / 网络。",
+        "unsupported": "无法识别的 Key 前缀。支持：sk-ant-（Anthropic）、sk-（OpenAI）、sk-or-（OpenRouter）。",
+        "notSupportedProvider": "{{provider}} 在 v0.1 中暂不支持，请使用 Anthropic、OpenAI 或 OpenRouter。",
+        "rendererDisconnected": "渲染进程未连接到主进程。",
+        "detectIpc": "提供商识别失败（无法连接主进程）：{{message}}。请重启应用后重试。",
+        "detectNetwork": "提供商识别失败（网络错误）：{{message}}。请检查网络后重试。"
       },
       "advanced": {
+        "toggle": "高级 — 自定义 Base URL（代理 / 中转）",
         "title": "高级 — 自定义 Base URL",
-        "description": "如果使用代理或中转站，请粘贴完整的 Base URL（必须包含 /v1）。"
+        "description": "覆盖提供商的默认端点。适用于中转服务和自托管代理。留空则使用官方端点。"
       },
       "preset": {
         "label": "预设",
-        "hint": "不知道选哪个？用 OpenAI 官方就选第一个，用中转代理选对应名字。",
+        "placeholder": "-- 选择一个预设 --",
+        "hint": "不知道选哪个？官方端点选 OpenAI Official，用中转代理选对应名字。",
         "custom": "自定义"
+      },
+      "apiKey": {
+        "label": "API Key"
+      },
+      "baseUrl": {
+        "label": "Base URL"
       },
       "connectionTest": {
         "button": "测试连通",
         "testing": "测试中...",
         "ok": "连接成功",
+        "okVerified": "连接成功 — Key 与端点已验证",
+        "idleHint": "继续之前请点击\"测试连通\"验证 Key 与连接。",
+        "runFirst": "请先点击\"测试连通\"验证连接",
         "errors": {
           "401": "API key 错误或权限不足。",
           "404": "Base URL 路径错误。试试加 /v1 后缀（如 https://your-host/v1）。",
           "ECONNREFUSED": "无法连接到 Base URL，检查域名 / 端口 / 网络。",
           "NETWORK": "网络错误，检查你的网络连接。",
-          "PARSE": "响应格式异常。"
+          "PARSE": "响应格式异常。请查看日志 ~/Library/Logs/open-codesign/main.log",
+          "IPC_BAD_INPUT": "传给连接测试的参数不合法，请检查提供商 / API Key / Base URL。"
         }
-      }
+      },
+      "back": "返回",
+      "continue": "继续"
     },
     "choose": {
-      "title": "选一个默认模型",
-      "primary": "主力",
-      "fast": "快速",
+      "title": "选择默认模型",
+      "description": "从推荐列表选一个，或直接输入提供商的模型 ID。之后可以按设计切换。",
+      "primary": "主力设计模型",
+      "fast": "快速补全模型",
+      "primaryHint": "用于完整设计生成。",
+      "fastHint": "用于快速编辑和局部调整。",
+      "primaryHintFree": "免费路径从 openrouter/free 开始，你也可以输入任意 OpenRouter 模型 ID。",
+      "fastHintFree": "保留 openrouter/free 以控制成本，或换成更快的自选模型。",
+      "customBaseUrl": "自定义 Base URL：{{url}}",
+      "costNote": "预计费用因提供商、模型和提示词长度而异。",
+      "costNoteFree": "OpenRouter 免费路由随时可能变动，如果免费路由不可用，请在此输入其他模型 ID。",
       "estimatedCost": "预计费用：{{amount}}",
-      "start": "开始设计"
+      "back": "返回",
+      "saving": "保存中...",
+      "finish": "完成设置"
     }
   },
   "topbar": {


### PR DESCRIPTION
## Summary

- All three onboarding screens (Welcome / PasteKey / ChooseModel) now use `useT()` — they were previously 100% hardcoded English with no i18n wiring at all
- All user-visible strings have correct i18n keys in both `en` and `zh-CN` locales (~30 net-new keys added, old placeholder stubs replaced with accurate copy)
- `getErrorHint` and `getValidationErrorMessage` in PasteKey now accept `t()` so translated error messages are returned at render time, not at module load
- Onboarding re-renders immediately when the `LanguageToggle` (already present in the onboarding header) is clicked

## Compatibility, upgradeability, no bloat, elegance

- Compatibility ✅ — no API or storage schema changes
- Upgradeability ✅ — only additive JSON key additions; no renames
- No bloat ✅ — zero new dependencies
- Elegance ✅ — follows the exact same `useT()` hook pattern used in every other component

## i18n audit findings

Hardcoded strings fixed in this PR:
- `Welcome.tsx`: title, subtitle, 3x PathButton title+subtitle pairs, "where to get a key" label
- `PasteKey.tsx`: title, description, preset label/placeholder/hint, API key label, base URL label, advanced toggle/description, all status messages (idle/detecting/validating/ok), all error messages, connection-test button/states, back/continue buttons
- `ChooseModel.tsx`: title, description, primary/fast model picker labels and hints (both standard and free-tier variants), custom base URL note, cost notes, back/saving/finish buttons

Out of scope (pre-existing, no change): `Settings.tsx` has hardcoded `<SectionTitle>` strings but no `useT()` at all — tracked separately.

## Test plan

- [ ] Launch app → onboarding shows English by default
- [ ] Click the language toggle (EN / ZH globe icon in onboarding header) → all visible text switches to Chinese immediately (no page reload)
- [ ] Click toggle back → reverts to English
- [ ] Complete onboarding → app opens normally
- [ ] `pnpm -r test` → all 11 i18n tests pass, including 2 new onboarding locale-switching tests