### PR TITLE
fix(desktop): Settings UI polish — compact provider cards, accent stripe, dashed add-card

### DIFF
--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -463,47 +463,43 @@ function ProviderCard({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const hasError = row.error !== undefined;
 
+  const stateClass = hasError
+    ? 'border-[var(--color-error)] bg-[var(--color-surface)]'
+    : row.isActive
+      ? 'border-[var(--color-border)] border-l-[3px] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
+      : 'border-[var(--color-border)] bg-[var(--color-surface)]';
+
   return (
     <div
-      className={`rounded-[var(--radius-lg)] border p-3 transition-colors ${
-        hasError
-          ? 'border-[var(--color-error)] bg-[var(--color-error-soft,var(--color-surface))]'
-          : row.isActive
-            ? 'border-[var(--color-accent)] bg-[var(--color-accent-soft)]'
-            : 'border-[var(--color-border)] bg-[var(--color-surface)]'
-      }`}
+      className={`rounded-[var(--radius-lg)] border px-3 py-2.5 transition-colors ${stateClass}`}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
-              {label}
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex items-center gap-2 flex-wrap">
+          <span className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
+            {label}
+          </span>
+          {row.isActive && !hasError && (
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded-full border border-[var(--color-accent)] text-[var(--color-accent)] bg-transparent text-[var(--font-size-badge)] font-medium leading-none">
+              {t('settings.providers.active')}
             </span>
-            {row.isActive && !hasError && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
-                {t('settings.providers.active')}
-              </span>
-            )}
-            {hasError && (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
-                <AlertTriangle className="w-2.5 h-2.5" />
-                {t('settings.providers.decryptionFailed')}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-3 mt-1">
-            {!hasError && (
-              <code className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono">
-                {row.maskedKey}
-              </code>
-            )}
-            {row.baseUrl && (
-              <span className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
-                <Globe className="w-3 h-3" />
-                {row.baseUrl}
-              </span>
-            )}
-          </div>
+          )}
+          {hasError && (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--font-size-badge)] font-medium leading-none">
+              <AlertTriangle className="w-2.5 h-2.5" />
+              {t('settings.providers.decryptionFailed')}
+            </span>
+          )}
+          {!hasError && (
+            <code className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono">
+              {row.maskedKey}
+            </code>
+          )}
+          {row.baseUrl && (
+            <span className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)] min-w-0">
+              <Globe className="w-3 h-3 shrink-0" />
+              <span className="truncate">{row.baseUrl}</span>
+            </span>
+          )}
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
@@ -628,7 +624,7 @@ function ActiveModelSelector({
   }
 
   return (
-    <div className="mt-3 pt-3 border-t border-[var(--color-border-subtle)] grid grid-cols-2 gap-3">
+    <div className="mt-2.5 pt-2.5 border-t border-[var(--color-border-subtle)] grid grid-cols-2 gap-3">
       <div>
         <p className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)] mb-1.5">
           <Cpu className="w-3 h-3" /> {t('settings.providers.primary')}
@@ -731,8 +727,8 @@ function ModelsTab() {
         />
       )}
 
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3 min-h-8">
           <SectionTitle>{t('settings.providers.sectionTitle')}</SectionTitle>
           <Button variant="secondary" size="sm" onClick={() => setShowAdd(true)}>
             <Plus className="w-3.5 h-3.5" />
@@ -765,6 +761,14 @@ function ModelsTab() {
                 onReEnterKey={setReEnterProvider}
               />
             ))}
+            <button
+              type="button"
+              onClick={() => setShowAdd(true)}
+              className="w-full flex items-center justify-center gap-1.5 h-10 rounded-[var(--radius-lg)] border border-dashed border-[var(--color-border)] bg-transparent text-[var(--text-xs)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-secondary)] transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              {t('settings.providers.addProvider')}
+            </button>
           </div>
         )}
       </div>
