### PR TITLE
feat(core): provider-aware errors + named-step logging in generate

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,7 @@
 import { stat } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { applyComment, generate } from '@open-codesign/core';
+import { type CoreLogger, applyComment, generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
 import {
   ApplyCommentPayload,
@@ -10,6 +10,7 @@ import {
   CodesignError,
   GeneratePayload,
   GeneratePayloadV1,
+  isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
@@ -68,6 +69,14 @@ function createWindow(): void {
 
 function registerIpcHandlers(): void {
   const logIpc = getLogger('main:ipc');
+
+  /** Adapter so `core` can log step events through the same scoped electron-log
+   * sink the IPC handler uses. Keeps a single timeline per generation in the
+   * log file without forcing `core` to depend on electron-log. */
+  const coreLoggerFor = (id: string): CoreLogger => ({
+    info: (event, data) => logIpc.info(event, { id, ...(data ?? {}) }),
+    error: (event, data) => logIpc.error(event, { id, ...(data ?? {}) }),
+  });
 
   /** In-flight requests: generationId → AbortController */
   const inFlight = new Map<string, AbortController>();
@@ -134,11 +143,43 @@ function registerIpcHandlers(): void {
     const controller = new AbortController();
     const id = payload.generationId;
     inFlight.set(id, controller);
+    const coreLogger = coreLoggerFor(id);
+    const stepCtx = { id, provider: payload.model.provider, modelId: payload.model.modelId };
 
+    coreLogger.info('[generate] step=load_config');
+    const loadStart = Date.now();
     const apiKey = getApiKeyForProvider(payload.model.provider);
     const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
     const baseUrl = payload.baseUrl ?? storedBaseUrl;
     const cfg = getCachedConfig();
+    coreLogger.info('[generate] step=load_config.ok', {
+      ms: Date.now() - loadStart,
+      hasApiKey: apiKey.length > 0,
+      baseUrl: baseUrl ?? '<default>',
+    });
+
+    coreLogger.info('[generate] step=validate_provider', stepCtx);
+    if (apiKey.length === 0) {
+      coreLogger.error('[generate] step=validate_provider.fail', {
+        provider: payload.model.provider,
+        reason: 'missing_api_key',
+      });
+      inFlight.delete(id);
+      throw new CodesignError(
+        `No API key configured for provider "${payload.model.provider}". Open Settings to add one.`,
+        'PROVIDER_AUTH_MISSING',
+      );
+    }
+    if (!isSupportedOnboardingProvider(payload.model.provider)) {
+      // Non-shortlist providers still work (any ProviderId is accepted by the
+      // payload schema), just warn so the log timeline shows we noticed.
+      coreLogger.info('[generate] step=validate_provider.warn', {
+        provider: payload.model.provider,
+        reason: 'not_in_onboarding_shortlist',
+      });
+    }
+    coreLogger.info('[generate] step=validate_provider.ok', { provider: payload.model.provider });
+
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,
@@ -169,6 +210,7 @@ function registerIpcHandlers(): void {
         designSystem: promptContext.designSystem ?? null,
         ...(baseUrl !== undefined ? { baseUrl } : {}),
         signal: controller.signal,
+        logger: coreLogger,
       });
       logIpc.info('generate.ok', {
         id,

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,95 @@
+import { CodesignError } from '@open-codesign/shared';
+import { describe, expect, it } from 'vitest';
+import { remapProviderError, rewriteUpstreamMessage } from './errors';
+
+const LEAKED =
+  'Incorrect API key provided: sk-AAA. You can find your API key at https://platform.openai.com/account/api-keys.';
+
+function httpError(status: number, message: string): Error & { status: number } {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
+describe('rewriteUpstreamMessage', () => {
+  it('keeps openai URL when active provider is openai', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'openai', 401);
+    expect(result.rewritten).toBe(false);
+    expect(result.message).toContain('platform.openai.com/account/api-keys');
+  });
+
+  it('rewrites leaked openai URL to anthropic billing URL', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'anthropic', 401);
+    expect(result.rewritten).toBe(true);
+    expect(result.message).not.toContain('openai.com');
+    expect(result.message).toContain('console.anthropic.com/settings/keys');
+  });
+
+  it('rewrites leaked openai URL to openrouter URL', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'openrouter', 401);
+    expect(result.message).toContain('openrouter.ai/settings/keys');
+  });
+
+  it('rewrites to deepseek URL even though it is not in the typed enum', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'deepseek', 401);
+    expect(result.message).toContain('platform.deepseek.com/api_keys');
+  });
+
+  it('strips URL and adds generic hint for unknown providers', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'mystery-llm', 401);
+    expect(result.rewritten).toBe(true);
+    expect(result.message).not.toContain('openai.com');
+    expect(result.message).toContain("Check your provider's API key settings");
+  });
+
+  it('does not rewrite 5xx errors', () => {
+    const result = rewriteUpstreamMessage(LEAKED, 'anthropic', 503);
+    expect(result.rewritten).toBe(false);
+  });
+
+  it('does not rewrite when no openai URL is present', () => {
+    const result = rewriteUpstreamMessage('Bad request: model not found', 'anthropic', 400);
+    expect(result.rewritten).toBe(false);
+  });
+});
+
+describe('remapProviderError', () => {
+  it('passes openai 401 through verbatim', () => {
+    const err = httpError(401, LEAKED);
+    const out = remapProviderError(err, 'openai');
+    expect(out).toBe(err);
+  });
+
+  it('rewrites anthropic 401 with leaked openai URL into a CodesignError', () => {
+    const err = httpError(401, LEAKED);
+    const out = remapProviderError(err, 'anthropic');
+    expect(out).toBeInstanceOf(CodesignError);
+    expect((out as CodesignError).message).toContain('console.anthropic.com/settings/keys');
+    expect((out as CodesignError).message).not.toContain('openai.com');
+    expect((out as CodesignError).code).toBe('PROVIDER_HTTP_4XX');
+  });
+
+  it('strips the URL when provider is unknown', () => {
+    const err = httpError(401, LEAKED);
+    const out = remapProviderError(err, 'mystery-llm');
+    expect(out).toBeInstanceOf(CodesignError);
+    expect((out as CodesignError).message).not.toContain('openai.com');
+    expect((out as CodesignError).message).toContain("Check your provider's API key settings");
+  });
+
+  it('passes 5xx errors through unchanged', () => {
+    const err = httpError(503, 'upstream unavailable');
+    const out = remapProviderError(err, 'anthropic');
+    expect(out).toBe(err);
+  });
+
+  it('extracts status code from CodesignError messages that embed it', () => {
+    const err = new CodesignError(
+      'HTTP 401 — see https://platform.openai.com/account/api-keys',
+      'PROVIDER_ERROR',
+    );
+    const out = remapProviderError(err, 'anthropic');
+    expect(out).toBeInstanceOf(CodesignError);
+    expect((out as CodesignError).message).toContain('console.anthropic.com/settings/keys');
+  });
+});

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,110 @@
+/**
+ * Provider-aware error remapping.
+ *
+ * Upstream SDKs (pi-ai, OpenAI client, etc.) embed an OpenAI key-help URL in
+ * 4xx error messages — even when the *active* provider is something else
+ * (e.g. DeepSeek behind an OpenAI-compatible base URL, or OpenRouter). That
+ * URL is misleading: clicking it sends the user to the wrong dashboard.
+ *
+ * We rewrite leaked openai.com URLs in 4xx upstream messages to the active
+ * provider's billing/key-help URL. Unknown providers get the URL stripped and
+ * a generic hint appended.
+ *
+ * This runs only on 4xx errors. 5xx and network errors pass through verbatim
+ * because their messages are usually already provider-neutral and the retry
+ * layer logs them with `reason`.
+ */
+
+import type { ProviderId } from '@open-codesign/shared';
+import { CodesignError } from '@open-codesign/shared';
+
+export const PROVIDER_KEY_HELP_URL: Partial<Record<ProviderId, string>> = {
+  openai: 'https://platform.openai.com/account/api-keys',
+  anthropic: 'https://console.anthropic.com/settings/keys',
+  openrouter: 'https://openrouter.ai/settings/keys',
+  google: 'https://aistudio.google.com/app/apikey',
+};
+
+// deepseek is not in the ProviderId enum yet but commonly used via openai-
+// compatible base URL — keyed by string so callers passing a free-form string
+// still get the rewrite. Kept separate so the typed map stays exhaustive-checked.
+const EXTRA_KEY_HELP_URL: Record<string, string> = {
+  deepseek: 'https://platform.deepseek.com/api_keys',
+};
+
+const OPENAI_URL_PATTERN = /https?:\/\/(?:platform\.openai\.com|openai\.com)\/[^\s)<>"']*/gi;
+const GENERIC_HINT = "Check your provider's API key settings.";
+
+function statusFromError(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const candidates = [
+    (err as { status?: unknown }).status,
+    (err as { statusCode?: unknown }).statusCode,
+    (err as { response?: { status?: unknown } }).response?.status,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isFinite(c)) return c;
+  }
+  if (err instanceof Error) {
+    const m = /\b(\d{3})\b/.exec(err.message);
+    if (m?.[1]) {
+      const n = Number(m[1]);
+      if (n >= 400 && n < 600) return n;
+    }
+  }
+  return undefined;
+}
+
+function lookupKeyHelpUrl(provider: string | undefined): string | undefined {
+  if (!provider) return undefined;
+  const typed = PROVIDER_KEY_HELP_URL[provider as ProviderId];
+  if (typed) return typed;
+  return EXTRA_KEY_HELP_URL[provider];
+}
+
+export interface RewriteResult {
+  message: string;
+  rewritten: boolean;
+  status?: number;
+}
+
+export function rewriteUpstreamMessage(
+  rawMessage: string,
+  provider: string | undefined,
+  status: number | undefined,
+): RewriteResult {
+  const result: RewriteResult = { message: rawMessage, rewritten: false };
+  if (status !== undefined) result.status = status;
+  if (status === undefined || status < 400 || status >= 500) return result;
+  if (!OPENAI_URL_PATTERN.test(rawMessage)) {
+    OPENAI_URL_PATTERN.lastIndex = 0;
+    return result;
+  }
+  OPENAI_URL_PATTERN.lastIndex = 0;
+  const target = lookupKeyHelpUrl(provider);
+  if (provider === 'openai') return result;
+  if (target) {
+    result.message = rawMessage.replace(OPENAI_URL_PATTERN, target);
+  } else {
+    const stripped = rawMessage.replace(OPENAI_URL_PATTERN, '').replace(/\s+/g, ' ').trim();
+    result.message = `${stripped} ${GENERIC_HINT}`.trim();
+  }
+  result.rewritten = true;
+  return result;
+}
+
+/**
+ * Wrap an upstream error so its message is safe to surface to the user. Only
+ * 4xx errors are rewritten — everything else is rethrown unchanged so the
+ * retry/network layer keeps its own taxonomy.
+ */
+export function remapProviderError(err: unknown, provider: string | undefined): unknown {
+  if (!(err instanceof Error)) return err;
+  if (err instanceof CodesignError && err.code === 'PROVIDER_ABORTED') return err;
+  const status = statusFromError(err);
+  if (status === undefined || status < 400 || status >= 500) return err;
+  const { message, rewritten } = rewriteUpstreamMessage(err.message, provider, status);
+  if (!rewritten) return err;
+  const code = err instanceof CodesignError ? err.code : 'PROVIDER_HTTP_4XX';
+  return new CodesignError(message, code, { cause: err });
+}

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -228,6 +228,72 @@ describe('generate()', () => {
     expect(result.artifacts).toHaveLength(1);
   });
 
