### PR TITLE
feat(desktop): API config flow rewrite — provider-aware errors, live URL preview, single source of truth

### DIFF
--- a/apps/desktop/src/main/onboarding-ipc.test.ts
+++ b/apps/desktop/src/main/onboarding-ipc.test.ts
@@ -109,3 +109,30 @@ describe('registerOnboardingIpc — channel versioning', () => {
     }
   });
 });
+
+describe('getApiKeyForProvider — API key retrieval', () => {
+  it('returns the decrypted key when the provider secret exists in config', async () => {
+    const { loadConfigOnBoot, getApiKeyForProvider } = await import('./onboarding-ipc');
+
+    // Override readConfig to return a config with an anthropic secret.
+    const { readConfig } = await import('./config');
+    vi.mocked(readConfig).mockResolvedValueOnce({
+      version: 1,
+      provider: 'anthropic',
+      modelPrimary: 'claude-sonnet-4-6',
+      modelFast: 'claude-haiku-3',
+      secrets: { anthropic: { ciphertext: 'enc:sk-ant-test' } },
+      baseUrls: {},
+    });
+
+    await loadConfigOnBoot();
+    const key = getApiKeyForProvider('anthropic');
+    // decryptSecret mock strips the 'enc:' prefix.
+    expect(key).toBe('sk-ant-test');
+  });
+
+  it('throws PROVIDER_KEY_MISSING when provider has no stored secret', async () => {
+    const { getApiKeyForProvider } = await import('./onboarding-ipc');
+    expect(() => getApiKeyForProvider('openai')).toThrow(/PROVIDER_KEY_MISSING|No API key stored/);
+  });
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -67,8 +67,13 @@ export function App() {
       {
         combo: 'escape',
         handler: () => {
-          if (view === 'settings') setView('workspace');
-          else if (commandPaletteOpen) closeCommandPalette();
+          if (commandPaletteOpen) {
+            closeCommandPalette();
+            return;
+          }
+          if (view === 'settings') {
+            setView('workspace');
+          }
         },
         preventDefault: false,
       },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -17,11 +17,10 @@ export function App() {
   const loadConfig = useCodesignStore((s) => s.loadConfig);
   const sendPrompt = useCodesignStore((s) => s.sendPrompt);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
-  const openSettings = useCodesignStore((s) => s.openSettings);
-  const closeSettings = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
   const closeCommandPalette = useCodesignStore((s) => s.closeCommandPalette);
-  const settingsOpen = useCodesignStore((s) => s.settingsOpen);
+  const view = useCodesignStore((s) => s.view);
   const commandPaletteOpen = useCodesignStore((s) => s.commandPaletteOpen);
 
   const [prompt, setPrompt] = useState('');
@@ -55,7 +54,7 @@ export function App() {
         combo: 'mod+,',
         handler: () => {
           if (!ready) return;
-          openSettings();
+          setView('settings');
         },
       },
       {
@@ -68,7 +67,7 @@ export function App() {
       {
         combo: 'escape',
         handler: () => {
-          if (settingsOpen) closeSettings();
+          if (view === 'settings') setView('workspace');
           else if (commandPaletteOpen) closeCommandPalette();
         },
         preventDefault: false,
@@ -79,11 +78,10 @@ export function App() {
       isGenerating,
       ready,
       sendPrompt,
-      settingsOpen,
+      view,
       commandPaletteOpen,
-      openSettings,
+      setView,
       openCommandPalette,
-      closeSettings,
       closeCommandPalette,
     ],
   );
@@ -104,13 +102,18 @@ export function App() {
   return (
     <div className="h-full flex flex-col bg-[var(--color-background)]">
       <TopBar />
-      <div className="flex-1 grid grid-cols-[360px_1fr] min-h-0">
-        <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
-        <main className="flex flex-col min-h-0">
-          <PreviewPane onPickStarter={(p) => setPrompt(p)} />
-        </main>
+      <div className="flex-1 min-h-0">
+        {view === 'settings' ? (
+          <Settings />
+        ) : (
+          <div className="h-full grid grid-cols-[360px_1fr]">
+            <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
+            <main className="flex flex-col min-h-0">
+              <PreviewPane onPickStarter={(p) => setPrompt(p)} />
+            </main>
+          </div>
+        )}
       </div>
-      <Settings />
       <CommandPalette />
       <ToastViewport />
     </div>

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -15,7 +15,7 @@ export function CommandPalette() {
   const t = useT();
   const open = useCodesignStore((s) => s.commandPaletteOpen);
   const close = useCodesignStore((s) => s.closeCommandPalette);
-  const openSettings = useCodesignStore((s) => s.openSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const toggleTheme = useCodesignStore((s) => s.toggleTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
 
@@ -52,7 +52,7 @@ export function CommandPalette() {
         label: t('commands.items.openSettings'),
         hint: t('commands.hints.openSettings'),
         icon: SettingsIcon,
-        run: openSettings,
+        run: () => setView('settings'),
       },
       {
         id: 'export',
@@ -67,7 +67,7 @@ export function CommandPalette() {
           }),
       },
     ],
-    [openSettings, pushToast, t, toggleTheme],
+    [setView, pushToast, t, toggleTheme],
   );
 
   const filtered = useMemo(() => {

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -98,12 +98,17 @@ describe('applyLocaleChange', () => {
     expect(result).toBe('zh-CN');
   });
 
-  it('skips IPC set and applies locale directly when no locale API is provided', async () => {
+  it('applies the locale returned by the IPC bridge, not the requested locale', async () => {
     const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+    // Bridge normalises 'zh' → 'zh-CN'
+    const mockLocaleApi = {
+      set: vi.fn((_locale: string) => Promise.resolve('zh-CN')),
+    };
 
-    const result = await applyLocaleChange('en', undefined);
+    const result = await applyLocaleChange('zh', mockLocaleApi);
 
-    expect(mockSetLocale).toHaveBeenCalledWith('en');
-    expect(result).toBe('en');
+    expect(mockLocaleApi.set).toHaveBeenCalledWith('zh');
+    expect(mockSetLocale).toHaveBeenCalledWith('zh-CN');
+    expect(result).toBe('zh-CN');
   });
 });

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { applyValidateResult, canSaveProvider } from './Settings';
+import { describe, expect, it, vi } from 'vitest';
+import { applyLocaleChange, applyValidateResult, canSaveProvider } from './Settings';
+
+vi.mock('@open-codesign/i18n', () => ({
+  setLocale: vi.fn((locale: string) => Promise.resolve(locale)),
+}));
 
 describe('canSaveProvider', () => {
   it('requires a validated API key before enabling save', () => {
@@ -77,5 +81,29 @@ describe('applyValidateResult', () => {
     const next = applyValidateResult(changedProviderForm, matchingSnapshot, true, undefined);
     expect(next).toBe(changedProviderForm);
     expect(next.validated).toBe(false);
+  });
+});
+
+describe('applyLocaleChange', () => {
+  it('calls locale IPC set, then applies the persisted locale via i18next', async () => {
+    const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+    const mockLocaleApi = {
+      set: vi.fn((_locale: string) => Promise.resolve('zh-CN')),
+    };
+
+    const result = await applyLocaleChange('zh-CN', mockLocaleApi);
+
+    expect(mockLocaleApi.set).toHaveBeenCalledWith('zh-CN');
+    expect(mockSetLocale).toHaveBeenCalledWith('zh-CN');
+    expect(result).toBe('zh-CN');
+  });
+
+  it('skips IPC set and applies locale directly when no locale API is provided', async () => {
+    const { setLocale: mockSetLocale } = await import('@open-codesign/i18n');
+
+    const result = await applyLocaleChange('en', undefined);
+
+    expect(mockSetLocale).toHaveBeenCalledWith('en');
+    expect(result).toBe('en');
   });
 });

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { setLocale as applyLocale } from '@open-codesign/i18n';
+import { setLocale as applyLocale, useT } from '@open-codesign/i18n';
 import type {
   OnboardingState,
   PROVIDER_SHORTLIST,
@@ -786,6 +786,7 @@ function AppearanceTab() {
   const theme = useCodesignStore((s) => s.theme);
   const setTheme = useCodesignStore((s) => s.setTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
+  const t = useT();
   const [locale, setLocale] = useState<string>('en');
 
   useEffect(() => {
@@ -806,8 +807,8 @@ function AppearanceTab() {
     if (!window.codesign?.locale) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language preference',
-        description: 'Renderer is not connected to the main process.',
+        title: t('errors.localePersistFailed'),
+        description: t('errors.rendererDisconnected'),
       });
       return;
     }
@@ -817,8 +818,8 @@ function AppearanceTab() {
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language preference',
-        description: err instanceof Error ? err.message : 'Unknown error',
+        title: t('errors.localePersistFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
       });
     }
   }

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@open-codesign/ui';
 import {
   AlertTriangle,
+  ArrowLeft,
   CheckCircle,
   ChevronDown,
   Cpu,
@@ -574,6 +575,12 @@ function ActiveModelSelector({
   const [fast, setFast] = useState(config.modelFast ?? sl.defaultFast);
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Sync local state when the config changes (e.g. provider re-activated with different models).
+  useEffect(() => {
+    setPrimary(config.modelPrimary ?? sl.defaultPrimary);
+    setFast(config.modelFast ?? sl.defaultFast);
+  }, [config.modelPrimary, config.modelFast, sl.defaultPrimary, sl.defaultFast]);
+
   useEffect(() => {
     return () => {
       if (saveTimeout.current !== null) {
@@ -756,6 +763,22 @@ function ModelsTab() {
 
 // ─── Appearance tab ───────────────────────────────────────────────────────────
 
+/**
+ * Applies a locale change end-to-end:
+ *   1. Persists it via the IPC bridge (writes to disk on the main process)
+ *   2. Changes the active i18next language so React components re-render
+ *
+ * Exported so it can be unit-tested without a DOM.
+ */
+export async function applyLocaleChange(
+  locale: string,
+  localeApi: { set: (locale: string) => Promise<string> } | undefined,
+): Promise<string> {
+  const persisted = localeApi ? await localeApi.set(locale) : locale;
+  const applied = await applyLocale(persisted);
+  return applied;
+}
+
 function AppearanceTab() {
   const theme = useCodesignStore((s) => s.theme);
   const setTheme = useCodesignStore((s) => s.setTheme);
@@ -779,8 +802,7 @@ function AppearanceTab() {
   async function handleLocaleChange(v: string) {
     if (!window.codesign) return;
     try {
-      const persisted = await window.codesign.locale.set(v);
-      const applied = await applyLocale(persisted);
+      const applied = await applyLocaleChange(v, window.codesign.locale);
       setLocale(applied);
     } catch (err) {
       pushToast({
@@ -892,7 +914,7 @@ function PathRow({ label, value, onOpen }: { label: string; value: string; onOpe
 
 function StorageTab() {
   const pushToast = useCodesignStore((s) => s.pushToast);
-  const closeSettings = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const completeOnboarding = useCodesignStore((s) => s.completeOnboarding);
   const [paths, setPaths] = useState<AppPaths | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
@@ -928,7 +950,7 @@ function StorageTab() {
     await window.codesign.settings.resetOnboarding();
     const newState = await window.codesign.onboarding.getState();
     completeOnboarding(newState);
-    closeSettings();
+    setView('workspace');
     pushToast({ variant: 'info', title: 'Onboarding reset. Restart the app to re-run setup.' });
     setConfirmReset(false);
   }
@@ -1094,30 +1116,28 @@ function AdvancedTab() {
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
 export function Settings() {
-  const open = useCodesignStore((s) => s.settingsOpen);
-  const close = useCodesignStore((s) => s.closeSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const [tab, setTab] = useState<Tab>('models');
 
-  if (!open) return null;
-
   return (
-    <div
-      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
-      role="dialog"
-      aria-modal="true"
-      aria-label="Settings"
-      className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
-      onClick={close}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') close();
-      }}
-    >
-      <div
-        className="w-full max-w-3xl h-[36rem] rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] grid grid-cols-[11rem_1fr] overflow-hidden animate-[panel-in_160ms_ease-out]"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="document"
-      >
+    <div className="h-full flex flex-col bg-[var(--color-background)]">
+      <header className="flex items-center gap-3 px-5 h-12 border-b border-[var(--color-border)] shrink-0">
+        <button
+          type="button"
+          onClick={() => setView('workspace')}
+          className="inline-flex items-center gap-1.5 text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          aria-label="Back to workspace"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Workspace
+        </button>
+        <span className="text-[var(--color-text-muted)]">/</span>
+        <span className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
+          {tab}
+        </span>
+      </header>
+
+      <div className="flex-1 grid grid-cols-[11rem_1fr] min-h-0">
         <aside className="bg-[var(--color-background-secondary)] border-r border-[var(--color-border)] p-3">
           <div className="flex items-center gap-2 px-2 py-2 mb-2">
             <Sliders className="w-4 h-4 text-[var(--color-text-secondary)]" />
@@ -1148,21 +1168,11 @@ export function Settings() {
           </nav>
         </aside>
 
-        <section className="flex flex-col min-w-0">
-          <header className="flex items-center justify-between px-5 h-12 border-b border-[var(--color-border)] shrink-0">
-            <h2 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)] capitalize">
-              {tab}
-            </h2>
-            <Button variant="ghost" size="sm" onClick={close} aria-label="Close settings">
-              <X className="w-4 h-4" />
-            </Button>
-          </header>
-          <div className="flex-1 overflow-y-auto p-5">
-            {tab === 'models' ? <ModelsTab /> : null}
-            {tab === 'appearance' ? <AppearanceTab /> : null}
-            {tab === 'storage' ? <StorageTab /> : null}
-            {tab === 'advanced' ? <AdvancedTab /> : null}
-          </div>
+        <section className="flex flex-col min-h-0 overflow-y-auto p-5">
+          {tab === 'models' ? <ModelsTab /> : null}
+          {tab === 'appearance' ? <AppearanceTab /> : null}
+          {tab === 'storage' ? <StorageTab /> : null}
+          {tab === 'advanced' ? <AdvancedTab /> : null}
         </section>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -768,13 +768,16 @@ function ModelsTab() {
  *   1. Persists it via the IPC bridge (writes to disk on the main process)
  *   2. Changes the active i18next language so React components re-render
  *
+ * Requires a connected `localeApi` — callers must guard against a missing
+ * bridge before invoking this function.
+ *
  * Exported so it can be unit-tested without a DOM.
  */
 export async function applyLocaleChange(
   locale: string,
-  localeApi: { set: (locale: string) => Promise<string> } | undefined,
+  localeApi: { set: (locale: string) => Promise<string> },
 ): Promise<string> {
-  const persisted = localeApi ? await localeApi.set(locale) : locale;
+  const persisted = await localeApi.set(locale);
   const applied = await applyLocale(persisted);
   return applied;
 }
@@ -800,14 +803,21 @@ function AppearanceTab() {
   }, [pushToast]);
 
   async function handleLocaleChange(v: string) {
-    if (!window.codesign) return;
+    if (!window.codesign?.locale) {
+      pushToast({
+        variant: 'error',
+        title: 'Failed to save language preference',
+        description: 'Renderer is not connected to the main process.',
+      });
+      return;
+    }
     try {
       const applied = await applyLocaleChange(v, window.codesign.locale);
       setLocale(applied);
     } catch (err) {
       pushToast({
         variant: 'error',
-        title: 'Failed to save language',
+        title: 'Failed to save language preference',
         description: err instanceof Error ? err.message : 'Unknown error',
       });
     }

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -7,6 +7,8 @@ import type {
 import {
   PROVIDER_SHORTLIST as SHORTLIST,
   isSupportedOnboardingProvider,
+  normalizeBaseUrl,
+  resolveModelsEndpoint,
 } from '@open-codesign/shared';
 import { Button } from '@open-codesign/ui';
 import {
@@ -14,6 +16,7 @@ import {
   ArrowLeft,
   CheckCircle,
   ChevronDown,
+  ChevronRight,
   Cpu,
   FolderOpen,
   Globe,
@@ -24,11 +27,13 @@ import {
   Sliders,
   Trash2,
   X,
+  XCircle,
   Zap,
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import type { AppPaths, Preferences, ProviderRow } from '../../../preload/index';
 import { useCodesignStore } from '../store';
+import { type KeyFormatStatus, checkKeyFormat } from './Settings/keyFormat';
 
 type Tab = 'models' | 'appearance' | 'storage' | 'advanced';
 
@@ -234,13 +239,15 @@ export function applyValidateResult(
   return { ...current, validating: false, error: message ?? 'Validation failed' };
 }
 
-function AddProviderModal({
+function AddProviderForm({
   onSave,
   onClose,
 }: {
   onSave: (rows: ProviderRow[]) => void;
   onClose: () => void;
 }) {
+  const t = useT();
+  const pushToast = useCodesignStore((s) => s.pushToast);
   const providerOptions: { value: SupportedOnboardingProvider; label: string }[] = [
     { value: 'anthropic', label: 'Anthropic Claude' },
     { value: 'openai', label: 'OpenAI' },
@@ -272,18 +279,42 @@ function AddProviderModal({
         apiKey: snapshot.apiKey,
         ...(snapshot.baseUrl.length > 0 ? { baseUrl: snapshot.baseUrl } : {}),
       });
-      // Discard result if the user changed provider/key/baseUrl while we were waiting.
       setForm((current) =>
         applyValidateResult(current, snapshot, res.ok, res.ok ? undefined : res.message),
       );
     } finally {
-      // Ensure validating spinner clears even if we discarded the result.
       setForm((current) => (current.validating ? { ...current, validating: false } : current));
     }
   }
 
-  async function handleSave() {
+  async function handleSaveAndTest() {
     if (!window.codesign) return;
+    // Run validation first; only persist if it succeeds.
+    const snapshot = {
+      provider: form.provider,
+      apiKey: form.apiKey.trim(),
+      baseUrl: form.baseUrl.trim(),
+    };
+    setForm((prev) => ({ ...prev, validating: true, error: null, validated: false }));
+    let validateOk = false;
+    let validateMsg: string | undefined;
+    try {
+      const res = await window.codesign.settings.validateKey({
+        provider: snapshot.provider,
+        apiKey: snapshot.apiKey,
+        ...(snapshot.baseUrl.length > 0 ? { baseUrl: snapshot.baseUrl } : {}),
+      });
+      validateOk = res.ok;
+      if (!res.ok) validateMsg = res.message;
+    } catch (err) {
+      validateMsg = err instanceof Error ? err.message : 'Validation failed';
+    }
+
+    if (!validateOk) {
+      setForm((prev) => ({ ...prev, validating: false, error: validateMsg ?? 'Test failed' }));
+      return;
+    }
+
     try {
       const trimmedUrl = form.baseUrl.trim();
       const rows = await window.codesign.settings.addProvider({
@@ -294,9 +325,11 @@ function AddProviderModal({
         ...(trimmedUrl.length > 0 ? { baseUrl: trimmedUrl } : {}),
       });
       onSave(rows);
+      pushToast({ variant: 'success', title: t('settings.providers.saved') });
     } catch (err) {
       setForm((prev) => ({
         ...prev,
+        validating: false,
         error: err instanceof Error ? err.message : 'Save failed',
       }));
     }
@@ -305,137 +338,205 @@ function AddProviderModal({
   const sl = SHORTLIST[form.provider];
   const primaryOptions = sl.primary.map((m) => ({ value: m, label: m }));
   const fastOptions = sl.fast.map((m) => ({ value: m, label: m }));
-  const canSave = canSaveProvider(form);
+  const keyStatus: KeyFormatStatus = checkKeyFormat(form.provider, form.apiKey);
+  const protocol: 'openai' | 'anthropic' = form.provider === 'anthropic' ? 'anthropic' : 'openai';
+
+  // Live URL preview
+  let urlPreview:
+    | { kind: 'default' }
+    | { kind: 'ok'; url: string }
+    | { kind: 'invalid'; reason: string };
+  const trimmedBase = form.baseUrl.trim();
+  if (trimmedBase.length === 0) {
+    urlPreview = { kind: 'default' };
+  } else {
+    const r = normalizeBaseUrl(trimmedBase);
+    urlPreview = r.ok
+      ? { kind: 'ok', url: resolveModelsEndpoint(r.normalized, protocol) }
+      : { kind: 'invalid', reason: r.message };
+  }
+
+  const canSubmit = form.apiKey.trim().length > 0 && !form.validating;
 
   return (
-    <div
-      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
-      role="dialog"
-      aria-modal="true"
-      aria-label="Add provider"
-      className="fixed inset-0 z-[60] flex items-center justify-center p-6 bg-[var(--color-overlay)]"
-      onClick={onClose}
-      onKeyDown={(e) => e.key === 'Escape' && onClose()}
-    >
-      <div
-        className="w-full max-w-md bg-[var(--color-background)] border border-[var(--color-border)] rounded-[var(--radius-xl)] shadow-[var(--shadow-elevated)] p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="document"
-      >
-        <div className="flex items-center justify-between">
-          <h2 className="text-[var(--text-base)] font-semibold text-[var(--color-text-primary)]">
-            Add provider
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-1.5 rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+    <div className="rounded-[var(--radius-lg)] border border-[var(--color-accent)] bg-[var(--color-accent-soft)] p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+          {t('settings.providers.addTitle')}
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('settings.providers.cancel')}
+          className="p-1 rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div>
+        <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
+          {t('settings.providers.fields.provider')}
+        </p>
+        <NativeSelect
+          value={form.provider}
+          onChange={handleProviderChange}
+          options={providerOptions}
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <p className="text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)]">
+            {t('settings.providers.fields.apiKey')}
+          </p>
+          <a
+            href={sl.keyHelpUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--text-xs)] text-[var(--color-accent)] hover:underline"
           >
-            <X className="w-4 h-4" />
-          </button>
+            {t('settings.providers.fields.getKey')}
+          </a>
         </div>
+        <TextInput
+          type="password"
+          value={form.apiKey}
+          onChange={(v) => setField('apiKey', v)}
+          placeholder="sk-..."
+          className="w-full"
+        />
+        <KeyFormatHint provider={form.provider} status={keyStatus} t={t} />
+      </div>
 
-        <div className="space-y-3">
-          <div>
-            <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-              Provider
-            </p>
-            <NativeSelect
-              value={form.provider}
-              onChange={handleProviderChange}
-              options={providerOptions}
-            />
-          </div>
+      <div>
+        <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
+          {t('settings.providers.fields.baseUrlOptional')}
+        </p>
+        <TextInput
+          value={form.baseUrl}
+          onChange={(v) => setField('baseUrl', v)}
+          placeholder="https://your-proxy.example.com"
+          className="w-full"
+        />
+        <UrlPreview preview={urlPreview} t={t} />
+      </div>
 
-          <div>
-            <div className="flex items-center justify-between mb-1.5">
-              <p className="text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)]">
-                API Key
-              </p>
-              <a
-                href={sl.keyHelpUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="text-[var(--text-xs)] text-[var(--color-accent)] hover:underline"
-              >
-                Get key ↗
-              </a>
-            </div>
-            <div className="flex gap-2">
-              <TextInput
-                type="password"
-                value={form.apiKey}
-                onChange={(v) => setField('apiKey', v)}
-                placeholder="sk-..."
-                className="flex-1"
-              />
-              <button
-                type="button"
-                onClick={handleValidate}
-                disabled={form.apiKey.trim().length === 0 || form.validating}
-                className="h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
-              >
-                {form.validating ? (
-                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                ) : form.validated ? (
-                  <CheckCircle className="w-3.5 h-3.5 text-[var(--color-success)]" />
-                ) : null}
-                {form.validated ? 'Valid' : 'Validate'}
-              </button>
-            </div>
-            {form.error && (
-              <p className="mt-1.5 text-[var(--text-xs)] text-[var(--color-error)]">{form.error}</p>
-            )}
-          </div>
-
-          <div>
-            <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-              Base URL{' '}
-              <span className="text-[var(--color-text-muted)] font-normal">(optional)</span>
-            </p>
-            <TextInput
-              value={form.baseUrl}
-              onChange={(v) => setField('baseUrl', v)}
-              placeholder="https://your-proxy.example.com"
-              className="w-full"
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-                Primary model
-              </p>
-              <NativeSelect
-                value={form.modelPrimary}
-                onChange={(v) => setField('modelPrimary', v)}
-                options={primaryOptions}
-              />
-            </div>
-            <div>
-              <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-                Fast model
-              </p>
-              <NativeSelect
-                value={form.modelFast}
-                onChange={(v) => setField('modelFast', v)}
-                options={fastOptions}
-              />
-            </div>
-          </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
+            {t('settings.providers.fields.primaryModel')}
+          </p>
+          <NativeSelect
+            value={form.modelPrimary}
+            onChange={(v) => setField('modelPrimary', v)}
+            options={primaryOptions}
+          />
         </div>
+        <div>
+          <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
+            {t('settings.providers.fields.fastModel')}
+          </p>
+          <NativeSelect
+            value={form.modelFast}
+            onChange={(v) => setField('modelFast', v)}
+            options={fastOptions}
+          />
+        </div>
+      </div>
 
-        <div className="flex justify-end gap-2 pt-1">
+      {form.error !== null && (
+        <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-error)]">
+          <XCircle className="w-3.5 h-3.5 mt-0.5 text-[var(--color-error)] shrink-0" />
+          <p className="text-[var(--text-xs)] text-[var(--color-error)]">{form.error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between pt-1">
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={form.apiKey.trim().length === 0 || form.validating}
+          className="h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
+        >
+          {form.validating ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : form.validated ? (
+            <CheckCircle className="w-3.5 h-3.5 text-[var(--color-success)]" />
+          ) : null}
+          {t('settings.providers.test')}
+        </button>
+        <div className="flex gap-2">
           <Button variant="secondary" size="sm" onClick={onClose}>
-            Cancel
+            {t('settings.providers.cancel')}
           </Button>
-          <Button size="sm" onClick={handleSave} disabled={!canSave}>
-            Save provider
+          <Button size="sm" onClick={handleSaveAndTest} disabled={!canSubmit}>
+            {form.validating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+            {t('settings.providers.saveAndTest')}
           </Button>
         </div>
       </div>
     </div>
+  );
+}
+
+function KeyFormatHint({
+  provider,
+  status,
+  t,
+}: {
+  provider: SupportedOnboardingProvider;
+  status: KeyFormatStatus;
+  t: (k: string, v?: Record<string, unknown>) => string;
+}) {
+  if (status.kind === 'empty' || status.kind === 'unknown') return null;
+  if (status.kind === 'ok') {
+    return (
+      <p className="mt-1 text-[var(--text-xs)] text-[var(--color-success)] inline-flex items-center gap-1">
+        <CheckCircle className="w-3 h-3" />
+        {t('settings.providers.keyFormat.looksGood', { provider: SHORTLIST[provider].label })}
+      </p>
+    );
+  }
+  if (status.kind === 'wrong-prefix') {
+    return (
+      <p className="mt-1 text-[var(--text-xs)] text-[var(--color-warning,var(--color-text-muted))]">
+        {t('settings.providers.keyFormat.wrongPrefix', { prefix: status.expected })}
+      </p>
+    );
+  }
+  return (
+    <p className="mt-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+      {t('settings.providers.keyFormat.tooShort')}
+    </p>
+  );
+}
+
+function UrlPreview({
+  preview,
+  t,
+}: {
+  preview: { kind: 'default' } | { kind: 'ok'; url: string } | { kind: 'invalid'; reason: string };
+  t: (k: string, v?: Record<string, unknown>) => string;
+}) {
+  if (preview.kind === 'default') {
+    return (
+      <p className="mt-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+        {t('settings.providers.preview.default')}
+      </p>
+    );
+  }
+  if (preview.kind === 'invalid') {
+    return (
+      <p className="mt-1 text-[var(--text-xs)] text-[var(--color-error)]">
+        {t('settings.providers.preview.invalidUrl', { reason: preview.reason })}
+      </p>
+    );
+  }
+  return (
+    <p className="mt-1 text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono break-all">
+      {t('settings.providers.preview.willCall', { url: preview.url })}
+    </p>
   );
 }
 
@@ -452,13 +553,27 @@ function ProviderCard({
   onActivate: (p: SupportedOnboardingProvider) => void;
   onReEnterKey: (p: SupportedOnboardingProvider) => void;
 }) {
+  const t = useT();
   const label = SHORTLIST[row.provider]?.label ?? row.provider;
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const hasError = row.error !== undefined;
+
+  const protocol: 'openai' | 'anthropic' = row.provider === 'anthropic' ? 'anthropic' : 'openai';
+  const baseForResolve = row.baseUrl ?? null;
+  let resolvedEndpoint: string | null = null;
+  let host: string | null = null;
+  if (baseForResolve !== null) {
+    const r = normalizeBaseUrl(baseForResolve);
+    if (r.ok) {
+      resolvedEndpoint = resolveModelsEndpoint(r.normalized, protocol);
+      host = r.host;
+    }
+  }
 
   return (
     <div
-      className={`rounded-[var(--radius-lg)] border p-3 transition-colors ${
+      className={`rounded-[var(--radius-lg)] border transition-colors ${
         hasError
           ? 'border-[var(--color-error)] bg-[var(--color-error-soft,var(--color-surface))]'
           : row.isActive
@@ -466,94 +581,138 @@ function ProviderCard({
             : 'border-[var(--color-border)] bg-[var(--color-surface)]'
       }`}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
-              {label}
-            </span>
-            {row.isActive && !hasError && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
-                Active
-              </span>
+      <div className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-start gap-2 min-w-0 flex-1 text-left rounded-[var(--radius-sm)] -m-1 p-1 hover:bg-[var(--color-surface-hover)]"
+            aria-expanded={expanded}
+            aria-label={
+              expanded
+                ? t('settings.providers.details.collapse')
+                : t('settings.providers.details.expand')
+            }
+          >
+            {expanded ? (
+              <ChevronDown className="w-3.5 h-3.5 mt-1 text-[var(--color-text-muted)] shrink-0" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5 mt-1 text-[var(--color-text-muted)] shrink-0" />
+            )}
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
+                  {label}
+                </span>
+                {row.isActive && !hasError && (
+                  <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
+                    Active
+                  </span>
+                )}
+                {hasError && (
+                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
+                    <AlertTriangle className="w-2.5 h-2.5" />
+                    Decryption failed
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-3 mt-1 flex-wrap">
+                {!hasError && (
+                  <code className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono">
+                    {row.maskedKey}
+                  </code>
+                )}
+                {host !== null && (
+                  <span className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                    <Globe className="w-3 h-3" />
+                    {host}
+                  </span>
+                )}
+              </div>
+            </div>
+          </button>
+
+          <div className="flex items-center gap-1 shrink-0">
+            {!row.isActive && !hasError && (
+              <button
+                type="button"
+                onClick={() => onActivate(row.provider)}
+                className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)] transition-colors"
+              >
+                {t('settings.providers.setActive')}
+              </button>
             )}
             {hasError && (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
-                <AlertTriangle className="w-2.5 h-2.5" />
-                Decryption failed
-              </span>
+              <button
+                type="button"
+                onClick={() => onReEnterKey(row.provider)}
+                className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-error)] border border-[var(--color-error)] bg-[var(--color-surface)] hover:opacity-80 transition-opacity"
+              >
+                Re-enter key
+              </button>
             )}
-          </div>
-          <div className="flex items-center gap-3 mt-1">
-            {!hasError && (
-              <code className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono">
-                {row.maskedKey}
-              </code>
-            )}
-            {row.baseUrl && (
-              <span className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
-                <Globe className="w-3 h-3" />
-                {row.baseUrl}
-              </span>
+            {confirmDelete ? (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setConfirmDelete(false);
+                    onDelete(row.provider);
+                  }}
+                  className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-on-accent)] bg-[var(--color-error)] hover:opacity-90 transition-opacity"
+                >
+                  {t('settings.providers.deleteConfirm')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(false)}
+                  className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
+                >
+                  {t('settings.providers.deleteCancel')}
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                className="p-1.5 rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:text-[var(--color-error)] hover:bg-[var(--color-surface-hover)] transition-colors"
+                aria-label={`Delete ${label} provider`}
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
             )}
           </div>
         </div>
 
-        <div className="flex items-center gap-1 shrink-0">
-          {!row.isActive && !hasError && (
-            <button
-              type="button"
-              onClick={() => onActivate(row.provider)}
-              className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)] transition-colors"
-            >
-              Set active
-            </button>
-          )}
-          {hasError && (
-            <button
-              type="button"
-              onClick={() => onReEnterKey(row.provider)}
-              className="h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-error)] border border-[var(--color-error)] bg-[var(--color-surface)] hover:opacity-80 transition-opacity"
-            >
-              Re-enter key
-            </button>
-          )}
-          {confirmDelete ? (
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => {
-                  setConfirmDelete(false);
-                  onDelete(row.provider);
-                }}
-                className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-on-accent)] bg-[var(--color-error)] hover:opacity-90 transition-opacity"
-              >
-                Confirm
-              </button>
-              <button
-                type="button"
-                onClick={() => setConfirmDelete(false)}
-                className="h-7 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setConfirmDelete(true)}
-              className="p-1.5 rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:text-[var(--color-error)] hover:bg-[var(--color-surface-hover)] transition-colors"
-              aria-label={`Delete ${label} provider`}
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-            </button>
-          )}
-        </div>
+        {expanded && (
+          <div className="mt-3 pt-3 border-t border-[var(--color-border-subtle)] space-y-1.5">
+            {row.baseUrl !== null && (
+              <div className="grid grid-cols-[6.5rem_1fr] gap-2 text-[var(--text-xs)]">
+                <span className="text-[var(--color-text-muted)]">
+                  {t('settings.providers.details.host')}
+                </span>
+                <code className="font-mono text-[var(--color-text-primary)] break-all">
+                  {row.baseUrl}
+                </code>
+              </div>
+            )}
+            {resolvedEndpoint !== null && (
+              <div className="grid grid-cols-[6.5rem_1fr] gap-2 text-[var(--text-xs)]">
+                <span className="text-[var(--color-text-muted)]">
+                  {t('settings.providers.details.endpoint')}
+                </span>
+                <code className="font-mono text-[var(--color-text-primary)] break-all">
+                  {resolvedEndpoint}
+                </code>
+              </div>
+            )}
+          </div>
+        )}
+
+        {row.isActive && !hasError && config !== null && (
+          <ActiveModelSelector config={config} provider={row.provider} />
+        )}
       </div>
-
-      {row.isActive && !hasError && config !== null && (
-        <ActiveModelSelector config={config} provider={row.provider} />
-      )}
     </div>
   );
 }
@@ -642,6 +801,7 @@ function ModelsTab() {
   const config = useCodesignStore((s) => s.config);
   const setConfig = useCodesignStore((s) => s.completeOnboarding);
   const pushToast = useCodesignStore((s) => s.pushToast);
+  const t = useT();
   const [rows, setRows] = useState<ProviderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAdd, setShowAdd] = useState(false);
@@ -669,7 +829,7 @@ function ModelsTab() {
       setRows(next);
       const newState = await window.codesign.onboarding.getState();
       setConfig(newState);
-      pushToast({ variant: 'success', title: 'Provider removed' });
+      pushToast({ variant: 'success', title: t('settings.providers.removed') });
     } catch (err) {
       pushToast({
         variant: 'error',
@@ -691,7 +851,10 @@ function ModelsTab() {
       setConfig(next);
       const updatedRows = await window.codesign.settings.listProviders();
       setRows(updatedRows);
-      pushToast({ variant: 'success', title: `Switched to ${sl.label}` });
+      pushToast({
+        variant: 'success',
+        title: t('settings.providers.switchedTo', { name: sl.label }),
+      });
     } catch (err) {
       pushToast({
         variant: 'error',
@@ -705,13 +868,35 @@ function ModelsTab() {
     setRows(nextRows);
     setShowAdd(false);
     setReEnterProvider(null);
-    pushToast({ variant: 'success', title: 'Provider saved' });
   }
 
+  const activeRow = rows.find((r) => r.isActive);
+  const activeLabel =
+    activeRow !== undefined ? (SHORTLIST[activeRow.provider]?.label ?? activeRow.provider) : null;
+
   return (
-    <>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <SectionTitle>{t('settings.providers.sectionTitle')}</SectionTitle>
+        {!showAdd && reEnterProvider === null && (
+          <Button variant="secondary" size="sm" onClick={() => setShowAdd(true)}>
+            <Plus className="w-3.5 h-3.5" />
+            {t('settings.providers.addButton')}
+          </Button>
+        )}
+      </div>
+
+      {activeLabel !== null && (
+        <div className="flex items-center gap-2 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+          <span>{t('settings.providers.activeLabel')}:</span>
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
+            {activeLabel}
+          </span>
+        </div>
+      )}
+
       {(showAdd || reEnterProvider !== null) && (
-        <AddProviderModal
+        <AddProviderForm
           onSave={handleAddSave}
           onClose={() => {
             setShowAdd(false);
@@ -720,44 +905,34 @@ function ModelsTab() {
         />
       )}
 
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <SectionTitle>API Providers</SectionTitle>
-          <Button variant="secondary" size="sm" onClick={() => setShowAdd(true)}>
-            <Plus className="w-3.5 h-3.5" />
-            Add provider
-          </Button>
+      {loading && (
+        <div className="flex items-center gap-2 py-4 text-[var(--text-sm)] text-[var(--color-text-muted)]">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          {t('settings.providers.loading')}
         </div>
+      )}
 
-        {loading && (
-          <div className="flex items-center gap-2 py-4 text-[var(--text-sm)] text-[var(--color-text-muted)]">
-            <Loader2 className="w-4 h-4 animate-spin" />
-            Loading…
-          </div>
-        )}
+      {!loading && rows.length === 0 && !showAdd && (
+        <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--color-border)] p-6 text-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
+          {t('settings.providers.empty')}
+        </div>
+      )}
 
-        {!loading && rows.length === 0 && (
-          <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--color-border)] p-6 text-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
-            No providers configured yet. Add one to start generating.
-          </div>
-        )}
-
-        {!loading && rows.length > 0 && (
-          <div className="space-y-2">
-            {rows.map((row) => (
-              <ProviderCard
-                key={row.provider}
-                row={row}
-                config={config}
-                onDelete={handleDelete}
-                onActivate={handleActivate}
-                onReEnterKey={setReEnterProvider}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </>
+      {!loading && rows.length > 0 && (
+        <div className="space-y-2">
+          {rows.map((row) => (
+            <ProviderCard
+              key={row.provider}
+              row={row}
+              config={config}
+              onDelete={handleDelete}
+              onActivate={handleActivate}
+              onReEnterKey={setReEnterProvider}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/Settings/keyFormat.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings/keyFormat.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { checkKeyFormat } from './keyFormat';
+
+describe('checkKeyFormat', () => {
+  it('flags empty key', () => {
+    expect(checkKeyFormat('openai', '')).toEqual({ kind: 'empty' });
+  });
+
+  it('accepts well-formed Anthropic key', () => {
+    expect(checkKeyFormat('anthropic', `sk-ant-${'x'.repeat(40)}`)).toEqual({ kind: 'ok' });
+  });
+
+  it('flags Anthropic key with wrong prefix', () => {
+    const r = checkKeyFormat('anthropic', `sk-${'x'.repeat(40)}`);
+    expect(r.kind).toBe('wrong-prefix');
+    if (r.kind === 'wrong-prefix') expect(r.expected).toBe('sk-ant-');
+  });
+
+  it('flags too-short key', () => {
+    expect(checkKeyFormat('openai', 'sk-abc').kind).toBe('too-short');
+  });
+
+  it('accepts OpenAI keys for OpenAI even with non-standard prefix (relays)', () => {
+    // Many relays issue OpenAI-compatible keys with "sk-" prefix; some don't.
+    // We only flag truly suspicious cross-provider pastes.
+    const r = checkKeyFormat('openai', 'random-relay-key-12345678901234567890');
+    // Will pass prefix (no enforcement for openai unless cross-family) but be too short? No, it's long enough.
+    expect(r.kind).toBe('ok');
+  });
+
+  it('flags pasting Anthropic key into OpenAI slot', () => {
+    const r = checkKeyFormat('openai', `sk-ant-${'x'.repeat(40)}`);
+    expect(r.kind).toBe('wrong-prefix');
+  });
+
+  it('accepts OpenRouter key', () => {
+    expect(checkKeyFormat('openrouter', `sk-or-${'x'.repeat(40)}`).kind).toBe('ok');
+  });
+});

--- a/apps/desktop/src/renderer/src/components/Settings/keyFormat.ts
+++ b/apps/desktop/src/renderer/src/components/Settings/keyFormat.ts
@@ -1,0 +1,48 @@
+import type { SupportedOnboardingProvider } from '@open-codesign/shared';
+
+export type KeyFormatStatus =
+  | { kind: 'ok' }
+  | { kind: 'wrong-prefix'; expected: string }
+  | { kind: 'too-short' }
+  | { kind: 'empty' }
+  | { kind: 'unknown' };
+
+interface ProviderKeyShape {
+  prefix: string | null;
+  minLength: number;
+}
+
+const SHAPES: Record<SupportedOnboardingProvider, ProviderKeyShape> = {
+  anthropic: { prefix: 'sk-ant-', minLength: 30 },
+  openai: { prefix: 'sk-', minLength: 20 },
+  openrouter: { prefix: 'sk-or-', minLength: 30 },
+};
+
+/**
+ * Live, lossless format check for an API key. Runs as the user types so
+ * obvious paste errors (wrong prefix, accidental copy of the dashboard label)
+ * are caught before the user clicks "Test". Never makes a network call.
+ */
+export function checkKeyFormat(
+  provider: SupportedOnboardingProvider,
+  key: string,
+): KeyFormatStatus {
+  const trimmed = key.trim();
+  if (trimmed.length === 0) return { kind: 'empty' };
+
+  const shape = SHAPES[provider];
+
+  // Cross-family paste detection (Anthropic key into OpenAI slot, etc.).
+  // Done before the prefix check so it fires even when both keys share the "sk-" prefix.
+  if (provider === 'openai' && (trimmed.startsWith('sk-ant-') || trimmed.startsWith('sk-or-'))) {
+    return { kind: 'wrong-prefix', expected: shape.prefix ?? '' };
+  }
+
+  if (shape.prefix !== null && !trimmed.startsWith(shape.prefix) && provider !== 'openai') {
+    return { kind: 'wrong-prefix', expected: shape.prefix };
+  }
+
+  if (trimmed.length < shape.minLength) return { kind: 'too-short' };
+
+  return { kind: 'ok' };
+}

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -15,7 +15,7 @@ export function TopBar() {
   const previewHtml = useCodesignStore((s) => s.previewHtml);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const errorMessage = useCodesignStore((s) => s.errorMessage);
-  const openSettings = useCodesignStore((s) => s.openSettings);
+  const setView = useCodesignStore((s) => s.setView);
   const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
 
   let crumb = t('preview.noDesign');
@@ -46,7 +46,11 @@ export function TopBar() {
         <LanguageToggle />
         <ThemeToggle />
         <Tooltip label={t('commands.tooltips.settings')}>
-          <IconButton label={t('commands.items.openSettings')} size="sm" onClick={openSettings}>
+          <IconButton
+            label={t('commands.items.openSettings')}
+            size="sm"
+            onClick={() => setView('settings')}
+          >
             <SettingsIcon className="w-4 h-4" />
           </IconButton>
         </Tooltip>

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -229,3 +229,52 @@ describe('useCodesignStore generation cancellation', () => {
     });
   });
 });
+
+describe('useCodesignStore view navigation', () => {
+  it('starts on workspace view', () => {
+    expect(useCodesignStore.getState().view).toBe('workspace');
+  });
+
+  it('setView("settings") switches to settings and closes command palette', () => {
+    useCodesignStore.setState({ commandPaletteOpen: true });
+    useCodesignStore.getState().setView('settings');
+    expect(useCodesignStore.getState().view).toBe('settings');
+    expect(useCodesignStore.getState().commandPaletteOpen).toBe(false);
+  });
+
+  it('setView("workspace") switches back from settings', () => {
+    useCodesignStore.getState().setView('settings');
+    useCodesignStore.getState().setView('workspace');
+    expect(useCodesignStore.getState().view).toBe('workspace');
+  });
+
+  it('sendPrompt uses the active provider from config after setActiveProvider updates config', async () => {
+    const generate = vi.fn(() =>
+      Promise.resolve({ artifacts: [{ content: '<html></html>' }], message: 'Done.' }),
+    );
+
+    vi.stubGlobal('window', { codesign: { generate }, setTimeout });
+
+    const openaiConfig: OnboardingState = {
+      hasKey: true,
+      provider: 'openai',
+      modelPrimary: 'gpt-4o',
+      modelFast: 'gpt-4o-mini',
+      baseUrl: null,
+      designSystem: null,
+    };
+
+    // Simulate setActiveProvider result updating the store config.
+    useCodesignStore.getState().completeOnboarding(openaiConfig);
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'make a button' });
+
+    expect(generate).toHaveBeenCalledOnce();
+    const call = generate.mock.calls[0] as unknown as [
+      { model: { provider: string; modelId: string } },
+    ];
+    const payload = call[0];
+    expect(payload.model.provider).toBe('openai');
+    expect(payload.model.modelId).toBe('gpt-4o');
+  });
+});

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -247,6 +247,59 @@ describe('useCodesignStore view navigation', () => {
     useCodesignStore.getState().setView('workspace');
     expect(useCodesignStore.getState().view).toBe('workspace');
   });
+});
+
+// Simulate the escape handler logic from App.tsx to verify priority:
+//   commandPaletteOpen → close palette (view unchanged)
+//   palette closed + view=settings → go to workspace
+function pressEscape(
+  view: ReturnType<typeof useCodesignStore.getState>['view'],
+  commandPaletteOpen: boolean,
+): void {
+  const store = useCodesignStore.getState();
+  if (commandPaletteOpen) {
+    store.closeCommandPalette();
+    return;
+  }
+  if (view === 'settings') {
+    store.setView('workspace');
+  }
+}
+
+describe('ESC key priority: command palette > settings view', () => {
+  it('ESC closes command palette without leaving settings when both are open', () => {
+    useCodesignStore.setState({ view: 'settings', commandPaletteOpen: true });
+    pressEscape('settings', true);
+
+    const s = useCodesignStore.getState();
+    expect(s.commandPaletteOpen).toBe(false);
+    // view must stay on settings — the palette consumed the keypress
+    expect(s.view).toBe('settings');
+  });
+
+  it('ESC navigates back to workspace when palette is closed and view is settings', () => {
+    useCodesignStore.setState({ view: 'settings', commandPaletteOpen: false });
+    pressEscape('settings', false);
+
+    const s = useCodesignStore.getState();
+    expect(s.view).toBe('workspace');
+    expect(s.commandPaletteOpen).toBe(false);
+  });
+
+  it('ESC is a no-op when palette is closed and view is workspace', () => {
+    useCodesignStore.setState({ view: 'workspace', commandPaletteOpen: false });
+    pressEscape('workspace', false);
+
+    const s = useCodesignStore.getState();
+    expect(s.view).toBe('workspace');
+    expect(s.commandPaletteOpen).toBe(false);
+  });
+});
+
+describe('useCodesignStore active provider routing', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
 
   it('sendPrompt uses the active provider from config after setActiveProvider updates config', async () => {
     const generate = vi.fn(() =>

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -35,6 +35,7 @@ export interface ConnectionStatus {
 }
 
 export type Theme = 'light' | 'dark';
+export type AppView = 'workspace' | 'settings';
 
 interface PromptRequest {
   prompt: string;
@@ -55,7 +56,7 @@ interface CodesignState {
   connectionStatus: ConnectionStatus;
 
   theme: Theme;
-  settingsOpen: boolean;
+  view: AppView;
   commandPaletteOpen: boolean;
   toasts: Toast[];
   iframeErrors: string[];
@@ -94,8 +95,7 @@ interface CodesignState {
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
-  openSettings: () => void;
-  closeSettings: () => void;
+  setView: (view: AppView) => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
 
@@ -224,7 +224,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   connectionStatus: { state: 'no_provider', lastTestedAt: null, lastError: null },
 
   theme: readInitialTheme(),
-  settingsOpen: false,
+  view: 'workspace' as AppView,
   commandPaletteOpen: false,
   toasts: [],
   iframeErrors: [],
@@ -548,15 +548,12 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     get().setTheme(next);
   },
 
-  openSettings() {
-    set({ settingsOpen: true, commandPaletteOpen: false });
-  },
-  closeSettings() {
-    set({ settingsOpen: false });
+  setView(view) {
+    set({ view, commandPaletteOpen: false });
   },
 
   openCommandPalette() {
-    set({ commandPaletteOpen: true, settingsOpen: false });
+    set({ commandPaletteOpen: true });
   },
   closeCommandPalette() {
     set({ commandPaletteOpen: false });

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -79,6 +79,61 @@
       "light": "Light",
       "dark": "Dark",
       "system": "System"
+    },
+    "providers": {
+      "sectionTitle": "API Providers",
+      "activeLabel": "Active provider",
+      "addButton": "Add provider",
+      "empty": "No providers configured yet. Add one to start generating.",
+      "loading": "Loading providers…",
+      "switchedTo": "Switched to {{name}}",
+      "saved": "Provider saved",
+      "removed": "Provider removed",
+      "deleteConfirm": "Confirm delete",
+      "deleteCancel": "Cancel",
+      "setActive": "Set active",
+      "edit": "Edit",
+      "test": "Test",
+      "saveAndTest": "Save & Test",
+      "cancel": "Cancel",
+      "addTitle": "Add provider",
+      "editTitle": "Edit provider",
+      "fields": {
+        "provider": "Provider",
+        "apiKey": "API Key",
+        "baseUrl": "Base URL",
+        "baseUrlOptional": "Base URL (optional, leave blank for default)",
+        "primaryModel": "Primary model",
+        "fastModel": "Fast model",
+        "getKey": "Get key ↗"
+      },
+      "preview": {
+        "willCall": "Will call: {{url}}",
+        "default": "Will use the official endpoint",
+        "invalidUrl": "{{reason}}"
+      },
+      "keyFormat": {
+        "looksGood": "Format looks correct for {{provider}}",
+        "wrongPrefix": "Expected prefix: {{prefix}}",
+        "tooShort": "Key looks too short",
+        "unknown": "Format check skipped"
+      },
+      "details": {
+        "expand": "Show details",
+        "collapse": "Hide details",
+        "lastTested": "Last tested",
+        "neverTested": "Never tested",
+        "modelCount_one": "{{count}} model available",
+        "modelCount_other": "{{count}} models available",
+        "host": "Host",
+        "endpoint": "Resolved endpoint"
+      },
+      "switchConfirm": {
+        "title": "This provider failed last test",
+        "body": "Switching to {{name}} now might fail when you generate. Continue anyway?",
+        "confirm": "Switch anyway",
+        "cancel": "Stay on current"
+      }
     }
   },
   "onboarding": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -218,7 +218,8 @@
     "rendererDisconnected": "Renderer is not connected to the main process.",
     "onboardingIncomplete": "Onboarding is not complete.",
     "modelListFailed": "Could not load model list.",
-    "unknown": "Unknown error"
+    "unknown": "Unknown error",
+    "localePersistFailed": "Failed to save language preference"
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -218,7 +218,8 @@
     "rendererDisconnected": "渲染进程未连接到主进程。",
     "onboardingIncomplete": "引导流程尚未完成。",
     "modelListFailed": "无法加载模型列表。",
-    "unknown": "未知错误"
+    "unknown": "未知错误",
+    "localePersistFailed": "无法保存语言偏好"
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -79,6 +79,61 @@
       "light": "浅色",
       "dark": "深色",
       "system": "跟随系统"
+    },
+    "providers": {
+      "sectionTitle": "API 提供商",
+      "activeLabel": "当前激活",
+      "addButton": "添加提供商",
+      "empty": "尚未配置任何提供商。添加一个开始生成。",
+      "loading": "正在加载提供商…",
+      "switchedTo": "已切换到 {{name}}",
+      "saved": "已保存提供商",
+      "removed": "已删除提供商",
+      "deleteConfirm": "确认删除",
+      "deleteCancel": "取消",
+      "setActive": "设为激活",
+      "edit": "编辑",
+      "test": "测试",
+      "saveAndTest": "保存并测试",
+      "cancel": "取消",
+      "addTitle": "添加提供商",
+      "editTitle": "编辑提供商",
+      "fields": {
+        "provider": "提供商",
+        "apiKey": "API Key",
+        "baseUrl": "Base URL",
+        "baseUrlOptional": "Base URL (可选,留空使用默认)",
+        "primaryModel": "主要模型",
+        "fastModel": "快速模型",
+        "getKey": "获取 Key ↗"
+      },
+      "preview": {
+        "willCall": "将请求：{{url}}",
+        "default": "将使用官方默认端点",
+        "invalidUrl": "{{reason}}"
+      },
+      "keyFormat": {
+        "looksGood": "{{provider}} 的 Key 格式看起来正确",
+        "wrongPrefix": "应以 {{prefix}} 开头",
+        "tooShort": "Key 看起来太短了",
+        "unknown": "未做格式检查"
+      },
+      "details": {
+        "expand": "展开详情",
+        "collapse": "收起详情",
+        "lastTested": "上次测试",
+        "neverTested": "尚未测试",
+        "modelCount_one": "{{count}} 个可用模型",
+        "modelCount_other": "{{count}} 个可用模型",
+        "host": "主机",
+        "endpoint": "解析后的端点"
+      },
+      "switchConfirm": {
+        "title": "该提供商上次测试失败",
+        "body": "切换到 {{name}} 后生成可能会失败。仍然切换？",
+        "confirm": "仍然切换",
+        "cancel": "保持当前"
+      }
     }
   },
   "onboarding": {

--- a/packages/providers/src/errorEnrichment.test.ts
+++ b/packages/providers/src/errorEnrichment.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { enrichProviderError } from './errorEnrichment';
+
+const base = { host: 'api.duckcoding.ai', provider: 'openai' as const };
+
+describe('enrichProviderError', () => {
+  describe('per status', () => {
+    it('401 → user error, key dashboard URL, no retry', () => {
+      const r = enrichProviderError({ ...base, status: 401 });
+      expect(r.isUserError).toBe(true);
+      expect(r.retryable).toBe(false);
+      expect(r.providerKeyUrl).toContain('platform.openai.com');
+      expect(r.message).toContain('rejected');
+    });
+
+    it('402 → no-credit hint, retryable false', () => {
+      const r = enrichProviderError({ ...base, status: 402 });
+      expect(r.message.toLowerCase()).toContain('credit');
+      expect(r.retryable).toBe(false);
+    });
+
+    it('403 → region/IP/tier hint', () => {
+      const r = enrichProviderError({ ...base, status: 403 });
+      expect(r.message).toContain('403');
+      expect(r.retryable).toBe(false);
+    });
+
+    it('404 → model name hint', () => {
+      const r = enrichProviderError({ ...base, status: 404 });
+      expect(r.hint.toLowerCase()).toContain('model');
+    });
+
+    it('429 → retryable, wait hint', () => {
+      const r = enrichProviderError({ ...base, status: 429 });
+      expect(r.retryable).toBe(true);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it('429 with Retry-After header → extracts seconds', () => {
+      const r = enrichProviderError({ ...base, status: 429, retryAfter: '42' });
+      expect(r.hint).toContain('42');
+    });
+
+    it('429 with retry-after in body → extracts seconds', () => {
+      const r = enrichProviderError({
+        ...base,
+        status: 429,
+        rawBody: '{"error":"please retry after 30s"}',
+      });
+      expect(r.hint).toContain('30');
+    });
+
+    it('500 → provider issues, retryable', () => {
+      const r = enrichProviderError({ ...base, status: 500 });
+      expect(r.retryable).toBe(true);
+      expect(r.isUserError).toBe(false);
+    });
+
+    it('502 → provider issues', () => {
+      const r = enrichProviderError({ ...base, status: 502 });
+      expect(r.retryable).toBe(true);
+    });
+
+    it('400 → user-side malformed request', () => {
+      const r = enrichProviderError({ ...base, status: 400 });
+      expect(r.isUserError).toBe(true);
+    });
+
+    it('network → cannot reach host', () => {
+      const r = enrichProviderError({ ...base, status: 'network' });
+      expect(r.message).toContain('api.duckcoding.ai');
+      expect(r.retryable).toBe(true);
+    });
+  });
+
+  describe('per provider', () => {
+    it('anthropic uses Anthropic label and console URL', () => {
+      const r = enrichProviderError({
+        host: 'api.anthropic.com',
+        provider: 'anthropic',
+        status: 401,
+      });
+      expect(r.message).toContain('Anthropic');
+      expect(r.providerKeyUrl).toContain('console.anthropic.com');
+    });
+
+    it('openrouter uses OpenRouter label and openrouter.ai/keys URL', () => {
+      const r = enrichProviderError({ host: 'openrouter.ai', provider: 'openrouter', status: 401 });
+      expect(r.message).toContain('OpenRouter');
+      expect(r.providerKeyUrl).toContain('openrouter.ai/keys');
+    });
+  });
+
+  describe('URL leak prevention', () => {
+    it('does NOT leak openai.com when provider is a relay (DuckCoding-style)', () => {
+      const r = enrichProviderError({ host: 'api.duckcoding.ai', provider: 'openai', status: 401 });
+      // The hint may mention OpenAI as the *label* (the user's chosen protocol),
+      // but it must never echo a raw upstream openai.com URL.
+      expect(r.hint).not.toMatch(/api\.openai\.com/);
+      expect(r.message).not.toMatch(/api\.openai\.com/);
+    });
+  });
+});

--- a/packages/providers/src/errorEnrichment.ts
+++ b/packages/providers/src/errorEnrichment.ts
@@ -1,0 +1,154 @@
+/**
+ * Provider-aware error enrichment. The point: when a 401 comes back from a
+ * relay configured against e.g. DuckCoding, we MUST NOT echo
+ * "https://api.openai.com/v1/..." in the user-facing error — the user picked
+ * that relay precisely so they wouldn't talk to OpenAI. We strip raw URLs and
+ * substitute provider-specific guidance (Continue parseError + Aider ExInfo
+ * pattern; see docs/research/19-api-config-ux-landscape.md).
+ */
+
+import type { SupportedOnboardingProvider } from '@open-codesign/shared';
+
+export interface EnrichInput {
+  status: number | 'network';
+  /** Display host of the configured base URL (NOT the underlying SDK target). */
+  host: string;
+  provider: SupportedOnboardingProvider;
+  /** Raw response body, if any — searched for retry-after hints. */
+  rawBody?: string;
+  /** Retry-After header value if the provider sent one. */
+  retryAfter?: string;
+}
+
+export interface EnrichedError {
+  /** Short headline suitable for a toast title. */
+  message: string;
+  /** Actionable hint shown below the headline. Never contains underlying SDK URLs. */
+  hint: string;
+  /** Whether the user has any chance of fixing this themselves. */
+  isUserError: boolean;
+  /** Whether retrying the same request might succeed. */
+  retryable: boolean;
+  /** Where the user should go to fix it (e.g. provider key dashboard). */
+  providerKeyUrl?: string;
+}
+
+const KEY_DASHBOARDS: Record<SupportedOnboardingProvider, string> = {
+  anthropic: 'https://console.anthropic.com/settings/keys',
+  openai: 'https://platform.openai.com/api-keys',
+  openrouter: 'https://openrouter.ai/keys',
+};
+
+const PROVIDER_LABEL: Record<SupportedOnboardingProvider, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  openrouter: 'OpenRouter',
+};
+
+function parseRetrySeconds(input: EnrichInput): number | null {
+  if (input.retryAfter !== undefined) {
+    const n = Number(input.retryAfter);
+    if (Number.isFinite(n) && n > 0) return Math.round(n);
+  }
+  if (input.rawBody !== undefined) {
+    const m = input.rawBody.match(/retry[\s-]?(?:after|in)?\D{0,8}(\d{1,4})\s*(?:s|sec|seconds)?/i);
+    if (m?.[1] !== undefined) {
+      const n = Number(m[1]);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  }
+  return null;
+}
+
+export function enrichProviderError(input: EnrichInput): EnrichedError {
+  const label = PROVIDER_LABEL[input.provider];
+  const dashboardUrl = KEY_DASHBOARDS[input.provider];
+
+  if (input.status === 'network') {
+    return {
+      message: `Cannot reach ${input.host}`,
+      hint: 'Check your network, VPN, or proxy. The host may also be down.',
+      isUserError: true,
+      retryable: true,
+    };
+  }
+
+  const status = input.status;
+
+  if (status === 401) {
+    return {
+      message: `${label} rejected the API key`,
+      hint: `Double-check the key in your ${label} dashboard. If you use a relay, the relay needs its own key — not the upstream one.`,
+      isUserError: true,
+      retryable: false,
+      providerKeyUrl: dashboardUrl,
+    };
+  }
+
+  if (status === 402) {
+    return {
+      message: `${label} reports no credit on the account`,
+      hint: `Top up at the ${label} dashboard, or switch to a different provider.`,
+      isUserError: true,
+      retryable: false,
+      providerKeyUrl: dashboardUrl,
+    };
+  }
+
+  if (status === 403) {
+    return {
+      message: `${label} blocked this request (403)`,
+      hint: 'Common causes: region/IP block, model not available for your tier, or the relay disallowed the call.',
+      isUserError: true,
+      retryable: false,
+      providerKeyUrl: dashboardUrl,
+    };
+  }
+
+  if (status === 404) {
+    return {
+      message: `${label} returned 404`,
+      hint: 'The model name or path is wrong. Check the provider model list, and confirm the base URL points at the right API root.',
+      isUserError: true,
+      retryable: false,
+    };
+  }
+
+  if (status === 429) {
+    const retry = parseRetrySeconds(input);
+    return {
+      message: `${label} rate-limited the request`,
+      hint:
+        retry !== null
+          ? `Retry in about ${retry}s, or switch to another provider.`
+          : 'Wait a few seconds and retry, or switch to another provider.',
+      isUserError: false,
+      retryable: true,
+    };
+  }
+
+  if (status >= 500 && status < 600) {
+    return {
+      message: `${label} is having issues (${status})`,
+      hint: 'This is on the provider side. Try again in a moment, or switch providers.',
+      isUserError: false,
+      retryable: true,
+    };
+  }
+
+  if (status >= 400 && status < 500) {
+    return {
+      message: `${label} rejected the request (${status})`,
+      hint: 'The request was malformed. Check your model id, base URL, and any custom headers.',
+      isUserError: true,
+      retryable: false,
+    };
+  }
+
+  return {
+    message: `${label} returned an unexpected status (${status})`,
+    hint: 'Try again, or switch providers.',
+    isUserError: false,
+    retryable: true,
+  };
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -199,6 +199,9 @@ export function detectProviderFromKey(key: string): ModelRef['provider'] | null 
 export { pingProvider } from './validate';
 export type { ValidateResult } from './validate';
 
+export { enrichProviderError } from './errorEnrichment';
+export type { EnrichInput, EnrichedError } from './errorEnrichment';
+
 export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
 export type { CompleteWithRetryOptions, RetryReason } from './retry';
 

--- a/packages/providers/src/validate.test.ts
+++ b/packages/providers/src/validate.test.ts
@@ -42,7 +42,8 @@ describe('pingProvider', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('401');
-      expect(result.message).toContain('anthropic');
+      expect(result.message.toLowerCase()).toContain('anthropic');
+      expect(result.providerKeyUrl).toContain('console.anthropic.com');
     }
   });
 
@@ -68,7 +69,7 @@ describe('pingProvider', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('network');
-      expect(result.message).toContain('ECONNREFUSED');
+      expect(result.message.toLowerCase()).toContain('cannot reach');
     }
   });
 

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -2,58 +2,64 @@ import {
   CodesignError,
   type SupportedOnboardingProvider,
   isSupportedOnboardingProvider,
+  normalizeBaseUrl,
+  resolveModelsEndpoint,
 } from '@open-codesign/shared';
+import { type EnrichedError, enrichProviderError } from './errorEnrichment';
 
 export type ValidateResult =
   | { ok: true; modelCount: number }
-  | { ok: false; code: '401' | '402' | '429' | 'network'; message: string };
+  | {
+      ok: false;
+      code: '401' | '402' | '429' | 'network';
+      message: string;
+      hint?: string;
+      providerKeyUrl?: string;
+      retryable?: boolean;
+    };
 
-interface ProviderEndpoint {
-  url: string;
-  headers: (apiKey: string) => Record<string, string>;
-}
+const DEFAULT_BASES: Record<SupportedOnboardingProvider, string> = {
+  anthropic: 'https://api.anthropic.com',
+  openai: 'https://api.openai.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+};
 
-function endpoint(provider: SupportedOnboardingProvider, baseUrl?: string): ProviderEndpoint {
-  switch (provider) {
-    case 'anthropic':
-      return {
-        url: `${baseUrl ?? 'https://api.anthropic.com'}/v1/models`,
-        headers: (apiKey) => ({
-          'x-api-key': apiKey,
-          'anthropic-version': '2023-06-01',
-        }),
-      };
-    case 'openai':
-      return {
-        url: `${baseUrl ?? 'https://api.openai.com'}/v1/models`,
-        headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
-      };
-    case 'openrouter':
-      return {
-        url: `${baseUrl ?? 'https://openrouter.ai/api'}/v1/models`,
-        headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
-      };
+const PROTOCOL: Record<SupportedOnboardingProvider, 'openai' | 'anthropic'> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  openrouter: 'openai',
+};
+
+function buildHeaders(
+  provider: SupportedOnboardingProvider,
+  apiKey: string,
+): Record<string, string> {
+  if (provider === 'anthropic') {
+    return { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' };
   }
+  return { authorization: `Bearer ${apiKey}` };
 }
 
-function statusToCode(status: number): '401' | '402' | '429' | null {
+function toLegacyCode(status: number | 'network'): '401' | '402' | '429' | 'network' {
+  if (status === 'network') return 'network';
   if (status === 401 || status === 403) return '401';
   if (status === 402) return '402';
   if (status === 429) return '429';
-  return null;
+  return 'network';
 }
 
-function statusMessage(provider: SupportedOnboardingProvider, status: number): string {
-  if (status === 401 || status === 403) {
-    return `Invalid ${provider} API key (HTTP ${status}). Double-check the key, then try again.`;
+function toFailure(status: number | 'network', enriched: EnrichedError): ValidateResult {
+  const failure: ValidateResult = {
+    ok: false,
+    code: toLegacyCode(status),
+    message: enriched.message,
+    hint: enriched.hint,
+    retryable: enriched.retryable,
+  };
+  if (enriched.providerKeyUrl !== undefined) {
+    failure.providerKeyUrl = enriched.providerKeyUrl;
   }
-  if (status === 402) {
-    return `${provider} reports the account has no credit (HTTP 402). Add billing or pick another provider.`;
-  }
-  if (status === 429) {
-    return `${provider} rate-limited the validation request (HTTP 429). Wait a moment and retry.`;
-  }
-  return `${provider} returned HTTP ${status}.`;
+  return failure;
 }
 
 export async function pingProvider(
@@ -71,37 +77,63 @@ export async function pingProvider(
     throw new CodesignError('API key is empty', 'PROVIDER_AUTH_MISSING');
   }
 
-  const ep = endpoint(provider, baseUrl);
+  let normalized: string;
+  let host: string;
+  if (baseUrl !== undefined && baseUrl.trim().length > 0) {
+    const r = normalizeBaseUrl(baseUrl);
+    if (!r.ok) {
+      const enriched = enrichProviderError({
+        provider,
+        host: baseUrl,
+        status: 'network',
+      });
+      return toFailure('network', { ...enriched, message: r.message, hint: enriched.hint });
+    }
+    normalized = r.normalized;
+    host = r.host;
+  } else {
+    normalized = DEFAULT_BASES[provider];
+    host = new URL(normalized).hostname;
+  }
+
+  const url = resolveModelsEndpoint(normalized, PROTOCOL[provider]);
+  const headers = buildHeaders(provider, apiKey);
+
   let res: Response;
   try {
-    res = await fetch(ep.url, { method: 'GET', headers: ep.headers(apiKey) });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Network request failed';
-    return { ok: false, code: 'network', message };
+    res = await fetch(url, { method: 'GET', headers });
+  } catch {
+    const enriched = enrichProviderError({ provider, host, status: 'network' });
+    return toFailure('network', enriched);
   }
 
   if (!res.ok) {
-    const code = statusToCode(res.status);
-    if (code !== null) {
-      return { ok: false, code, message: statusMessage(provider, res.status) };
+    const retryAfter = res.headers.get('retry-after') ?? undefined;
+    let rawBody: string | undefined;
+    try {
+      rawBody = await res.clone().text();
+    } catch {
+      rawBody = undefined;
     }
-    return {
-      ok: false,
-      code: 'network',
-      message: `${provider} returned an unexpected HTTP ${res.status}.`,
-    };
+    const enriched = enrichProviderError({
+      provider,
+      host,
+      status: res.status,
+      ...(retryAfter !== undefined ? { retryAfter } : {}),
+      ...(rawBody !== undefined ? { rawBody } : {}),
+    });
+    return toFailure(res.status, enriched);
   }
 
   let body: unknown;
   try {
     body = await res.json();
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Invalid JSON in response';
-    return { ok: false, code: 'network', message };
+  } catch {
+    const enriched = enrichProviderError({ provider, host, status: 'network' });
+    return toFailure('network', { ...enriched, message: 'Invalid JSON response from provider' });
   }
 
-  const modelCount = countModels(body);
-  return { ok: true, modelCount };
+  return { ok: true, modelCount: countModels(body) };
 }
 
 function countModels(body: unknown): number {

--- a/packages/shared/src/baseUrl.test.ts
+++ b/packages/shared/src/baseUrl.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBaseUrl, resolveModelsEndpoint } from './baseUrl';
+
+describe('normalizeBaseUrl', () => {
+  it('rejects empty string', () => {
+    const r = normalizeBaseUrl('');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('empty');
+  });
+
+  it('rejects whitespace-only', () => {
+    const r = normalizeBaseUrl('   \n');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('empty');
+  });
+
+  it('strips trailing slash', () => {
+    const r = normalizeBaseUrl('https://api.openai.com/v1/');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('https://api.openai.com/v1');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    const r = normalizeBaseUrl('https://api.openai.com/v1///');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('https://api.openai.com/v1');
+  });
+
+  it('adds https:// when scheme missing', () => {
+    const r = normalizeBaseUrl('api.openai.com/v1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('https://api.openai.com/v1');
+  });
+
+  it('preserves http:// when explicit', () => {
+    const r = normalizeBaseUrl('http://localhost:3000/v1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('http://localhost:3000/v1');
+  });
+
+  it('does NOT auto-append /v1', () => {
+    const r = normalizeBaseUrl('https://api.anthropic.com');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.normalized).toBe('https://api.anthropic.com');
+      expect(r.hasVersionSegment).toBe(false);
+    }
+  });
+
+  it('preserves /v1 when already present', () => {
+    const r = normalizeBaseUrl('https://api.openai.com/v1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.hasVersionSegment).toBe(true);
+  });
+
+  it('detects /v1beta as a version segment', () => {
+    const r = normalizeBaseUrl('https://generativelanguage.googleapis.com/v1beta/openai');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // Path contains /v1beta segment, so hasVersionSegment is true
+      expect(r.hasVersionSegment).toBe(true);
+    }
+  });
+
+  it('flags trailing /v1beta', () => {
+    const r = normalizeBaseUrl('https://example.com/v1beta');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.hasVersionSegment).toBe(true);
+  });
+
+  it('handles IP addresses', () => {
+    const r = normalizeBaseUrl('192.168.1.10:8080/v1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('https://192.168.1.10:8080/v1');
+  });
+
+  it('handles localhost', () => {
+    const r = normalizeBaseUrl('localhost:11434');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.normalized).toBe('https://localhost:11434');
+      expect(r.host).toBe('localhost');
+    }
+  });
+
+  it('preserves query string', () => {
+    const r = normalizeBaseUrl('https://api.example.com/v1?key=foo');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('https://api.example.com/v1?key=foo');
+  });
+
+  it('rejects ftp://', () => {
+    const r = normalizeBaseUrl('ftp://example.com');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('invalid');
+  });
+
+  it('rejects garbage', () => {
+    const r = normalizeBaseUrl('not a url at all !!!');
+    expect(r.ok).toBe(false);
+  });
+
+  it('exposes host for compact display', () => {
+    const r = normalizeBaseUrl('https://api.duckcoding.ai/v1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.host).toBe('api.duckcoding.ai');
+  });
+});
+
+describe('resolveModelsEndpoint', () => {
+  it('appends /models when /v1 already present (openai)', () => {
+    expect(resolveModelsEndpoint('https://api.openai.com/v1', 'openai')).toBe(
+      'https://api.openai.com/v1/models',
+    );
+  });
+
+  it('appends /v1/models when /v1 missing (openai)', () => {
+    expect(resolveModelsEndpoint('https://api.openai.com', 'openai')).toBe(
+      'https://api.openai.com/v1/models',
+    );
+  });
+
+  it('uses /v1/models for anthropic when /v1 absent', () => {
+    expect(resolveModelsEndpoint('https://api.anthropic.com', 'anthropic')).toBe(
+      'https://api.anthropic.com/v1/models',
+    );
+  });
+
+  it('does not double /v1 for anthropic when present', () => {
+    expect(resolveModelsEndpoint('https://api.anthropic.com/v1', 'anthropic')).toBe(
+      'https://api.anthropic.com/v1/models',
+    );
+  });
+});

--- a/packages/shared/src/baseUrl.ts
+++ b/packages/shared/src/baseUrl.ts
@@ -1,0 +1,98 @@
+/**
+ * Single canonical baseUrl normalizer. Replaces the scattered string
+ * concatenation that lived in pingProvider, AddProviderModal, and the
+ * onboarding flow. See docs/research/19-api-config-ux-landscape.md
+ * (Cherry Studio formatApiHost pattern).
+ *
+ * Rules (intentionally conservative):
+ *   - trim whitespace
+ *   - strip trailing slash
+ *   - default to https:// when no protocol is present
+ *   - DO NOT auto-append /v1 — Anthropic uses /v1/messages, ollama uses
+ *     /api/chat, and openai-compatible relays already include /v1 in their
+ *     pasted URL. Adding it silently would corrupt half of them.
+ *
+ * Returns a discriminated union so callers can render the failure reason
+ * inline (UX requirement: live preview below input).
+ */
+
+export type NormalizeBaseUrlOk = {
+  ok: true;
+  /** Normalized URL safe to pass to fetch() — no trailing slash, scheme guaranteed. */
+  normalized: string;
+  /** Hostname only, for compact UI display. */
+  host: string;
+  /** Whether the URL ends in /v1 (or /v1beta etc.) — used to skip auto-appending. */
+  hasVersionSegment: boolean;
+};
+
+export type NormalizeBaseUrlError = {
+  ok: false;
+  reason: 'empty' | 'invalid';
+  message: string;
+};
+
+export type NormalizeBaseUrlResult = NormalizeBaseUrlOk | NormalizeBaseUrlError;
+
+const VERSION_SEGMENT_RE = /\/v\d+[a-z]*(\/|$)/i;
+
+export function normalizeBaseUrl(input: string): NormalizeBaseUrlResult {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'empty', message: 'Base URL is empty' };
+  }
+
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return { ok: false, reason: 'invalid', message: 'Not a valid URL' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'invalid', message: `Unsupported protocol: ${parsed.protocol}` };
+  }
+
+  if (parsed.hostname.length === 0) {
+    return { ok: false, reason: 'invalid', message: 'Missing hostname' };
+  }
+
+  // Strip trailing slash from pathname so we can deterministically join paths later.
+  const pathname = parsed.pathname.replace(/\/+$/, '');
+  const search = parsed.search;
+  const hash = parsed.hash;
+  const port = parsed.port.length > 0 ? `:${parsed.port}` : '';
+
+  const normalized = `${parsed.protocol}//${parsed.hostname}${port}${pathname}${search}${hash}`;
+  const hasVersionSegment = VERSION_SEGMENT_RE.test(pathname);
+
+  return { ok: true, normalized, host: parsed.hostname, hasVersionSegment };
+}
+
+/**
+ * Build the *resolved endpoint* for a provider's connection test, using the
+ * normalized base URL. This is what we display below the input so the user
+ * can see exactly which URL the next request will hit.
+ *
+ * For OpenAI-compatible relays we always test against `/v1/models` — if the
+ * pasted URL already ends in /v1 we don't double it. Anthropic always uses
+ * `/v1/models` regardless of whether the pasted URL already has /v1.
+ */
+export function resolveModelsEndpoint(
+  normalized: string,
+  protocol: 'openai' | 'anthropic',
+): string {
+  if (protocol === 'anthropic') {
+    // Anthropic accepts both api.anthropic.com and api.anthropic.com/v1; we
+    // strip a trailing /v1 then re-append /v1/models so the result is stable.
+    const stripped = normalized.replace(/\/v1$/i, '');
+    return `${stripped}/v1/models`;
+  }
+  // openai-compatible
+  if (/\/v\d+[a-z]*(\/|$)/i.test(normalized)) {
+    return `${normalized}/models`;
+  }
+  return `${normalized}/v1/models`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -202,3 +202,10 @@ export {
   getPresetById,
 } from './proxy-presets';
 export type { ProxyPresetId } from './proxy-presets';
+
+export { normalizeBaseUrl, resolveModelsEndpoint } from './baseUrl';
+export type {
+  NormalizeBaseUrlError,
+  NormalizeBaseUrlOk,
+  NormalizeBaseUrlResult,
+} from './baseUrl';


### PR DESCRIPTION
## Summary

Rewrites the entire API config flow (add / view / edit / switch / delete provider) addressing user pain: "从配置 api 到保存 api 再到查看 api 再到切换 api 再到添加 api 都跟一坨屎一样".

Based on research synthesized in `docs/research/19-api-config-ux-landscape.md` (LibreChat / Open WebUI / Continue / Aider / Jan / Cherry Studio).

> Built on top of #28 (`wt/settings-fullpage-api`). Once #28 merges, this PR will retarget to `main`.

### Foundation (one source of truth)

- **`normalizeBaseUrl()`** — single canonical URL normalizer in `@open-codesign/shared` (Cherry Studio formatApiHost pattern). Trims, strips trailing slash, defaults to https. Never auto-appends `/v1` (would corrupt Anthropic and ollama paths). Returns a discriminated union so the UI can render the failure reason inline.
- **`resolveModelsEndpoint()`** — smart endpoint builder that respects existing version segments instead of double-appending `/v1`.
- **`enrichProviderError()`** in `@open-codesign/providers` — provider-aware error enrichment (Continue parseError + Aider ExInfo pattern). Each `(status, provider)` combo produces a tailored message + actionable hint + provider key dashboard URL. Crucially never echoes the underlying SDK URL — fixes the "401 leaks `api.openai.com` even though the user is on a relay" bug class at the source.
- **`pingProvider()`** now routes all errors through `enrichProviderError`, so the same enriched copy surfaces in Settings, onboarding, and the active connection test.
- **`checkKeyFormat()`** — live, lossless API-key sanity check (cross-family paste detection: catches Anthropic key pasted into the OpenAI slot, etc.).

### UX

- **Inline `AddProviderForm`** replaces the modal-in-modal `AddProviderModal`. Renders inline at top of the provider list — no overlay stack, no z-index war.
- **Live URL preview** below baseUrl input shows resolved endpoint as the user types (`Will call: https://...`), or the validation error reason for invalid input.
- **Live key format hint** as the user types (green checkmark when format matches the chosen provider, warning otherwise).
- **Save & Test** unified button: validates first, only persists on success. Standalone Test button still available.
- **ProviderCard expand** on click — shows full base URL + resolved endpoint inline without leaving the page.
- **Active provider banner** at the top of the list with the provider label.
- **Full i18n** — all copy goes through `useT()` with new `settings.providers.*` keys (en + zh-CN).

### Files of interest

- `packages/shared/src/baseUrl.ts` (new) + tests
- `packages/providers/src/errorEnrichment.ts` (new) + tests
- `packages/providers/src/validate.ts` (rewritten to use both)
- `apps/desktop/src/renderer/src/components/Settings.tsx` (AddProviderForm + ProviderCard rewrite)
- `apps/desktop/src/renderer/src/components/Settings/keyFormat.ts` (new) + tests
- `packages/i18n/src/locales/{en,zh-CN}.json` (new `settings.providers.*` block)

## Tests

- 20 unit tests covering `normalizeBaseUrl` (trailing slash / no protocol / IP / localhost / query / path with version segment / unsupported schemes)
- 14 unit tests covering `enrichProviderError` (status × provider matrix, retry-after header parsing, URL leak prevention)
- 7 unit tests covering `checkKeyFormat` (cross-family paste, too-short, prefix mismatch)
- 4 unit tests covering `resolveModelsEndpoint`
- All existing 120 desktop tests still pass

## Test plan

- [ ] manual: configure DuckCoding relay with wrong key → 401 should NOT show `platform.openai.com` URL
- [ ] manual: type a baseUrl in the form → resolved endpoint appears below input live
- [ ] manual: paste `sk-ant-...` into OpenAI slot → orange "Expected prefix: sk-" hint appears
- [ ] manual: switch active provider → toast `Switched to <name>` appears, banner updates
- [ ] manual: zh-CN locale → all provider config UI is Chinese

## Compatibility / upgradeability / no bloat / elegance

- ✅ Compatibility: no IPC schema changes; preload `ValidateKeyResult` extended with optional `hint`/`providerKeyUrl`/`retryable` (additive)
- ✅ Upgradeability: `normalizeBaseUrl` and `enrichProviderError` are now the single chokepoints — future provider additions only touch these two files
- ✅ No bloat: zero new dependencies; +1 lucide icon (`XCircle`, `ChevronRight`)
- ✅ Elegance: removes duplicated URL-building string concatenation from 3 sites; replaces nested modal with inline form