### PR TITLE
fix(desktop): preview perf + token counter wiring

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -56,6 +56,23 @@ export interface AppPaths {
 
 export type UpdateChannel = 'stable' | 'beta';
 
+export interface GenerateArtifact {
+  id: string;
+  type: string;
+  title: string;
+  content: string;
+  designParams: unknown[];
+  createdAt: string;
+}
+
+export interface GenerateResponse {
+  message: string;
+  artifacts: GenerateArtifact[];
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
 export interface Preferences {
   updateChannel: UpdateChannel;
   generationTimeoutSec: number;
@@ -76,7 +93,7 @@ const api = {
     ipcRenderer.invoke('codesign:v1:generate', {
       schemaVersion: 1,
       ...payload,
-    } satisfies GeneratePayloadV1),
+    } satisfies GeneratePayloadV1) as Promise<GenerateResponse>,
   cancelGeneration: (generationId: string) =>
     ipcRenderer.invoke('codesign:v1:cancel-generation', {
       schemaVersion: 1,
@@ -89,7 +106,7 @@ const api = {
     model?: ModelRef;
     referenceUrl?: string;
     attachments?: LocalInputFile[];
-  }) => ipcRenderer.invoke('codesign:apply-comment', payload),
+  }) => ipcRenderer.invoke('codesign:apply-comment', payload) as Promise<GenerateResponse>,
   pickInputFiles: () =>
     ipcRenderer.invoke('codesign:pick-input-files') as Promise<LocalInputFile[]>,
   pickDesignSystemDirectory: () =>

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -6,7 +6,7 @@ import {
   isIframeErrorMessage,
   isOverlayMessage,
 } from '@open-codesign/runtime';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { EmptyState } from '../preview/EmptyState';
 import { ErrorState } from '../preview/ErrorState';
 import { LoadingState } from '../preview/LoadingState';
@@ -137,6 +137,12 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const interactionMode = useCodesignStore((s) => s.interactionMode);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  // Memoize the srcdoc string so we only re-run the (regex-heavy) builder when
+  // previewHtml actually changes. Without this, every unrelated store update
+  // (toasts, theme, errors) re-ran buildSrcdoc and React still diffed an
+  // identical srcDoc prop — but the regex cost is non-trivial on large designs.
+  const srcDoc = useMemo(() => (previewHtml ? buildSrcdoc(previewHtml) : null), [previewHtml]);
+
   useEffect(() => {
     postModeToPreviewWindow(iframeRef.current?.contentWindow, interactionMode, pushIframeError);
   }, [interactionMode, pushIframeError]);
@@ -185,10 +191,9 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     const rawIframe = (
       <iframe
         ref={iframeRef}
-        key={previewHtml.length}
         title="design-preview"
         sandbox="allow-scripts"
-        srcDoc={buildSrcdoc(previewHtml)}
+        srcDoc={srcDoc ?? ''}
         onLoad={() => {
           postModeToPreviewWindow(
             iframeRef.current?.contentWindow,

--- a/apps/desktop/src/renderer/src/components/TopBar.test.ts
+++ b/apps/desktop/src/renderer/src/components/TopBar.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { formatCostUsd } from './TopBar';
+
+describe('formatCostUsd', () => {
+  it('returns 0.00 for zero or non-finite values', () => {
+    expect(formatCostUsd(0)).toBe('0.00');
+    expect(formatCostUsd(-1)).toBe('0.00');
+    expect(formatCostUsd(Number.NaN)).toBe('0.00');
+    expect(formatCostUsd(Number.POSITIVE_INFINITY)).toBe('0.00');
+  });
+
+  it('uses 4 decimals for sub-cent values so users see non-zero spend', () => {
+    expect(formatCostUsd(0.0042)).toBe('0.0042');
+    expect(formatCostUsd(0.0001)).toBe('0.0001');
+  });
+
+  it('uses 2 decimals once spend reaches a cent or more', () => {
+    expect(formatCostUsd(0.01)).toBe('0.01');
+    expect(formatCostUsd(1.234)).toBe('1.23');
+    expect(formatCostUsd(12.5)).toBe('12.50');
+  });
+});

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -11,10 +11,13 @@ import { ThemeToggle } from './ThemeToggle';
 const dragStyle = { WebkitAppRegion: 'drag' } as CSSProperties;
 const noDragStyle = { WebkitAppRegion: 'no-drag' } as CSSProperties;
 
-// Shell badge — mock data. Full cost accounting tracked separately.
+// Display the BYOK provider chip and accumulated weekly cost. Weekly totals are
+// persisted in localStorage under an ISO-week bucket; resets automatically.
 function ByokBadge() {
   const t = useT();
   const config = useCodesignStore((s) => s.config);
+  const weekCostUsd = useCodesignStore((s) => s.weekUsage.costUsd);
+  const lastUsage = useCodesignStore((s) => s.lastUsage);
 
   const provider = config?.provider ?? null;
   const model = config?.modelPrimary ?? null;
@@ -38,6 +41,14 @@ function ByokBadge() {
     ? (modelLabel.split('/').pop() ?? modelLabel)
     : modelLabel;
   const hasFullForm = shortModelLabel !== modelLabel;
+
+  const costLabel = formatCostUsd(weekCostUsd);
+  const tooltipParts: string[] = [t('topbar.spendTooltip')];
+  if (lastUsage) {
+    tooltipParts.push(
+      `Last: ${lastUsage.inputTokens.toLocaleString()} in / ${lastUsage.outputTokens.toLocaleString()} out · $${formatCostUsd(lastUsage.costUsd)}`,
+    );
+  }
 
   return (
     <div
@@ -65,12 +76,12 @@ function ByokBadge() {
       <span className="w-px h-[var(--size-icon-xs)] bg-[var(--color-border)]" aria-hidden="true" />
 
       {/* Cost this week — tabular mono numerals */}
-      <Tooltip label={t('topbar.spendTooltip')}>
+      <Tooltip label={tooltipParts.join(' — ')}>
         <span
           className="text-[var(--text-xs)] text-[var(--color-text-secondary)] leading-none"
           style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
         >
-          $0.00
+          ${costLabel}
           <span
             className="ml-[var(--space-1)] text-[var(--color-text-muted)]"
             style={{ fontFamily: 'var(--font-sans)' }}
@@ -81,6 +92,15 @@ function ByokBadge() {
       </Tooltip>
     </div>
   );
+}
+
+export function formatCostUsd(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0.00';
+  // Sub-cent costs are common for cheap providers — show 4 decimals so the
+  // user sees a non-zero number after the first request, then collapse to
+  // 2 decimals once the bucket grows past a cent.
+  if (value < 0.01) return value.toFixed(4);
+  return value.toFixed(2);
 }
 
 export function TopBar() {

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -46,7 +46,11 @@ function ByokBadge() {
   const tooltipParts: string[] = [t('topbar.spendTooltip')];
   if (lastUsage) {
     tooltipParts.push(
-      `Last: ${lastUsage.inputTokens.toLocaleString()} in / ${lastUsage.outputTokens.toLocaleString()} out · $${formatCostUsd(lastUsage.costUsd)}`,
+      t('topbar.lastUsageTooltip', {
+        input: lastUsage.inputTokens.toLocaleString(),
+        output: lastUsage.outputTokens.toLocaleString(),
+        cost: formatCostUsd(lastUsage.costUsd),
+      }),
     );
   }
 

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -311,6 +311,55 @@ describe('useCodesignStore token usage tracking', () => {
     const state = useCodesignStore.getState();
     expect(state.lastUsage).toEqual({ inputTokens: 0, outputTokens: 0, costUsd: 0 });
   });
+
+  it('surfaces a toast and preserves in-memory weekUsage when localStorage write throws', async () => {
+    const generate = vi.fn(() =>
+      Promise.resolve({
+        artifacts: [{ content: '<html>ok</html>' }],
+        message: 'Done.',
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 0.01,
+      }),
+    );
+
+    const setItem = vi.fn(() => {
+      throw new Error('QuotaExceeded');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    vi.stubGlobal('window', {
+      codesign: { generate },
+      setTimeout,
+      localStorage: { getItem: () => null, setItem },
+    });
+
+    useCodesignStore.setState({
+      weekUsage: {
+        isoWeek: isoWeekKey(new Date()),
+        inputTokens: 7,
+        outputTokens: 3,
+        costUsd: 0.02,
+      },
+      lastUsage: null,
+    });
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'persist failure' });
+
+    const state = useCodesignStore.getState();
+    expect(setItem).toHaveBeenCalled();
+    expect(state.weekUsage.inputTokens).toBe(107);
+    expect(state.weekUsage.outputTokens).toBe(53);
+    expect(state.weekUsage.costUsd).toBeCloseTo(0.03, 6);
+    expect(state.lastUsage).toEqual({ inputTokens: 100, outputTokens: 50, costUsd: 0.01 });
+    expect(state.toasts.at(-1)).toMatchObject({
+      variant: 'error',
+      description: 'QuotaExceeded',
+    });
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
 });
 
 describe('accumulateWeekUsage', () => {

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -2,7 +2,7 @@ import { initI18n } from '@open-codesign/i18n';
 import type { LocalInputFile, OnboardingState, SelectedElement } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GenerationStage } from './store';
-import { accumulateWeekUsage, isoWeekKey, useCodesignStore } from './store';
+import { accumulateWeekUsage, coerceUsageSnapshot, isoWeekKey, useCodesignStore } from './store';
 
 const READY_CONFIG: OnboardingState = {
   hasKey: true,
@@ -399,6 +399,41 @@ describe('accumulateWeekUsage', () => {
     expect(next.inputTokens).toBe(10);
     expect(next.outputTokens).toBe(10);
     expect(next.costUsd).toBe(1);
+  });
+});
+
+describe('coerceUsageSnapshot', () => {
+  it('rejects NaN inputs and reports the field', () => {
+    const { usage, rejected } = coerceUsageSnapshot({
+      inputTokens: Number.NaN,
+      outputTokens: 200,
+      costUsd: 0.01,
+    });
+    expect(usage.inputTokens).toBe(0);
+    expect(usage.outputTokens).toBe(200);
+    expect(usage.costUsd).toBe(0.01);
+    expect(rejected).toEqual(['inputTokens']);
+  });
+
+  it('rejects Infinity inputs and reports the field', () => {
+    const { usage, rejected } = coerceUsageSnapshot({
+      inputTokens: 100,
+      outputTokens: Number.POSITIVE_INFINITY,
+      costUsd: Number.NEGATIVE_INFINITY,
+    });
+    expect(usage.outputTokens).toBe(0);
+    expect(usage.costUsd).toBe(0);
+    expect(rejected).toEqual(['outputTokens', 'costUsd']);
+  });
+
+  it('accepts finite zero without rejecting', () => {
+    const { usage, rejected } = coerceUsageSnapshot({
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    expect(usage).toEqual({ inputTokens: 0, outputTokens: 0, costUsd: 0 });
+    expect(rejected).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -2,7 +2,7 @@ import { initI18n } from '@open-codesign/i18n';
 import type { LocalInputFile, OnboardingState, SelectedElement } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GenerationStage } from './store';
-import { useCodesignStore } from './store';
+import { accumulateWeekUsage, isoWeekKey, useCodesignStore } from './store';
 
 const READY_CONFIG: OnboardingState = {
   hasKey: true,
@@ -247,6 +247,109 @@ describe('useCodesignStore view navigation', () => {
     useCodesignStore.getState().setView('settings');
     useCodesignStore.getState().setView('workspace');
     expect(useCodesignStore.getState().view).toBe('workspace');
+  });
+});
+
+describe('useCodesignStore token usage tracking', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('records lastUsage and accumulates weekUsage when generate resolves with usage fields', async () => {
+    const generate = vi.fn(() =>
+      Promise.resolve({
+        artifacts: [{ content: '<html>ok</html>' }],
+        message: 'Done.',
+        inputTokens: 1200,
+        outputTokens: 800,
+        costUsd: 0.0125,
+      }),
+    );
+
+    vi.stubGlobal('window', {
+      codesign: { generate },
+      setTimeout,
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {
+          /* noop */
+        },
+      },
+    });
+
+    useCodesignStore.setState({
+      weekUsage: { isoWeek: '2099-W01', inputTokens: 0, outputTokens: 0, costUsd: 0 },
+      lastUsage: null,
+    });
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'design landing' });
+
+    const state = useCodesignStore.getState();
+    expect(state.lastUsage).toEqual({ inputTokens: 1200, outputTokens: 800, costUsd: 0.0125 });
+    expect(state.weekUsage.inputTokens).toBe(1200);
+    expect(state.weekUsage.outputTokens).toBe(800);
+    expect(state.weekUsage.costUsd).toBeCloseTo(0.0125, 6);
+    expect(state.streamingTokenCount).toBe(2000);
+  });
+
+  it('treats missing usage fields as zero without crashing', async () => {
+    const generate = vi.fn(() =>
+      Promise.resolve({
+        artifacts: [{ content: '<html>ok</html>' }],
+        message: 'Done.',
+      }),
+    );
+
+    vi.stubGlobal('window', {
+      codesign: { generate },
+      setTimeout,
+      localStorage: { getItem: () => null, setItem: () => undefined },
+    });
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'fallback' });
+
+    const state = useCodesignStore.getState();
+    expect(state.lastUsage).toEqual({ inputTokens: 0, outputTokens: 0, costUsd: 0 });
+  });
+});
+
+describe('accumulateWeekUsage', () => {
+  it('adds delta to current bucket when isoWeek matches', () => {
+    const prev = { isoWeek: '2026-W16', inputTokens: 100, outputTokens: 50, costUsd: 0.5 };
+    const next = accumulateWeekUsage(
+      prev,
+      { inputTokens: 30, outputTokens: 20, costUsd: 0.25 },
+      new Date('2026-04-19T12:00:00Z'),
+    );
+    expect(next.isoWeek).toBe('2026-W16');
+    expect(next.inputTokens).toBe(130);
+    expect(next.outputTokens).toBe(70);
+    expect(next.costUsd).toBeCloseTo(0.75, 6);
+  });
+
+  it('resets bucket when the ISO week has rolled over', () => {
+    const prev = { isoWeek: '2025-W01', inputTokens: 999, outputTokens: 999, costUsd: 9 };
+    const next = accumulateWeekUsage(
+      prev,
+      { inputTokens: 5, outputTokens: 7, costUsd: 0.01 },
+      new Date('2026-04-19T12:00:00Z'),
+    );
+    expect(next.isoWeek).not.toBe('2025-W01');
+    expect(next.inputTokens).toBe(5);
+    expect(next.outputTokens).toBe(7);
+    expect(next.costUsd).toBeCloseTo(0.01, 6);
+  });
+
+  it('clamps negative deltas to zero', () => {
+    const prev = { isoWeek: isoWeekKey(new Date()), inputTokens: 10, outputTokens: 10, costUsd: 1 };
+    const next = accumulateWeekUsage(
+      prev,
+      { inputTokens: -5, outputTokens: -3, costUsd: -0.5 },
+      new Date(),
+    );
+    expect(next.inputTokens).toBe(10);
+    expect(next.outputTokens).toBe(10);
+    expect(next.costUsd).toBe(1);
   });
 });
 

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -243,6 +243,32 @@ export function isoWeekKey(date: Date): string {
   return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
 }
 
+function isFiniteUsageNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0;
+}
+
+export function coerceUsageSnapshot(result: {
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  costUsd?: unknown;
+}): { usage: UsageSnapshot; rejected: string[] } {
+  const rejected: string[] = [];
+  const pick = (label: string, v: unknown): number => {
+    if (v === undefined) return 0;
+    if (isFiniteUsageNumber(v)) return v;
+    rejected.push(label);
+    return 0;
+  };
+  return {
+    usage: {
+      inputTokens: pick('inputTokens', result.inputTokens),
+      outputTokens: pick('outputTokens', result.outputTokens),
+      costUsd: pick('costUsd', result.costUsd),
+    },
+    rejected,
+  };
+}
+
 function readStoredWeekUsage(now: Date): WeekUsage {
   const fresh: WeekUsage = {
     isoWeek: isoWeekKey(now),
@@ -258,9 +284,9 @@ function readStoredWeekUsage(now: Date): WeekUsage {
     const parsed = JSON.parse(raw) as Partial<WeekUsage>;
     if (
       typeof parsed.isoWeek !== 'string' ||
-      typeof parsed.inputTokens !== 'number' ||
-      typeof parsed.outputTokens !== 'number' ||
-      typeof parsed.costUsd !== 'number'
+      !isFiniteUsageNumber(parsed.inputTokens) ||
+      !isFiniteUsageNumber(parsed.outputTokens) ||
+      !isFiniteUsageNumber(parsed.costUsd)
     ) {
       warnReason = 'weekly usage entry has unexpected shape';
     } else if (parsed.isoWeek === fresh.isoWeek) {
@@ -545,11 +571,7 @@ function applyGenerateSuccess(
 ): void {
   const firstArtifact = result.artifacts[0];
   const assistantMessage = result.message || tr('common.done');
-  const usage: UsageSnapshot = {
-    inputTokens: typeof result.inputTokens === 'number' ? result.inputTokens : 0,
-    outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
-    costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
-  };
+  const { usage, rejected: rejectedUsageFields } = coerceUsageSnapshot(result);
   let persistError: string | null = null;
   let didApply = false;
   finishIfCurrent(set, generationId, (state) => {
@@ -572,6 +594,15 @@ function applyGenerateSuccess(
     if (designId) {
       const artifact = artifactFromResult(firstArtifact, prompt, assistantMessage);
       void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+    }
+    if (rejectedUsageFields.length > 0) {
+      const detail = rejectedUsageFields.join(', ');
+      console.warn('[open-codesign] dropped non-finite usage values from provider:', detail);
+      get().pushToast({
+        variant: 'error',
+        title: tr('errors.weekUsageInvalid'),
+        description: detail,
+      });
     }
     if (persistError) {
       console.warn('[open-codesign] failed to persist weekly usage:', persistError);
@@ -950,11 +981,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       });
       const firstArtifact = result.artifacts[0];
       const assistantText = result.message || tr('common.applied');
-      const usage: UsageSnapshot = {
-        inputTokens: typeof result.inputTokens === 'number' ? result.inputTokens : 0,
-        outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
-        costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
-      };
+      const { usage, rejected: rejectedUsageFields } = coerceUsageSnapshot(result);
       let persistError: string | null = null;
       set((s) => {
         const nextWeek = accumulateWeekUsage(s.weekUsage, usage, new Date());
@@ -972,6 +999,15 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       if (designId) {
         const artifact = artifactFromResult(firstArtifact, userMessage.content, assistantText);
         void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+      }
+      if (rejectedUsageFields.length > 0) {
+        const detail = rejectedUsageFields.join(', ');
+        console.warn('[open-codesign] dropped non-finite usage values from provider:', detail);
+        get().pushToast({
+          variant: 'error',
+          title: tr('errors.weekUsageInvalid'),
+          description: detail,
+        });
       }
       if (persistError) {
         console.warn('[open-codesign] failed to persist weekly usage:', persistError);

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -251,6 +251,7 @@ function readStoredWeekUsage(now: Date): WeekUsage {
     costUsd: 0,
   };
   if (typeof window === 'undefined') return fresh;
+  let warnReason: string | null = null;
   try {
     const raw = window.localStorage.getItem(WEEK_USAGE_STORAGE_KEY);
     if (!raw) return fresh;
@@ -261,19 +262,44 @@ function readStoredWeekUsage(now: Date): WeekUsage {
       typeof parsed.outputTokens !== 'number' ||
       typeof parsed.costUsd !== 'number'
     ) {
-      return fresh;
+      warnReason = 'weekly usage entry has unexpected shape';
+    } else if (parsed.isoWeek === fresh.isoWeek) {
+      return {
+        isoWeek: parsed.isoWeek,
+        inputTokens: parsed.inputTokens,
+        outputTokens: parsed.outputTokens,
+        costUsd: parsed.costUsd,
+      };
     }
-    if (parsed.isoWeek !== fresh.isoWeek) return fresh;
-    return {
-      isoWeek: parsed.isoWeek,
-      inputTokens: parsed.inputTokens,
-      outputTokens: parsed.outputTokens,
-      costUsd: parsed.costUsd,
-    };
+    // else: stale week — silently roll over (not corruption).
   } catch (err) {
-    console.warn('[open-codesign] failed to read weekly usage from storage:', err);
-    return fresh;
+    warnReason = err instanceof Error ? err.message : String(err);
   }
+  if (warnReason !== null) surfaceWeekUsageReadFailure(warnReason);
+  return fresh;
+}
+
+// Surface storage corruption to the user instead of silently dropping their
+// running totals. Deferred via setTimeout because this can run during store
+// initialisation, before the toast queue exists.
+function surfaceWeekUsageReadFailure(reason: string): void {
+  const fallback = () =>
+    console.warn('[open-codesign] failed to read weekly usage from storage:', reason);
+  if (typeof window === 'undefined') {
+    fallback();
+    return;
+  }
+  setTimeout(() => {
+    try {
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: tr('errors.weekUsageReadFailed'),
+        description: reason,
+      });
+    } catch {
+      fallback();
+    }
+  }, 0);
 }
 
 function persistWeekUsage(usage: WeekUsage): string | null {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -275,12 +275,13 @@ function readStoredWeekUsage(now: Date): WeekUsage {
   }
 }
 
-function persistWeekUsage(usage: WeekUsage): void {
-  if (typeof window === 'undefined') return;
+function persistWeekUsage(usage: WeekUsage): string | null {
+  if (typeof window === 'undefined') return null;
   try {
     window.localStorage.setItem(WEEK_USAGE_STORAGE_KEY, JSON.stringify(usage));
-  } catch {
-    // localStorage unavailable
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : 'Failed to persist weekly usage';
   }
 }
 
@@ -522,9 +523,12 @@ function applyGenerateSuccess(
     outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
     costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
   };
+  let persistError: string | null = null;
+  let didApply = false;
   finishIfCurrent(set, generationId, (state) => {
     const nextWeek = accumulateWeekUsage(state.weekUsage, usage, new Date());
-    persistWeekUsage(nextWeek);
+    persistError = persistWeekUsage(nextWeek);
+    didApply = true;
     return {
       messages: [...state.messages, { role: 'assistant', content: assistantMessage }],
       previewHtml: firstArtifact?.content ?? state.previewHtml,
@@ -536,10 +540,20 @@ function applyGenerateSuccess(
       weekUsage: nextWeek,
     };
   });
-  const designId = get().currentDesignId;
-  if (designId) {
-    const artifact = artifactFromResult(firstArtifact, prompt, assistantMessage);
-    void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+  if (didApply) {
+    const designId = get().currentDesignId;
+    if (designId) {
+      const artifact = artifactFromResult(firstArtifact, prompt, assistantMessage);
+      void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+    }
+    if (persistError) {
+      console.warn('[open-codesign] failed to persist weekly usage:', persistError);
+      get().pushToast({
+        variant: 'error',
+        title: tr('errors.storageFailed'),
+        description: persistError,
+      });
+    }
   }
 }
 
@@ -593,6 +607,7 @@ async function runGenerate(
   advanceStageIfCurrent(get, set, generationId, 'parsing');
   advanceStageIfCurrent(get, set, generationId, 'rendering');
   applyGenerateSuccess(
+    get,
     set,
     get,
     generationId,
@@ -913,9 +928,10 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
         costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
       };
+      let persistError: string | null = null;
       set((s) => {
         const nextWeek = accumulateWeekUsage(s.weekUsage, usage, new Date());
-        persistWeekUsage(nextWeek);
+        persistError = persistWeekUsage(nextWeek);
         return {
           messages: [...s.messages, { role: 'assistant', content: assistantText }],
           previewHtml: firstArtifact?.content ?? s.previewHtml,
@@ -929,6 +945,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       if (designId) {
         const artifact = artifactFromResult(firstArtifact, userMessage.content, assistantText);
         void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+      }
+      if (persistError) {
+        console.warn('[open-codesign] failed to persist weekly usage:', persistError);
+        get().pushToast({
+          variant: 'error',
+          title: tr('errors.storageFailed'),
+          description: persistError,
+        });
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : tr('errors.unknown');

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -270,7 +270,8 @@ function readStoredWeekUsage(now: Date): WeekUsage {
       outputTokens: parsed.outputTokens,
       costUsd: parsed.costUsd,
     };
-  } catch {
+  } catch (err) {
+    console.warn('[open-codesign] failed to read weekly usage from storage:', err);
     return fresh;
   }
 }

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -55,6 +55,19 @@ export type InteractionMode = 'default' | 'comment';
 
 export type PreviewViewport = 'desktop' | 'tablet' | 'mobile';
 
+export interface UsageSnapshot {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+export interface WeekUsage {
+  isoWeek: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
 interface PromptRequest {
   prompt: string;
   attachments: LocalInputFile[];
@@ -68,6 +81,8 @@ interface CodesignState {
   activeGenerationId: string | null;
   generationStage: GenerationStage;
   streamingTokenCount: number;
+  lastUsage: UsageSnapshot | null;
+  weekUsage: WeekUsage;
   errorMessage: string | null;
   lastError: string | null;
   config: OnboardingState | null;
@@ -160,6 +175,7 @@ interface CodesignState {
 
 const THEME_STORAGE_KEY = 'open-codesign:theme';
 const PROJECTS_STORAGE_KEY = 'open-codesign:projects:v1';
+const WEEK_USAGE_STORAGE_KEY = 'open-codesign:week-usage';
 
 type ProjectsReadResult = { projects: Project[]; error: string | null };
 
@@ -215,6 +231,71 @@ function persistProjects(projects: Project[]): { error: string | null } {
     console.warn('[open-codesign] Failed to persist projects to storage:', err);
     return { error: msg };
   }
+}
+
+export function isoWeekKey(date: Date): string {
+  // ISO 8601 week-numbering: Thursday-anchored, Monday-start.
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+}
+
+function readStoredWeekUsage(now: Date): WeekUsage {
+  const fresh: WeekUsage = {
+    isoWeek: isoWeekKey(now),
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+  };
+  if (typeof window === 'undefined') return fresh;
+  try {
+    const raw = window.localStorage.getItem(WEEK_USAGE_STORAGE_KEY);
+    if (!raw) return fresh;
+    const parsed = JSON.parse(raw) as Partial<WeekUsage>;
+    if (
+      typeof parsed.isoWeek !== 'string' ||
+      typeof parsed.inputTokens !== 'number' ||
+      typeof parsed.outputTokens !== 'number' ||
+      typeof parsed.costUsd !== 'number'
+    ) {
+      return fresh;
+    }
+    if (parsed.isoWeek !== fresh.isoWeek) return fresh;
+    return {
+      isoWeek: parsed.isoWeek,
+      inputTokens: parsed.inputTokens,
+      outputTokens: parsed.outputTokens,
+      costUsd: parsed.costUsd,
+    };
+  } catch {
+    return fresh;
+  }
+}
+
+function persistWeekUsage(usage: WeekUsage): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(WEEK_USAGE_STORAGE_KEY, JSON.stringify(usage));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+export function accumulateWeekUsage(prev: WeekUsage, delta: UsageSnapshot, now: Date): WeekUsage {
+  const currentKey = isoWeekKey(now);
+  const base =
+    prev.isoWeek === currentKey
+      ? prev
+      : { isoWeek: currentKey, inputTokens: 0, outputTokens: 0, costUsd: 0 };
+  return {
+    isoWeek: currentKey,
+    inputTokens: base.inputTokens + Math.max(0, delta.inputTokens),
+    outputTokens: base.outputTokens + Math.max(0, delta.outputTokens),
+    costUsd: base.costUsd + Math.max(0, delta.costUsd),
+  };
 }
 
 function readInitialTheme(): Theme {
@@ -426,17 +507,35 @@ function applyGenerateSuccess(
   get: GetState,
   generationId: string,
   prompt: string,
-  result: { artifacts: Array<{ type?: string; content: string }>; message: string },
+  result: {
+    artifacts: Array<{ type?: string; content: string }>;
+    message: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    costUsd?: number;
+  },
 ): void {
   const firstArtifact = result.artifacts[0];
   const assistantMessage = result.message || tr('common.done');
-  finishIfCurrent(set, generationId, (state) => ({
-    messages: [...state.messages, { role: 'assistant', content: assistantMessage }],
-    previewHtml: firstArtifact?.content ?? state.previewHtml,
-    isGenerating: false,
-    activeGenerationId: null,
-    generationStage: 'done' as GenerationStage,
-  }));
+  const usage: UsageSnapshot = {
+    inputTokens: typeof result.inputTokens === 'number' ? result.inputTokens : 0,
+    outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
+    costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
+  };
+  finishIfCurrent(set, generationId, (state) => {
+    const nextWeek = accumulateWeekUsage(state.weekUsage, usage, new Date());
+    persistWeekUsage(nextWeek);
+    return {
+      messages: [...state.messages, { role: 'assistant', content: assistantMessage }],
+      previewHtml: firstArtifact?.content ?? state.previewHtml,
+      isGenerating: false,
+      activeGenerationId: null,
+      generationStage: 'done' as GenerationStage,
+      streamingTokenCount: usage.inputTokens + usage.outputTokens,
+      lastUsage: usage,
+      weekUsage: nextWeek,
+    };
+  });
   const designId = get().currentDesignId;
   if (designId) {
     const artifact = artifactFromResult(firstArtifact, prompt, assistantMessage);
@@ -498,7 +597,13 @@ async function runGenerate(
     get,
     generationId,
     payload.prompt,
-    result as { artifacts: Array<{ type?: string; content: string }>; message: string },
+    result as {
+      artifacts: Array<{ type?: string; content: string }>;
+      message: string;
+      inputTokens?: number;
+      outputTokens?: number;
+      costUsd?: number;
+    },
   );
 }
 
@@ -530,6 +635,8 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   activeGenerationId: null,
   generationStage: 'idle' as GenerationStage,
   streamingTokenCount: 0,
+  lastUsage: null,
+  weekUsage: readStoredWeekUsage(new Date()),
   errorMessage: null,
   lastError: null,
   config: null,
@@ -801,12 +908,23 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       });
       const firstArtifact = result.artifacts[0];
       const assistantText = result.message || tr('common.applied');
-      set((s) => ({
-        messages: [...s.messages, { role: 'assistant', content: assistantText }],
-        previewHtml: firstArtifact?.content ?? s.previewHtml,
-        isGenerating: false,
-        selectedElement: null,
-      }));
+      const usage: UsageSnapshot = {
+        inputTokens: typeof result.inputTokens === 'number' ? result.inputTokens : 0,
+        outputTokens: typeof result.outputTokens === 'number' ? result.outputTokens : 0,
+        costUsd: typeof result.costUsd === 'number' ? result.costUsd : 0,
+      };
+      set((s) => {
+        const nextWeek = accumulateWeekUsage(s.weekUsage, usage, new Date());
+        persistWeekUsage(nextWeek);
+        return {
+          messages: [...s.messages, { role: 'assistant', content: assistantText }],
+          previewHtml: firstArtifact?.content ?? s.previewHtml,
+          isGenerating: false,
+          selectedElement: null,
+          lastUsage: usage,
+          weekUsage: nextWeek,
+        };
+      });
       const designId = get().currentDesignId;
       if (designId) {
         const artifact = artifactFromResult(firstArtifact, userMessage.content, assistantText);

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -300,7 +300,8 @@
     },
     "spendThisWeek": "this week",
     "byokTitle": "BYOK — bring-your-own-key. Usage tracked locally.",
-    "spendTooltip": "Estimated spending this week"
+    "spendTooltip": "Estimated spending this week",
+    "lastUsageTooltip": "Last: {{input}} in / {{output}} out · ${{cost}}"
   },
   "theme": {
     "toggleAria": "Toggle theme",
@@ -414,7 +415,8 @@
     "unknown": "Unknown error",
     "localePersistFailed": "Failed to save language preference",
     "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist.",
-    "storageFailed": "Failed to save to local storage"
+    "storageFailed": "Failed to save to local storage",
+    "weekUsageReadFailed": "Couldn't read this week's usage from local storage. Showing fresh totals."
   },
   "projects": {
     "untitled": "Untitled design",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -416,6 +416,7 @@
     "localePersistFailed": "Failed to save language preference",
     "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist.",
     "storageFailed": "Failed to save to local storage",
+    "weekUsageInvalid": "Provider returned invalid usage values; ignored to keep weekly totals accurate.",
     "weekUsageReadFailed": "Couldn't read this week's usage from local storage. Showing fresh totals."
   },
   "projects": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -299,8 +299,8 @@
       }
     },
     "spendThisWeek": "this week",
-    "byokTitle": "BYOK — bring-your-own-key. Full usage tracking coming soon.",
-    "spendTooltip": "Spending this week (full tracking coming soon)"
+    "byokTitle": "BYOK — bring-your-own-key. Usage tracked locally.",
+    "spendTooltip": "Estimated spending this week"
   },
   "theme": {
     "toggleAria": "Toggle theme",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -413,7 +413,8 @@
     "modelListFailed": "Could not load model list.",
     "unknown": "Unknown error",
     "localePersistFailed": "Failed to save language preference",
-    "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist."
+    "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist.",
+    "storageFailed": "Failed to save to local storage"
   },
   "projects": {
     "untitled": "Untitled design",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -412,7 +412,8 @@
     "modelListFailed": "无法加载模型列表。",
     "unknown": "未知错误",
     "localePersistFailed": "无法保存语言偏好",
-    "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。"
+    "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。",
+    "storageFailed": "本地存储写入失败"
   },
   "projects": {
     "untitled": "未命名设计",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -298,8 +298,8 @@
       }
     },
     "spendThisWeek": "本周",
-    "byokTitle": "BYOK — 自带密钥，完整用量统计即将上线。",
-    "spendTooltip": "本周花费（完整统计即将上线）"
+    "byokTitle": "BYOK — 自带密钥，用量在本机统计。",
+    "spendTooltip": "本周预估花费"
   },
   "theme": {
     "toggleAria": "切换主题",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -415,6 +415,7 @@
     "localePersistFailed": "无法保存语言偏好",
     "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。",
     "storageFailed": "本地存储写入失败",
+    "weekUsageInvalid": "模型提供方返回了非法的用量值，已忽略以保证周用量统计准确。",
     "weekUsageReadFailed": "无法从本地存储读取本周用量，已重置为新一轮统计。"
   },
   "projects": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -299,7 +299,8 @@
     },
     "spendThisWeek": "本周",
     "byokTitle": "BYOK — 自带密钥，用量在本机统计。",
-    "spendTooltip": "本周预估花费"
+    "spendTooltip": "本周预估花费",
+    "lastUsageTooltip": "上次：{{input}} 输入 / {{output}} 输出 · ${{cost}}"
   },
   "theme": {
     "toggleAria": "切换主题",
@@ -413,7 +414,8 @@
     "unknown": "未知错误",
     "localePersistFailed": "无法保存语言偏好",
     "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。",
-    "storageFailed": "本地存储写入失败"
+    "storageFailed": "本地存储写入失败",
+    "weekUsageReadFailed": "无法从本地存储读取本周用量，已重置为新一轮统计。"
   },
   "projects": {
     "untitled": "未命名设计",


### PR DESCRIPTION
## Summary

Two user-reported bugs from the v0.x feedback round:

**A. Preview iframe was laggy.** `PreviewPane` set `key={previewHtml.length}` on the iframe, which forced React to fully unmount and re-mount it whenever the HTML grew or shrank by even one character. During streaming and on every `applyComment` revision the entire document was re-parsed from scratch, scroll position was discarded, and the overlay script re-attached on each chunk. `buildSrcdoc()` (regex-heavy) also ran on every unrelated render (toast / theme / errors).

**B. TopBar always showed `$0.00 this week`.** The badge was hard-coded. The generate IPC already returned `inputTokens` / `outputTokens` / `costUsd` from `@open-codesign/core`, but the renderer store cast the result to `{ artifacts, message }` and threw the rest away. There was no end-to-end wire.

### Changes

- `PreviewPane`: drop the length-based `key`, memoize `buildSrcdoc(previewHtml)`.
- Type the preload `generate` / `applyComment` returns as `GenerateResponse`.
- Store gains `lastUsage` and `weekUsage`; both `applyGenerateSuccess` and `applyInlineComment` now record per-call usage and accumulate it into the active ISO-week bucket.
- Persist `weekUsage` to localStorage under `open-codesign:week-usage`. Auto-resets when the ISO week rolls over (no migration). Matches existing theme persistence pattern; SQLite-backed history can absorb this later without schema churn.
- TopBar reads `weekUsage.costUsd` and shows `lastUsage` in the tooltip. New `formatCostUsd` shows 4 decimals for sub-cent values so the user sees a non-zero number after their first request.
- i18n updated (en + zh-CN) to drop the "coming soon" disclaimer.

### Root causes

- **Preview perf:** `key={previewHtml.length}` is the smoking gun — it forced full iframe remounts on every char change in the HTML.
- **Token counter:** the IPC contract was complete, but the renderer-side reducer in `applyGenerateSuccess` only consumed `artifacts` + `message`, and `ByokBadge` never read store state.

### Tests

- `store.test.ts`: usage payload accepted (full + missing-fields fallback), accumulator handles week rollover and clamps negative deltas. 5 new test cases.
- `TopBar.test.ts`: new — `formatCostUsd` covers zero / sub-cent / multi-cent paths.
- All 146 desktop vitest tests pass; full repo `pnpm test` green; `pnpm typecheck` clean; `pnpm lint` clean (0 errors, 7 pre-existing complexity warnings unchanged).

### PRINCIPLES §5b

- Compatibility: green — IPC payload shape unchanged; store adds optional fields; localStorage key is new and bucket auto-resets.
- Upgradeability: green — `WeekUsage.isoWeek` carries the bucket key; future migration to SQLite is a one-shot read of localStorage.
- No bloat: green — no new deps; ~40 lines of helper code in store; one tiny memoization in PreviewPane.
- Elegance: green — single source of truth (`weekUsage` in store), no plumbing through preload beyond a typed return.

### Known follow-ups

- Sandbox-runtime perf: if streaming preview still feels slow after this PR, the next layer is to swap the full-srcdoc swap for a `contentDocument.body.innerHTML` patch that preserves scroll. Out of scope here — needs the sandbox-runtime research thread to land first (`docs/RESEARCH_QUEUE.md`).
- Token persistence currently lives in localStorage. Once the SQLite history schema lands, migrate `weekUsage` into a `usage_buckets` table keyed by ISO week; `accumulateWeekUsage` is already pure and reusable.
- `pi-ai` providers that don't return usage will show `$0.00`; a chars/4 fallback estimator can be added behind a feature flag if users complain.

cc: do not merge until Codex bot review reports No findings.