+  it('emits named-step logs in order through the injected logger', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    const events: string[] = [];
+    const logger = {
+      info: (event: string) => events.push(event),
+      error: (event: string) => events.push(`ERR:${event}`),
+    };
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+      logger,
+    });
+
+    expect(events).toEqual([
+      '[generate] step=resolve_model',
+      '[generate] step=resolve_model.ok',
+      '[generate] step=build_request',
+      '[generate] step=build_request.ok',
+      '[generate] step=send_request',
+      '[generate] step=send_request.ok',
+      '[generate] step=parse_response',
+      '[generate] step=parse_response.ok',
+    ]);
+  });
+
+  it('logs send_request.fail and rewrites leaked openai URL when provider is non-openai', async () => {
+    const upstream = Object.assign(
+      new Error('Incorrect API key. See https://platform.openai.com/account/api-keys.'),
+      {
+        status: 401,
+      },
+    );
+    completeMock.mockRejectedValueOnce(upstream);
+
+    const events: string[] = [];
+    const logger = {
+      info: (event: string) => events.push(event),
+      error: (event: string) => events.push(`ERR:${event}`),
+    };
+
+    await expect(
+      generate({
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+        logger,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('console.anthropic.com/settings/keys'),
+    });
+
+    expect(events).toContain('[generate] step=send_request');
+    expect(events).toContain('ERR:[generate] step=send_request.fail');
+    expect(events).not.toContain('[generate] step=parse_response');
+  });
+
   it('brand tokens in designSystem are placed in a user message, not the system prompt', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -474,6 +474,46 @@ describe('applyComment()', () => {
     expect(result.artifacts[0]?.content).toBe(SAMPLE_HTML);
     expect(result.message).toContain('Here is the revised HTML artifact.');
   });
+
+  it('emits named-step logs in order through the injected logger', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    const events: string[] = [];
+    const logger = {
+      info: (event: string) => events.push(event),
+      error: (event: string) => events.push(`ERR:${event}`),
+    };
+
+    await applyComment({
+      html: SAMPLE_HTML,
+      comment: 'Tighten the hero copy.',
+      selection: {
+        selector: '#hero',
+        tag: 'section',
+        outerHTML: '<section id="hero">Hi</section>',
+        rect: { top: 0, left: 0, width: 100, height: 100 },
+      },
+      model: MODEL,
+      apiKey: 'sk-test',
+      logger,
+    });
+
+    expect(events).toEqual([
+      '[apply_comment] step=resolve_model',
+      '[apply_comment] step=resolve_model.ok',
+      '[apply_comment] step=build_request',
+      '[apply_comment] step=build_request.ok',
+      '[apply_comment] step=send_request',
+      '[apply_comment] step=send_request.ok',
+      '[apply_comment] step=parse_response',
+      '[apply_comment] step=parse_response.ok',
+    ]);
+  });
 });
 
 describe('composeSystemPrompt()', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
+import type { GenerateResult } from '@open-codesign/providers';
 import { type RetryReason, complete, completeWithRetry } from '@open-codesign/providers';
 import type {
   Artifact,
@@ -8,9 +9,17 @@ import type {
   StoredDesignSystem,
 } from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
+import { remapProviderError } from './errors.js';
+import { type CoreLogger, NOOP_LOGGER } from './logger.js';
 import { type PromptComposeOptions, composeSystemPrompt } from './prompts/index.js';
 
 export type { PromptComposeOptions };
+export type { CoreLogger } from './logger.js';
+export {
+  PROVIDER_KEY_HELP_URL,
+  remapProviderError,
+  rewriteUpstreamMessage,
+} from './errors.js';
 
 export interface AttachmentContext {
   name: string;
@@ -44,6 +53,7 @@ export interface GenerateInput {
   mode?: Extract<PromptComposeOptions['mode'], 'create'> | undefined;
   signal?: AbortSignal | undefined;
   onRetry?: ((info: RetryReason) => void) | undefined;
+  logger?: CoreLogger | undefined;
 }
 
 export interface ApplyCommentInput {
@@ -58,6 +68,7 @@ export interface ApplyCommentInput {
   referenceUrl?: ReferenceUrlContext | null | undefined;
   signal?: AbortSignal | undefined;
   onRetry?: ((info: RetryReason) => void) | undefined;
+  logger?: CoreLogger | undefined;
 }
 
 export interface GenerateOutput {
@@ -80,6 +91,7 @@ interface ModelRunInput {
   signal?: AbortSignal | undefined;
   onRetry?: ((info: RetryReason) => void) | undefined;
   messages: ChatMessage[];
+  logger?: CoreLogger | undefined;
 }
 
 function createHtmlArtifact(content: string, index: number): Artifact {
@@ -238,43 +250,101 @@ function buildRevisionPrompt(input: ApplyCommentInput, contextSections: string[]
 }
 
 async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
-  const result = await completeWithRetry(
-    input.model,
-    input.messages,
-    {
-      apiKey: input.apiKey,
-      ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
-      ...(input.signal !== undefined ? { signal: input.signal } : {}),
-    },
-    {
-      ...(input.onRetry !== undefined ? { onRetry: input.onRetry } : {}),
-    },
-    complete,
-  );
+  const log = input.logger ?? NOOP_LOGGER;
+  const ctx = {
+    provider: input.model.provider,
+    modelId: input.model.modelId,
+  } as const;
 
-  const parser = createArtifactParser();
-  const collected: Collected = { text: '', artifacts: [] };
-  collect(parser.feed(result.content), collected);
-  collect(parser.flush(), collected);
-
-  if (collected.artifacts.length === 0) {
-    const fallback = extractFallbackArtifact(collected.text);
-    if (fallback.artifact) {
-      collected.artifacts.push(fallback.artifact);
-      collected.text = fallback.message;
-    }
+  log.info('[generate] step=send_request', ctx);
+  const sendStart = Date.now();
+  let result: GenerateResult;
+  try {
+    result = await completeWithRetry(
+      input.model,
+      input.messages,
+      {
+        apiKey: input.apiKey,
+        ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+        ...(input.signal !== undefined ? { signal: input.signal } : {}),
+      },
+      {
+        ...(input.onRetry !== undefined ? { onRetry: input.onRetry } : {}),
+      },
+      complete,
+    );
+  } catch (err) {
+    const remapped = remapProviderError(err, input.model.provider);
+    log.error('[generate] step=send_request.fail', {
+      ...ctx,
+      ms: Date.now() - sendStart,
+      errorClass: err instanceof Error ? err.constructor.name : typeof err,
+      status: extractStatus(err),
+      code: remapped instanceof CodesignError ? remapped.code : undefined,
+    });
+    throw remapped;
   }
+  log.info('[generate] step=send_request.ok', { ...ctx, ms: Date.now() - sendStart });
 
-  return {
-    message: collected.text.trim(),
-    artifacts: collected.artifacts,
-    inputTokens: result.inputTokens,
-    outputTokens: result.outputTokens,
-    costUsd: result.costUsd,
-  };
+  log.info('[generate] step=parse_response', ctx);
+  const parseStart = Date.now();
+  try {
+    const parser = createArtifactParser();
+    const collected: Collected = { text: '', artifacts: [] };
+    collect(parser.feed(result.content), collected);
+    collect(parser.flush(), collected);
+
+    if (collected.artifacts.length === 0) {
+      const fallback = extractFallbackArtifact(collected.text);
+      if (fallback.artifact) {
+        collected.artifacts.push(fallback.artifact);
+        collected.text = fallback.message;
+      }
+    }
+
+    log.info('[generate] step=parse_response.ok', {
+      ...ctx,
+      ms: Date.now() - parseStart,
+      artifacts: collected.artifacts.length,
+    });
+
+    return {
+      message: collected.text.trim(),
+      artifacts: collected.artifacts,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      costUsd: result.costUsd,
+    };
+  } catch (err) {
+    log.error('[generate] step=parse_response.fail', {
+      ...ctx,
+      ms: Date.now() - parseStart,
+      errorClass: err instanceof Error ? err.constructor.name : typeof err,
+    });
+    throw err;
+  }
+}
+
+function extractStatus(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const candidates = [
+    (err as { status?: unknown }).status,
+    (err as { statusCode?: unknown }).statusCode,
+    (err as { response?: { status?: unknown } }).response?.status,
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'number' && Number.isFinite(c)) return c;
+  }
+  return undefined;
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {
+  const log = input.logger ?? NOOP_LOGGER;
+  const ctx = {
+    provider: input.model.provider,
+    modelId: input.model.modelId,
+  } as const;
+
   if (!input.prompt.trim()) {
     throw new CodesignError('Prompt cannot be empty', 'INPUT_EMPTY_PROMPT');
   }
@@ -290,6 +360,15 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     );
   }
 
+  log.info('[generate] step=resolve_model', ctx);
+  const resolveStart = Date.now();
+  // Tier 1: model is already resolved by the caller (no primary/fast fallback
+  // here yet). Step exists so logs/UI can show the same name even when the
+  // logic later picks between primary/fast.
+  log.info('[generate] step=resolve_model.ok', { ...ctx, ms: Date.now() - resolveStart });
+
+  log.info('[generate] step=build_request', ctx);
+  const buildStart = Date.now();
   const messages: ChatMessage[] = [
     {
       role: 'system',
@@ -302,6 +381,11 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     ...input.history,
     { role: 'user', content: buildPrompt(input.prompt, buildContextSections(input)) },
   ];
+  log.info('[generate] step=build_request.ok', {
+    ...ctx,
+    ms: Date.now() - buildStart,
+    messages: messages.length,
+  });
 
   return runModel({
     model: input.model,
@@ -310,6 +394,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     signal: input.signal,
     onRetry: input.onRetry,
     messages,
+    logger: input.logger,
   });
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,8 @@ interface ModelRunInput {
   onRetry?: ((info: RetryReason) => void) | undefined;
   messages: ChatMessage[];
   logger?: CoreLogger | undefined;
+  /** Log step namespace, e.g. 'generate' or 'apply_comment'. Defaults to 'generate'. */
+  logScope?: string | undefined;
 }
 
 function createHtmlArtifact(content: string, index: number): Artifact {
@@ -251,12 +253,13 @@ function buildRevisionPrompt(input: ApplyCommentInput, contextSections: string[]
 
 async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
   const log = input.logger ?? NOOP_LOGGER;
+  const scope = input.logScope ?? 'generate';
   const ctx = {
     provider: input.model.provider,
     modelId: input.model.modelId,
   } as const;
 
-  log.info('[generate] step=send_request', ctx);
+  log.info(`[${scope}] step=send_request`, ctx);
   const sendStart = Date.now();
   let result: GenerateResult;
   try {
@@ -275,7 +278,7 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
     );
   } catch (err) {
     const remapped = remapProviderError(err, input.model.provider);
-    log.error('[generate] step=send_request.fail', {
+    log.error(`[${scope}] step=send_request.fail`, {
       ...ctx,
       ms: Date.now() - sendStart,
       errorClass: err instanceof Error ? err.constructor.name : typeof err,
@@ -284,9 +287,9 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
     });
     throw remapped;
   }
-  log.info('[generate] step=send_request.ok', { ...ctx, ms: Date.now() - sendStart });
+  log.info(`[${scope}] step=send_request.ok`, { ...ctx, ms: Date.now() - sendStart });
 
-  log.info('[generate] step=parse_response', ctx);
+  log.info(`[${scope}] step=parse_response`, ctx);
   const parseStart = Date.now();
   try {
     const parser = createArtifactParser();
@@ -302,7 +305,7 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
       }
     }
 
-    log.info('[generate] step=parse_response.ok', {
+    log.info(`[${scope}] step=parse_response.ok`, {
       ...ctx,
       ms: Date.now() - parseStart,
       artifacts: collected.artifacts.length,
@@ -316,7 +319,7 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
       costUsd: result.costUsd,
     };
   } catch (err) {
-    log.error('[generate] step=parse_response.fail', {
+    log.error(`[${scope}] step=parse_response.fail`, {
       ...ctx,
       ms: Date.now() - parseStart,
       errorClass: err instanceof Error ? err.constructor.name : typeof err,
@@ -399,6 +402,12 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
 }
 
 export async function applyComment(input: ApplyCommentInput): Promise<GenerateOutput> {
+  const log = input.logger ?? NOOP_LOGGER;
+  const ctx = {
+    provider: input.model.provider,
+    modelId: input.model.modelId,
+  } as const;
+
   if (!input.comment.trim()) {
     throw new CodesignError('Comment cannot be empty', 'INPUT_EMPTY_COMMENT');
   }
@@ -406,6 +415,12 @@ export async function applyComment(input: ApplyCommentInput): Promise<GenerateOu
     throw new CodesignError('Existing HTML cannot be empty', 'INPUT_EMPTY_HTML');
   }
 
+  log.info('[apply_comment] step=resolve_model', ctx);
+  const resolveStart = Date.now();
+  log.info('[apply_comment] step=resolve_model.ok', { ...ctx, ms: Date.now() - resolveStart });
+
+  log.info('[apply_comment] step=build_request', ctx);
+  const buildStart = Date.now();
   const messages: ChatMessage[] = [
     {
       role: 'system',
@@ -415,6 +430,11 @@ export async function applyComment(input: ApplyCommentInput): Promise<GenerateOu
     },
     { role: 'user', content: buildRevisionPrompt(input, buildContextSections(input)) },
   ];
+  log.info('[apply_comment] step=build_request.ok', {
+    ...ctx,
+    ms: Date.now() - buildStart,
+    messages: messages.length,
+  });
 
   return runModel({
     model: input.model,
@@ -423,5 +443,7 @@ export async function applyComment(input: ApplyCommentInput): Promise<GenerateOu
     signal: input.signal,
     onRetry: input.onRetry,
     messages,
+    logger: input.logger,
+    logScope: 'apply_comment',
   });
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal logger interface used by `generate()` and `applyComment()` to emit
+ * step-named structured events. The desktop main process injects a wrapper
+ * around its electron-log scope; tests pass a spy. Defaults to a no-op so
+ * library consumers without logging needs pay nothing.
+ *
+ * Each event uses the convention `step=<name>` plus a phase suffix:
+ *   - `[generate] step=<name>` (start, with provider+model context)
+ *   - `[generate] step=<name>.ok` (success, with timing)
+ *   - `[generate] step=<name>.fail` (error, with class + status code)
+ */
+
+export interface CoreLogger {
+  info: (event: string, data?: Record<string, unknown>) => void;
+  error: (event: string, data?: Record<string, unknown>) => void;
+}
+
+export const NOOP_LOGGER: CoreLogger = {
+  info: () => {},
+  error: () => {},
+};


### PR DESCRIPTION
Fixes runtime bug where 401/4xx errors leak OpenAI URL for non-OpenAI providers, and adds step-named structured logging so users/devs can pinpoint which generate stage failed.

## Summary
- Rewrite leaked openai.com URLs in upstream errors to the active provider's correct billing/key-help URL
- Add named-step logging (load_config / validate_provider / resolve_model / build_request / send_request / parse_response) with timing + provider/model context
- Strip URL when provider unknown

## Test plan
- [ ] vitest covering all 4 error-mapping cases
- [ ] vitest verifying step log order
- [ ] manual: trigger 401 with mismatched key/provider and confirm correct URL