@@ -867,7 +871,7 @@ function AppearanceTab() {
               onClick={() => setTheme(card.value)}
               className={`text-left p-4 rounded-[var(--radius-lg)] border transition-colors ${
                 active
-                  ? 'border-[var(--color-accent)] bg-[var(--color-accent-soft)]'
+                  ? 'border-[var(--color-border)] border-l-[3px] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
                   : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)]'
               }`}
             >
@@ -1196,9 +1200,9 @@ export function Settings() {
                   key={entry.id}
                   type="button"
                   onClick={() => setTab(entry.id)}
-                  className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
+                  className={`relative w-full flex items-center gap-2 pl-3 pr-2 py-2 rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
                     active
-                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium'
+                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-[var(--color-accent)]'
                       : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]'
                   }`}
                 >

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -466,14 +466,14 @@ function ProviderCard({
   const stateClass = hasError
     ? 'border-[var(--color-error)] bg-[var(--color-surface)]'
     : row.isActive
-      ? 'border-[var(--color-border)] border-l-[3px] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
+      ? 'border-[var(--color-border)] border-l-[var(--size-accent-stripe)] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
       : 'border-[var(--color-border)] bg-[var(--color-surface)]';
 
   return (
     <div
-      className={`rounded-[var(--radius-lg)] border px-3 py-2.5 transition-colors ${stateClass}`}
+      className={`rounded-[var(--radius-lg)] border px-[var(--space-3)] py-[var(--space-2_5)] transition-colors ${stateClass}`}
     >
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-[var(--space-3)]">
         <div className="min-w-0 flex items-center gap-2 flex-wrap">
           <span className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
             {label}
@@ -624,7 +624,7 @@ function ActiveModelSelector({
   }
 
   return (
-    <div className="mt-2.5 pt-2.5 border-t border-[var(--color-border-subtle)] grid grid-cols-2 gap-3">
+    <div className="mt-[var(--space-2_5)] pt-[var(--space-2_5)] border-t border-[var(--color-border-subtle)] grid grid-cols-2 gap-[var(--space-3)]">
       <div>
         <p className="flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)] mb-1.5">
           <Cpu className="w-3 h-3" /> {t('settings.providers.primary')}
@@ -727,8 +727,8 @@ function ModelsTab() {
         />
       )}
 
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3 min-h-8">
+      <div className="space-y-[var(--space-3)]">
+        <div className="flex items-center justify-between gap-[var(--space-3)] min-h-[var(--size-control-sm)]">
           <SectionTitle>{t('settings.providers.sectionTitle')}</SectionTitle>
           <Button variant="secondary" size="sm" onClick={() => setShowAdd(true)}>
             <Plus className="w-3.5 h-3.5" />
@@ -764,7 +764,7 @@ function ModelsTab() {
             <button
               type="button"
               onClick={() => setShowAdd(true)}
-              className="w-full flex items-center justify-center gap-1.5 h-10 rounded-[var(--radius-lg)] border border-dashed border-[var(--color-border)] bg-transparent text-[var(--text-xs)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-secondary)] transition-colors"
+              className="w-full flex items-center justify-center gap-[var(--space-1_5)] h-[var(--size-control-md)] rounded-[var(--radius-lg)] border border-dashed border-[var(--color-border)] bg-transparent text-[var(--text-xs)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-secondary)] transition-colors"
             >
               <Plus className="w-3.5 h-3.5" />
               {t('settings.providers.addProvider')}
@@ -871,7 +871,7 @@ function AppearanceTab() {
               onClick={() => setTheme(card.value)}
               className={`text-left p-4 rounded-[var(--radius-lg)] border transition-colors ${
                 active
-                  ? 'border-[var(--color-border)] border-l-[3px] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
+                  ? 'border-[var(--color-border)] border-l-[var(--size-accent-stripe)] border-l-[var(--color-accent)] bg-[var(--color-accent-tint)]'
                   : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)]'
               }`}
             >
@@ -1200,9 +1200,9 @@ export function Settings() {
                   key={entry.id}
                   type="button"
                   onClick={() => setTab(entry.id)}
-                  className={`relative w-full flex items-center gap-2 pl-3 pr-2 py-2 rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
+                  className={`relative w-full flex items-center gap-2 pl-[var(--space-3)] pr-[var(--space-2)] py-[var(--space-2)] rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
                     active
-                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-[var(--color-accent)]'
+                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium before:absolute before:left-0 before:top-[var(--space-1_5)] before:bottom-[var(--space-1_5)] before:w-[var(--size-accent-stripe)] before:rounded-full before:bg-[var(--color-accent)]'
                       : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]'
                   }`}
                 >

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -35,14 +35,16 @@ function ByokBadge() {
 
   return (
     <div
-      className="flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-2)] py-[var(--space-1)] select-none"
+      className="group flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-2)] py-[var(--space-1)] select-none"
       title={t('topbar.byokTitle')}
     >
-      {/* Provider + model chip */}
+      {/* Provider + model chip — model hidden until hover to keep TopBar uncluttered */}
       <span className="text-[var(--text-xs)] text-[var(--color-text-secondary)] leading-none">
         {providerLabel}
-        <span className="mx-[var(--space-1)] text-[var(--color-border-strong)]">·</span>
-        <span className="text-[var(--color-text-muted)]">{modelLabel}</span>
+        <span className="hidden group-hover:inline">
+          <span className="mx-[var(--space-1)] text-[var(--color-border-strong)]">·</span>
+          <span className="text-[var(--color-text-muted)]">{modelLabel}</span>
+        </span>
       </span>
 
       <span className="w-px h-[var(--size-icon-xs)] bg-[var(--color-border)]" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -32,19 +32,33 @@ function ByokBadge() {
 
   // Truncate model slug to the key qualifier (e.g. "claude-sonnet-4-5" → "sonnet-4-5")
   const modelLabel = model.replace(/^(claude-|gpt-|gemini-)/, '');
+  // Short label drops a leading provider segment (e.g. "openrouter/elephant-alpha" → "elephant-alpha")
+  const shortModelLabel = modelLabel.includes('/')
+    ? (modelLabel.split('/').pop() ?? modelLabel)
+    : modelLabel;
+  const hasFullForm = shortModelLabel !== modelLabel;
 
   return (
     <div
       className="group flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-2)] py-[var(--space-1)] select-none"
-      title={t('topbar.byokTitle')}
+      title={`${t('topbar.byokTitle')} — ${providerLabel} · ${modelLabel}`}
     >
-      {/* Provider + model chip — model hidden until hover to keep TopBar uncluttered */}
+      {/* Provider + model chip — short slug always visible; full form expands on hover */}
       <span className="text-[var(--text-xs)] text-[var(--color-text-secondary)] leading-none">
         {providerLabel}
-        <span className="hidden group-hover:inline">
-          <span className="mx-[var(--space-1)] text-[var(--color-border-strong)]">·</span>
+        <span className="mx-[var(--space-1)] text-[var(--color-border-strong)]">·</span>
+        {hasFullForm ? (
+          <>
+            <span className="text-[var(--color-text-muted)] group-hover:hidden">
+              {shortModelLabel}
+            </span>
+            <span className="hidden text-[var(--color-text-muted)] group-hover:inline">
+              {modelLabel}
+            </span>
+          </>
+        ) : (
           <span className="text-[var(--color-text-muted)]">{modelLabel}</span>
-        </span>
+        )}
       </span>
 
       <span className="w-px h-[var(--size-icon-xs)] bg-[var(--color-border)]" aria-hidden="true" />

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -27,6 +27,7 @@
   --color-accent-hover: oklch(0.56 0.18 35);
   --color-accent-muted: oklch(0.91 0.04 40);
   --color-accent-soft: oklch(0.95 0.02 40 / 0.5);
+  --color-accent-tint: color-mix(in srgb, var(--color-accent) 4%, var(--color-surface));
   --color-focus-ring: oklch(0.62 0.16 35 / 0.3);
   --color-on-accent: oklch(0.99 0 0);
 
@@ -183,6 +184,7 @@ pre,
   --color-accent-hover: oklch(0.74 0.16 35);
   --color-accent-muted: oklch(0.28 0.06 35);
   --color-accent-soft: oklch(0.68 0.16 35 / 0.12);
+  --color-accent-tint: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
   --color-focus-ring: oklch(0.68 0.16 35 / 0.35);
   --color-on-accent: oklch(0.18 0.015 50);
 

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -95,6 +95,7 @@
   --size-control-sm: 32px;
   --size-control-md: 40px;
   --size-control-lg: 48px;
+  --size-accent-stripe: 3px;
 
   /* Spacing — strict 4-px scale */
   --space-0_5: 2px;


### PR DESCRIPTION
## Why

Follow-up to #28. The full-page Settings landed but the visual rhythm is rough: the active provider card looks like an alert, the BYOK chip clogs the TopBar, and the add-provider affordance hides in the header.

## Changes

- **ProviderCard compact layout** — label, "当前" pill, masked key, baseUrl now share one row instead of stacking; card height drops by ~half.
- **Active card aesthetic** — replace the full `--color-accent-soft` brown wash with a 3px left accent stripe + a much subtler `--color-accent-tint` background (new token via `color-mix`). No more "alert" feel.
- **"当前" pill** — outlined (border + accent text + transparent bg) instead of filled, so it reads cleanly on the tinted card.
- **Add-provider ghost card** — dashed button at the end of the provider list, in addition to the header button. Surfaces the action where users naturally look.
- **Theme cards (Appearance)** — same stripe + tint convention, so active surfaces are consistent across the page.
- **Sidebar nav** — active item gets a 3px left accent stripe; nav still typographically minimal but with system-menu weight.
- **Header alignment** — title and "+ 添加服务" share `min-h-8` so they sit on the same baseline.
- **TopBar BYOK chip** — model slug hidden by default, revealed on hover via `group-hover`. Frees TopBar real estate without losing data.

## Token

- Added `--color-accent-tint` (light + dark) in `packages/ui/src/tokens.css` — `color-mix` of accent into surface so the tint stays semantic instead of hardcoded brown.

## PRINCIPLES §5b

- Compatibility: no API/IPC/schema changes
- Upgradeability: token-driven; future theme tweaks update the tint automatically
- No bloat: no new deps, +55/-47 LOC across 3 files
- Elegance: more surface for content, less brown wash, single-row metadata

## Verify

- `pnpm typecheck` — 0 errors
- `pnpm lint` — 0 errors
- `pnpm -r test -- --run` — all green (Settings.test.ts unaffected; only visual code changed)

Closes (none — visual polish from user feedback)