### PR TITLE
[Claude Design adoption] PR-A: designs hub + multi-type create wizard

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -135,7 +135,7 @@ export function App() {
                 {t('hub.backToHub')}
               </button>
             </div>
-            <div className="flex-1 min-h-0 grid grid-cols-[360px_1fr]">
+            <div className="flex-1 min-h-0 grid grid-cols-[var(--size-hub-sidebar)_1fr]">
               <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
               <main className="flex flex-col min-h-0">
                 <PreviewPane onPickStarter={(p) => setPrompt(p)} />

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -117,7 +117,12 @@ export function App() {
         {view === 'settings' ? (
           <Settings />
         ) : view === 'hub' ? (
-          <HubView />
+          <HubView
+            onUseExamplePrompt={(p) => {
+              setPrompt(p);
+              setView('workspace');
+            }}
+          />
         ) : (
           <div className="h-full flex flex-col">
             <div className="px-[var(--space-5)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)]">

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { useT } from '@open-codesign/i18n';
+import { ChevronLeft } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { CommandPalette } from './components/CommandPalette';
 import { PreviewPane } from './components/PreviewPane';
@@ -9,6 +10,7 @@ import { TopBar } from './components/TopBar';
 import { useKeyboard } from './hooks/useKeyboard';
 import { Onboarding } from './onboarding';
 import { useCodesignStore } from './store';
+import { HubView } from './views/HubView';
 
 export function App() {
   const t = useT();
@@ -73,6 +75,10 @@ export function App() {
           }
           if (view === 'settings') {
             setView('workspace');
+            return;
+          }
+          if (view === 'workspace') {
+            setView('hub');
           }
         },
         preventDefault: false,
@@ -110,12 +116,26 @@ export function App() {
       <div className="flex-1 min-h-0">
         {view === 'settings' ? (
           <Settings />
+        ) : view === 'hub' ? (
+          <HubView />
         ) : (
-          <div className="h-full grid grid-cols-[360px_1fr]">
-            <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
-            <main className="flex flex-col min-h-0">
-              <PreviewPane onPickStarter={(p) => setPrompt(p)} />
-            </main>
+          <div className="h-full flex flex-col">
+            <div className="px-[var(--space-5)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)]">
+              <button
+                type="button"
+                onClick={() => setView('hub')}
+                className="inline-flex items-center gap-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+              >
+                <ChevronLeft className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]" />
+                {t('hub.backToHub')}
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 grid grid-cols-[360px_1fr]">
+              <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
+              <main className="flex flex-col min-h-0">
+                <PreviewPane onPickStarter={(p) => setPrompt(p)} />
+              </main>
+            </div>
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -331,3 +331,49 @@ describe('useCodesignStore active provider routing', () => {
     expect(payload.model.modelId).toBe('gpt-4o');
   });
 });
+
+describe('useCodesignStore project storage error surfacing', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('createProject pushes a toast when localStorage.setItem throws and keeps the project in memory', () => {
+    const setItem = vi.fn(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const getItem = vi.fn(() => null);
+
+    vi.stubGlobal('window', {
+      localStorage: { setItem, getItem, removeItem: vi.fn(), clear: vi.fn() },
+      setTimeout,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const projectsBefore = useCodesignStore.getState().projects;
+    const toastsBefore = useCodesignStore.getState().toasts.length;
+
+    const project = useCodesignStore
+      .getState()
+      .createProject({ name: 'My Project', type: 'slideDeck' });
+
+    const state = useCodesignStore.getState();
+
+    // In-memory state stays consistent — the project was added even though persist failed.
+    expect(state.projects[0]).toEqual(project);
+    expect(state.projects).toHaveLength(projectsBefore.length + 1);
+    expect(state.currentProjectId).toBe(project.id);
+
+    // Toast surfaced with the i18n title and the underlying error message.
+    expect(state.toasts.length).toBe(toastsBefore + 1);
+    expect(state.toasts.at(-1)).toMatchObject({
+      variant: 'error',
+      description: 'QuotaExceededError',
+    });
+    expect(state.toasts.at(-1)?.title).toBeTruthy();
+
+    expect(setItem).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1,6 +1,7 @@
 import { initI18n } from '@open-codesign/i18n';
-import type { OnboardingState } from '@open-codesign/shared';
+import type { LocalInputFile, OnboardingState, SelectedElement } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GenerationStage } from './store';
 import { useCodesignStore } from './store';
 
 const READY_CONFIG: OnboardingState = {
@@ -375,5 +376,63 @@ describe('useCodesignStore project storage error surfacing', () => {
     expect(warnSpy).toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+
+  it('createProject resets project-scoped workspace state when switching to the new project', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        setItem: vi.fn(),
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      },
+      setTimeout,
+    });
+
+    const staleFile: LocalInputFile = {
+      path: '/tmp/old.png',
+      name: 'old.png',
+      size: 1,
+    };
+    const staleSelection: SelectedElement = {
+      selector: '.stale',
+      tag: 'div',
+      outerHTML: '<div class="stale">old</div>',
+      rect: { top: 0, left: 0, width: 10, height: 10 },
+    };
+
+    useCodesignStore.setState({
+      messages: [{ role: 'user', content: 'old prompt' }],
+      previewHtml: '<html>old</html>',
+      inputFiles: [staleFile],
+      referenceUrl: 'https://example.com/old',
+      selectedElement: staleSelection,
+      lastPromptInput: { prompt: 'old prompt', attachments: [staleFile] },
+      isGenerating: true,
+      activeGenerationId: 'gen-old',
+      errorMessage: 'stale error',
+      lastError: 'stale error',
+      generationStage: 'streaming' as GenerationStage,
+    });
+
+    const project = useCodesignStore
+      .getState()
+      .createProject({ name: 'Fresh Project', type: 'prototype' });
+
+    const state = useCodesignStore.getState();
+    expect(state.currentProjectId).toBe(project.id);
+    expect(state.view).toBe('workspace');
+    expect(state.createProjectModalOpen).toBe(false);
+    expect(state.messages).toEqual([]);
+    expect(state.previewHtml).toBeNull();
+    expect(state.inputFiles).toEqual([]);
+    expect(state.referenceUrl).toBe('');
+    expect(state.selectedElement).toBeNull();
+    expect(state.lastPromptInput).toBeNull();
+    expect(state.isGenerating).toBe(false);
+    expect(state.activeGenerationId).toBeNull();
+    expect(state.errorMessage).toBeNull();
+    expect(state.lastError).toBeNull();
+    expect(state.generationStage).toBe('idle');
   });
 });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -231,8 +231,8 @@ describe('useCodesignStore generation cancellation', () => {
 });
 
 describe('useCodesignStore view navigation', () => {
-  it('starts on workspace view', () => {
-    expect(useCodesignStore.getState().view).toBe('workspace');
+  it('starts on hub view', () => {
+    expect(useCodesignStore.getState().view).toBe('hub');
   });
 
   it('setView("settings") switches to settings and closes command palette', () => {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -723,7 +723,15 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       createProjectModalOpen: false,
       messages: [],
       previewHtml: null,
+      inputFiles: [],
+      referenceUrl: '',
+      selectedElement: null,
+      lastPromptInput: null,
       generationStage: 'idle' as GenerationStage,
+      isGenerating: false,
+      activeGenerationId: null,
+      errorMessage: null,
+      lastError: null,
     });
     if (persist.error) {
       get().pushToast({

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,11 +1,14 @@
 import { i18n } from '@open-codesign/i18n';
-import type {
-  ChatMessage,
-  LocalInputFile,
-  ModelRef,
-  OnboardingState,
-  SelectedElement,
-  SupportedOnboardingProvider,
+import {
+  type ChatMessage,
+  type LocalInputFile,
+  type ModelRef,
+  type OnboardingState,
+  PROJECT_SCHEMA_VERSION,
+  type Project,
+  type ProjectDraft,
+  type SelectedElement,
+  type SupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import { create } from 'zustand';
 import type { StoreApi } from 'zustand';
@@ -45,7 +48,8 @@ export interface ConnectionStatus {
 }
 
 export type Theme = 'light' | 'dark';
-export type AppView = 'workspace' | 'settings';
+export type AppView = 'hub' | 'workspace' | 'settings';
+export type HubTab = 'recent' | 'your' | 'examples' | 'designSystems';
 
 interface PromptRequest {
   prompt: string;
@@ -69,6 +73,10 @@ interface CodesignState {
 
   theme: Theme;
   view: AppView;
+  hubTab: HubTab;
+  projects: Project[];
+  currentProjectId: string | null;
+  createProjectModalOpen: boolean;
   commandPaletteOpen: boolean;
   toasts: Toast[];
   iframeErrors: string[];
@@ -108,6 +116,11 @@ interface CodesignState {
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
   setView: (view: AppView) => void;
+  setHubTab: (tab: HubTab) => void;
+  openCreateProjectModal: () => void;
+  closeCreateProjectModal: () => void;
+  createProject: (draft: ProjectDraft) => Project;
+  openProject: (id: string) => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
 
@@ -116,6 +129,34 @@ interface CodesignState {
 }
 
 const THEME_STORAGE_KEY = 'open-codesign:theme';
+const PROJECTS_STORAGE_KEY = 'open-codesign:projects:v1';
+
+function readStoredProjects(): Project[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(PROJECTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (p): p is Project =>
+        typeof p === 'object' &&
+        p !== null &&
+        (p as { schemaVersion?: unknown }).schemaVersion === PROJECT_SCHEMA_VERSION,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function persistProjects(projects: Project[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects));
+  } catch {
+    // localStorage unavailable
+  }
+}
 
 function readInitialTheme(): Theme {
   if (typeof window === 'undefined') return 'light';
@@ -292,7 +333,11 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   connectionStatus: { state: 'no_provider', lastTestedAt: null, lastError: null },
 
   theme: readInitialTheme(),
-  view: 'workspace' as AppView,
+  view: 'hub' as AppView,
+  hubTab: 'recent' as HubTab,
+  projects: readStoredProjects(),
+  currentProjectId: null,
+  createProjectModalOpen: false,
   commandPaletteOpen: false,
   toasts: [],
   iframeErrors: [],
@@ -611,6 +656,51 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   setView(view) {
     set({ view, commandPaletteOpen: false });
+  },
+
+  setHubTab(tab) {
+    set({ hubTab: tab });
+  },
+
+  openCreateProjectModal() {
+    set({ createProjectModalOpen: true });
+  },
+
+  closeCreateProjectModal() {
+    set({ createProjectModalOpen: false });
+  },
+
+  createProject(draft) {
+    const now = new Date().toISOString();
+    const project: Project = {
+      schemaVersion: PROJECT_SCHEMA_VERSION,
+      id: newId(),
+      name: draft.name.trim(),
+      type: draft.type,
+      createdAt: now,
+      updatedAt: now,
+      ...(draft.fidelity ? { fidelity: draft.fidelity } : {}),
+      ...(draft.speakerNotes !== undefined ? { speakerNotes: draft.speakerNotes } : {}),
+      ...(draft.templateId ? { templateId: draft.templateId } : {}),
+    };
+    const next = [project, ...get().projects];
+    persistProjects(next);
+    set({
+      projects: next,
+      currentProjectId: project.id,
+      view: 'workspace',
+      createProjectModalOpen: false,
+      messages: [],
+      previewHtml: null,
+      generationStage: 'idle' as GenerationStage,
+    });
+    return project;
+  },
+
+  openProject(id) {
+    const project = get().projects.find((p) => p.id === id);
+    if (!project) return;
+    set({ currentProjectId: id, view: 'workspace' });
   },
 
   openCommandPalette() {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -5,7 +5,7 @@ import {
   type ModelRef,
   type OnboardingState,
   PROJECT_SCHEMA_VERSION,
-  type Project,
+  Project,
   type ProjectDraft,
   type SelectedElement,
   type SupportedOnboardingProvider,
@@ -131,30 +131,59 @@ interface CodesignState {
 const THEME_STORAGE_KEY = 'open-codesign:theme';
 const PROJECTS_STORAGE_KEY = 'open-codesign:projects:v1';
 
-function readStoredProjects(): Project[] {
-  if (typeof window === 'undefined') return [];
+type ProjectsReadResult = { projects: Project[]; error: string | null };
+
+function readStoredProjects(): ProjectsReadResult {
+  if (typeof window === 'undefined') return { projects: [], error: null };
+  let raw: string | null;
   try {
-    const raw = window.localStorage.getItem(PROJECTS_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (p): p is Project =>
-        typeof p === 'object' &&
-        p !== null &&
-        (p as { schemaVersion?: unknown }).schemaVersion === PROJECT_SCHEMA_VERSION,
-    );
-  } catch {
-    return [];
+    raw = window.localStorage.getItem(PROJECTS_STORAGE_KEY);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn('[open-codesign] Failed to read projects from storage:', err);
+    return { projects: [], error: msg };
   }
+  if (!raw) return { projects: [], error: null };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn('[open-codesign] Failed to parse stored projects:', err);
+    return { projects: [], error: msg };
+  }
+  if (!Array.isArray(parsed)) {
+    const msg = 'Invalid projects storage payload: expected array';
+    console.warn(`[open-codesign] ${msg}`);
+    return { projects: [], error: msg };
+  }
+  const projects: Project[] = [];
+  let invalidCount = 0;
+  for (const item of parsed) {
+    const result = Project.safeParse(item);
+    if (result.success && result.data.schemaVersion === PROJECT_SCHEMA_VERSION) {
+      projects.push(result.data);
+    } else {
+      invalidCount += 1;
+    }
+  }
+  if (invalidCount > 0) {
+    const msg = `Skipped ${invalidCount} invalid project record(s) in storage`;
+    console.warn(`[open-codesign] ${msg}`);
+    return { projects, error: msg };
+  }
+  return { projects, error: null };
 }
 
-function persistProjects(projects: Project[]): void {
-  if (typeof window === 'undefined') return;
+function persistProjects(projects: Project[]): { error: string | null } {
+  if (typeof window === 'undefined') return { error: null };
   try {
     window.localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects));
-  } catch {
-    // localStorage unavailable
+    return { error: null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn('[open-codesign] Failed to persist projects to storage:', err);
+    return { error: msg };
   }
 }
 
@@ -318,6 +347,8 @@ function buildPromptRequest(
   };
 }
 
+const initialProjectsRead = readStoredProjects();
+
 export const useCodesignStore = create<CodesignState>((set, get) => ({
   messages: [],
   previewHtml: null,
@@ -335,7 +366,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   theme: readInitialTheme(),
   view: 'hub' as AppView,
   hubTab: 'recent' as HubTab,
-  projects: readStoredProjects(),
+  projects: initialProjectsRead.projects,
   currentProjectId: null,
   createProjectModalOpen: false,
   commandPaletteOpen: false,
@@ -684,7 +715,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       ...(draft.templateId ? { templateId: draft.templateId } : {}),
     };
     const next = [project, ...get().projects];
-    persistProjects(next);
+    const persist = persistProjects(next);
     set({
       projects: next,
       currentProjectId: project.id,
@@ -694,13 +725,34 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       previewHtml: null,
       generationStage: 'idle' as GenerationStage,
     });
+    if (persist.error) {
+      get().pushToast({
+        variant: 'error',
+        title: tr('errors.projectStorageFailed'),
+        description: persist.error,
+      });
+    }
     return project;
   },
 
   openProject(id) {
     const project = get().projects.find((p) => p.id === id);
     if (!project) return;
-    set({ currentProjectId: id, view: 'workspace' });
+    set({
+      currentProjectId: id,
+      view: 'workspace',
+      messages: [],
+      previewHtml: null,
+      inputFiles: [],
+      referenceUrl: '',
+      selectedElement: null,
+      lastPromptInput: null,
+      generationStage: 'idle' as GenerationStage,
+      isGenerating: false,
+      activeGenerationId: null,
+      errorMessage: null,
+      lastError: null,
+    });
   },
 
   openCommandPalette() {
@@ -725,3 +777,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
   },
 }));
+
+if (initialProjectsRead.error && typeof window !== 'undefined') {
+  // Defer so i18n + UI have a chance to mount before the toast renders.
+  setTimeout(() => {
+    useCodesignStore.getState().pushToast({
+      variant: 'error',
+      title: tr('errors.projectStorageFailed'),
+      description: initialProjectsRead.error ?? '',
+    });
+  }, 0);
+}

--- a/apps/desktop/src/renderer/src/views/HubView.tsx
+++ b/apps/desktop/src/renderer/src/views/HubView.tsx
@@ -1,0 +1,70 @@
+import { useT } from '@open-codesign/i18n';
+import { Plus } from 'lucide-react';
+import { type HubTab, useCodesignStore } from '../store';
+import { CreateProjectModal } from './create/CreateProjectModal';
+import { DesignSystemsTab } from './hub/DesignSystemsTab';
+import { ExamplesTab } from './hub/ExamplesTab';
+import { RecentTab } from './hub/RecentTab';
+import { YourDesignsTab } from './hub/YourDesignsTab';
+
+const TABS: HubTab[] = ['recent', 'your', 'examples', 'designSystems'];
+
+export function HubView() {
+  const t = useT();
+  const hubTab = useCodesignStore((s) => s.hubTab);
+  const setHubTab = useCodesignStore((s) => s.setHubTab);
+  const openCreateProjectModal = useCodesignStore((s) => s.openCreateProjectModal);
+  const createProjectModalOpen = useCodesignStore((s) => s.createProjectModalOpen);
+
+  return (
+    <div className="h-full flex flex-col bg-[var(--color-background)] overflow-hidden">
+      <header className="px-[var(--space-8)] pt-[var(--space-8)] pb-[var(--space-4)] flex items-end justify-between gap-[var(--space-4)] border-b border-[var(--color-border-muted)]">
+        <div className="flex items-end gap-[var(--space-8)]">
+          <h1
+            className="display text-[var(--text-2xl)] leading-[var(--leading-heading)] tracking-[var(--tracking-heading)] text-[var(--color-text-primary)] m-0"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {t('hub.tabs.your')}
+          </h1>
+          <nav className="flex items-center gap-[var(--space-1)]" aria-label={t('hub.tabs.your')}>
+            {TABS.map((tab) => {
+              const active = tab === hubTab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setHubTab(tab)}
+                  aria-current={active ? 'page' : undefined}
+                  className={`px-[var(--space-3)] py-[var(--space-2)] rounded-[var(--radius-md)] text-[var(--text-sm)] transition-colors ${
+                    active
+                      ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)] font-medium'
+                      : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)]'
+                  }`}
+                >
+                  {t(`hub.tabs.${tab}`)}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+        <button
+          type="button"
+          onClick={openCreateProjectModal}
+          className="inline-flex items-center gap-[var(--space-2)] h-[var(--size-control-md)] px-[var(--space-4)] rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] hover:scale-[var(--scale-hover-up)] active:scale-[var(--scale-press-down)] transition-[transform,background-color] duration-[var(--duration-faster)] ease-[var(--ease-out)]"
+        >
+          <Plus className="w-[var(--size-icon-md)] h-[var(--size-icon-md)]" strokeWidth={2.4} />
+          {t('hub.newDesign')}
+        </button>
+      </header>
+
+      <main className="flex-1 min-h-0 overflow-y-auto px-[var(--space-8)] py-[var(--space-6)]">
+        {hubTab === 'recent' ? <RecentTab /> : null}
+        {hubTab === 'your' ? <YourDesignsTab /> : null}
+        {hubTab === 'examples' ? <ExamplesTab /> : null}
+        {hubTab === 'designSystems' ? <DesignSystemsTab /> : null}
+      </main>
+
+      {createProjectModalOpen ? <CreateProjectModal /> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/HubView.tsx
+++ b/apps/desktop/src/renderer/src/views/HubView.tsx
@@ -9,7 +9,11 @@ import { YourDesignsTab } from './hub/YourDesignsTab';
 
 const TABS: HubTab[] = ['recent', 'your', 'examples', 'designSystems'];
 
-export function HubView() {
+export interface HubViewProps {
+  onUseExamplePrompt?: (prompt: string) => void;
+}
+
+export function HubView({ onUseExamplePrompt }: HubViewProps = {}) {
   const t = useT();
   const hubTab = useCodesignStore((s) => s.hubTab);
   const setHubTab = useCodesignStore((s) => s.setHubTab);
@@ -60,7 +64,9 @@ export function HubView() {
       <main className="flex-1 min-h-0 overflow-y-auto px-[var(--space-8)] py-[var(--space-6)]">
         {hubTab === 'recent' ? <RecentTab /> : null}
         {hubTab === 'your' ? <YourDesignsTab /> : null}
-        {hubTab === 'examples' ? <ExamplesTab /> : null}
+        {hubTab === 'examples' ? (
+          <ExamplesTab onUsePrompt={(example) => onUseExamplePrompt?.(example.prompt)} />
+        ) : null}
         {hubTab === 'designSystems' ? <DesignSystemsTab /> : null}
       </main>
 

--- a/apps/desktop/src/renderer/src/views/create/CreateProjectModal.test.ts
+++ b/apps/desktop/src/renderer/src/views/create/CreateProjectModal.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildDraft } from './CreateProjectModal';
+
+describe('CreateProjectModal.buildDraft', () => {
+  it('returns null when name is empty (CTA stays disabled)', () => {
+    expect(
+      buildDraft({ type: 'prototype', name: '   ', speakerNotes: false, templateId: '' }),
+    ).toBeNull();
+  });
+
+  it('builds a prototype draft', () => {
+    const draft = buildDraft({
+      type: 'prototype',
+      name: '  Onboarding flow ',
+      speakerNotes: false,
+      templateId: '',
+    });
+    expect(draft).toEqual({ name: 'Onboarding flow', type: 'prototype' });
+  });
+
+  it('builds a slide-deck draft and preserves speakerNotes', () => {
+    const draft = buildDraft({
+      type: 'slideDeck',
+      name: 'Pitch',
+      speakerNotes: true,
+      templateId: '',
+    });
+    expect(draft).toEqual({ name: 'Pitch', type: 'slideDeck', speakerNotes: true });
+  });
+
+  it('refuses a template draft when no template is picked', () => {
+    expect(
+      buildDraft({ type: 'template', name: 'Demo', speakerNotes: false, templateId: '' }),
+    ).toBeNull();
+  });
+
+  it('builds a from-template draft when a template id is provided', () => {
+    const draft = buildDraft({
+      type: 'template',
+      name: 'Demo',
+      speakerNotes: false,
+      templateId: 'meditation-app',
+    });
+    expect(draft).toEqual({ name: 'Demo', type: 'template', templateId: 'meditation-app' });
+  });
+
+  it('builds an other draft', () => {
+    const draft = buildDraft({
+      type: 'other',
+      name: 'Free form',
+      speakerNotes: false,
+      templateId: '',
+    });
+    expect(draft).toEqual({ name: 'Free form', type: 'other' });
+  });
+});

--- a/apps/desktop/src/renderer/src/views/create/CreateProjectModal.tsx
+++ b/apps/desktop/src/renderer/src/views/create/CreateProjectModal.tsx
@@ -1,0 +1,181 @@
+import { getCurrentLocale, useT } from '@open-codesign/i18n';
+import type { ProjectDraft, ProjectType } from '@open-codesign/shared';
+import { type DemoTemplate, getDemos } from '@open-codesign/templates';
+import { X } from 'lucide-react';
+import { useEffect, useId, useMemo, useState } from 'react';
+import { useCodesignStore } from '../../store';
+import { FromTemplateForm, buildFromTemplateDraft } from './FromTemplateForm';
+import { OtherForm, buildOtherDraft } from './OtherForm';
+import { PrototypeForm, buildPrototypeDraft } from './PrototypeForm';
+import { SlideDeckForm, buildSlideDeckDraft } from './SlideDeckForm';
+
+const TYPES: ProjectType[] = ['prototype', 'slideDeck', 'template', 'other'];
+
+export interface BuildDraftInput {
+  type: ProjectType;
+  name: string;
+  speakerNotes: boolean;
+  templateId: string;
+}
+
+export function buildDraft({
+  type,
+  name,
+  speakerNotes,
+  templateId,
+}: BuildDraftInput): ProjectDraft | null {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  switch (type) {
+    case 'prototype':
+      return buildPrototypeDraft(trimmed);
+    case 'slideDeck':
+      return buildSlideDeckDraft(trimmed, speakerNotes);
+    case 'template':
+      if (!templateId) return null;
+      return buildFromTemplateDraft(trimmed, templateId);
+    case 'other':
+      return buildOtherDraft(trimmed);
+  }
+}
+
+export function CreateProjectModal() {
+  const t = useT();
+  const closeModal = useCodesignStore((s) => s.closeCreateProjectModal);
+  const createProject = useCodesignStore((s) => s.createProject);
+  const titleId = useId();
+
+  const templates = useMemo<DemoTemplate[]>(() => getDemos(getCurrentLocale()), []);
+
+  const [type, setType] = useState<ProjectType>('prototype');
+  const [name, setName] = useState('');
+  const [speakerNotes, setSpeakerNotes] = useState(true);
+  const [templateId, setTemplateId] = useState<string>(templates[0]?.id ?? '');
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') closeModal();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [closeModal]);
+
+  const draft = buildDraft({ type, name, speakerNotes, templateId });
+  const canSubmit = draft !== null;
+
+  function submit(): void {
+    if (!draft) return;
+    createProject(draft);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-[var(--space-4)]"
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> conflicts with our custom backdrop click + overlay token theming.
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <button
+        type="button"
+        aria-label={t('create.close')}
+        onClick={closeModal}
+        className="absolute inset-0 bg-[var(--color-overlay)]"
+      />
+      <div className="relative w-full max-w-[560px] max-h-[calc(100vh-var(--space-12))] overflow-y-auto rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
+        <header className="flex items-start justify-between gap-[var(--space-4)] px-[var(--space-6)] pt-[var(--space-6)] pb-[var(--space-3)]">
+          <div className="space-y-[var(--space-1)]">
+            <h2
+              id={titleId}
+              className="display text-[var(--text-lg)] tracking-[var(--tracking-heading)] text-[var(--color-text-primary)] m-0"
+            >
+              {t('create.title')}
+            </h2>
+            <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] m-0 leading-[var(--leading-snug)]">
+              {t('create.subtitle')}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={closeModal}
+            aria-label={t('create.close')}
+            className="inline-flex items-center justify-center w-[var(--size-control-sm)] h-[var(--size-control-sm)] rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <X className="w-[var(--size-icon-md)] h-[var(--size-icon-md)]" />
+          </button>
+        </header>
+
+        <div
+          role="tablist"
+          aria-label={t('create.title')}
+          className="flex items-center gap-[var(--space-1)] px-[var(--space-6)] border-b border-[var(--color-border-muted)]"
+        >
+          {TYPES.map((kind) => {
+            const active = kind === type;
+            return (
+              <button
+                key={kind}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setType(kind)}
+                className={`px-[var(--space-3)] py-[var(--space-2)] text-[var(--text-sm)] border-b-2 -mb-px transition-colors ${
+                  active
+                    ? 'border-[var(--color-accent)] text-[var(--color-text-primary)] font-medium'
+                    : 'border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                {t(`create.types.${kind}`)}
+              </button>
+            );
+          })}
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+          className="px-[var(--space-6)] py-[var(--space-5)] space-y-[var(--space-4)]"
+        >
+          <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-snug)] m-0">
+            {t(`create.typeDescriptions.${type}`)}
+          </p>
+
+          {type === 'prototype' ? <PrototypeForm name={name} setName={setName} /> : null}
+          {type === 'slideDeck' ? (
+            <SlideDeckForm
+              name={name}
+              setName={setName}
+              speakerNotes={speakerNotes}
+              setSpeakerNotes={setSpeakerNotes}
+            />
+          ) : null}
+          {type === 'template' ? (
+            <FromTemplateForm
+              name={name}
+              setName={setName}
+              templateId={templateId}
+              setTemplateId={setTemplateId}
+              templates={templates}
+            />
+          ) : null}
+          {type === 'other' ? <OtherForm name={name} setName={setName} /> : null}
+
+          <footer className="flex items-center justify-between gap-[var(--space-3)] pt-[var(--space-2)]">
+            <span className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
+              {canSubmit ? '\u00a0' : t('create.disabledHint')}
+            </span>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="inline-flex items-center justify-center h-[var(--size-control-md)] px-[var(--space-5)] rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium shadow-[var(--shadow-soft)] hover:bg-[var(--color-accent-hover)] disabled:opacity-40 disabled:pointer-events-none transition-colors"
+            >
+              {t('create.cta')}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/create/CreateProjectModal.tsx
+++ b/apps/desktop/src/renderer/src/views/create/CreateProjectModal.tsx
@@ -82,7 +82,7 @@ export function CreateProjectModal() {
         onClick={closeModal}
         className="absolute inset-0 bg-[var(--color-overlay)]"
       />
-      <div className="relative w-full max-w-[560px] max-h-[calc(100vh-var(--space-12))] overflow-y-auto rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
+      <div className="relative w-full max-w-[var(--size-modal-md)] max-h-[calc(100vh-var(--space-12))] overflow-y-auto rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
         <header className="flex items-start justify-between gap-[var(--space-4)] px-[var(--space-6)] pt-[var(--space-6)] pb-[var(--space-3)]">
           <div className="space-y-[var(--space-1)]">
             <h2

--- a/apps/desktop/src/renderer/src/views/create/FromTemplateForm.tsx
+++ b/apps/desktop/src/renderer/src/views/create/FromTemplateForm.tsx
@@ -1,0 +1,70 @@
+import { useT } from '@open-codesign/i18n';
+import type { ProjectDraft } from '@open-codesign/shared';
+import type { DemoTemplate } from '@open-codesign/templates';
+import { FieldHelp, NameField } from './fields';
+
+export interface FromTemplateFormProps {
+  name: string;
+  setName: (next: string) => void;
+  templateId: string;
+  setTemplateId: (next: string) => void;
+  templates: DemoTemplate[];
+}
+
+export function FromTemplateForm({
+  name,
+  setName,
+  templateId,
+  setTemplateId,
+  templates,
+}: FromTemplateFormProps) {
+  const t = useT();
+  return (
+    <div className="space-y-[var(--space-4)]">
+      <NameField inputId="cd-create-name-template" value={name} onChange={setName} />
+      <fieldset className="space-y-[var(--space-2)] m-0 p-0 border-0">
+        <legend className="block text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium mb-[var(--space-1)]">
+          {t('create.fields.template')}
+        </legend>
+        <div className="grid grid-cols-1 gap-[var(--space-2)]">
+          {templates.map((tmpl) => {
+            const checked = templateId === tmpl.id;
+            return (
+              <label
+                key={tmpl.id}
+                className={`flex items-start gap-[var(--space-3)] rounded-[var(--radius-md)] border px-[var(--space-3)] py-[var(--space-3)] cursor-pointer transition-colors ${
+                  checked
+                    ? 'border-[var(--color-accent)] bg-[var(--color-accent-soft)]'
+                    : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-hover)]'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="cd-create-template"
+                  value={tmpl.id}
+                  checked={checked}
+                  onChange={() => setTemplateId(tmpl.id)}
+                  className="mt-[var(--space-1)] accent-[var(--color-accent)]"
+                />
+                <span className="space-y-[var(--space-0_5)] min-w-0">
+                  <span className="block text-[var(--text-sm)] font-medium text-[var(--color-text-primary)] truncate">
+                    {tmpl.title}
+                  </span>
+                  <span className="block text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-snug)]">
+                    {tmpl.description}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+        <FieldHelp>{t('create.fields.templateHint')}</FieldHelp>
+      </fieldset>
+      <FieldHelp>{t('create.help.templates')}</FieldHelp>
+    </div>
+  );
+}
+
+export function buildFromTemplateDraft(name: string, templateId: string): ProjectDraft {
+  return { name: name.trim(), type: 'template', templateId };
+}

--- a/apps/desktop/src/renderer/src/views/create/OtherForm.tsx
+++ b/apps/desktop/src/renderer/src/views/create/OtherForm.tsx
@@ -1,0 +1,22 @@
+import { useT } from '@open-codesign/i18n';
+import type { ProjectDraft } from '@open-codesign/shared';
+import { FieldHelp, NameField } from './fields';
+
+export interface OtherFormProps {
+  name: string;
+  setName: (next: string) => void;
+}
+
+export function OtherForm({ name, setName }: OtherFormProps) {
+  const t = useT();
+  return (
+    <div className="space-y-[var(--space-4)]">
+      <NameField inputId="cd-create-name-other" value={name} onChange={setName} />
+      <FieldHelp>{t('create.help.share')}</FieldHelp>
+    </div>
+  );
+}
+
+export function buildOtherDraft(name: string): ProjectDraft {
+  return { name: name.trim(), type: 'other' };
+}

--- a/apps/desktop/src/renderer/src/views/create/PrototypeForm.tsx
+++ b/apps/desktop/src/renderer/src/views/create/PrototypeForm.tsx
@@ -1,0 +1,28 @@
+import { useT } from '@open-codesign/i18n';
+import type { ProjectDraft } from '@open-codesign/shared';
+import { FieldHelp, NameField } from './fields';
+
+export interface PrototypeFormProps {
+  name: string;
+  setName: (next: string) => void;
+}
+
+export function PrototypeForm({ name, setName }: PrototypeFormProps) {
+  const t = useT();
+  return (
+    <div className="space-y-[var(--space-4)]">
+      <NameField inputId="cd-create-name-prototype" value={name} onChange={setName} />
+      <div className="space-y-[var(--space-2)]">
+        <span className="block text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium">
+          {t('create.fields.fidelity')}
+        </span>
+        <FieldHelp>{t('create.fields.fidelityComingSoon')}</FieldHelp>
+      </div>
+      <FieldHelp>{t('create.help.share')}</FieldHelp>
+    </div>
+  );
+}
+
+export function buildPrototypeDraft(name: string): ProjectDraft {
+  return { name: name.trim(), type: 'prototype' };
+}

--- a/apps/desktop/src/renderer/src/views/create/SlideDeckForm.tsx
+++ b/apps/desktop/src/renderer/src/views/create/SlideDeckForm.tsx
@@ -24,7 +24,7 @@ export function SlideDeckForm({
           type="checkbox"
           checked={speakerNotes}
           onChange={(e) => setSpeakerNotes(e.target.checked)}
-          className="mt-[var(--space-1)] w-4 h-4 accent-[var(--color-accent)]"
+          className="mt-[var(--space-1)] w-[var(--size-icon-md)] h-[var(--size-icon-md)] accent-[var(--color-accent)]"
         />
         <span className="space-y-[var(--space-0_5)]">
           <span className="block text-[var(--text-sm)] text-[var(--color-text-primary)]">

--- a/apps/desktop/src/renderer/src/views/create/SlideDeckForm.tsx
+++ b/apps/desktop/src/renderer/src/views/create/SlideDeckForm.tsx
@@ -1,0 +1,43 @@
+import { useT } from '@open-codesign/i18n';
+import type { ProjectDraft } from '@open-codesign/shared';
+import { FieldHelp, NameField } from './fields';
+
+export interface SlideDeckFormProps {
+  name: string;
+  setName: (next: string) => void;
+  speakerNotes: boolean;
+  setSpeakerNotes: (next: boolean) => void;
+}
+
+export function SlideDeckForm({
+  name,
+  setName,
+  speakerNotes,
+  setSpeakerNotes,
+}: SlideDeckFormProps) {
+  const t = useT();
+  return (
+    <div className="space-y-[var(--space-4)]">
+      <NameField inputId="cd-create-name-slide" value={name} onChange={setName} />
+      <label className="flex items-start gap-[var(--space-3)] cursor-pointer">
+        <input
+          type="checkbox"
+          checked={speakerNotes}
+          onChange={(e) => setSpeakerNotes(e.target.checked)}
+          className="mt-[var(--space-1)] w-4 h-4 accent-[var(--color-accent)]"
+        />
+        <span className="space-y-[var(--space-0_5)]">
+          <span className="block text-[var(--text-sm)] text-[var(--color-text-primary)]">
+            {t('create.fields.speakerNotes')}
+          </span>
+          <FieldHelp>{t('create.fields.speakerNotesHint')}</FieldHelp>
+        </span>
+      </label>
+      <FieldHelp>{t('create.help.share')}</FieldHelp>
+    </div>
+  );
+}
+
+export function buildSlideDeckDraft(name: string, speakerNotes: boolean): ProjectDraft {
+  return { name: name.trim(), type: 'slideDeck', speakerNotes };
+}

--- a/apps/desktop/src/renderer/src/views/create/fields.tsx
+++ b/apps/desktop/src/renderer/src/views/create/fields.tsx
@@ -1,0 +1,41 @@
+import { useT } from '@open-codesign/i18n';
+import type { ReactNode } from 'react';
+
+export interface NameFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  inputId: string;
+}
+
+export function NameField({ value, onChange, inputId }: NameFieldProps) {
+  const t = useT();
+  return (
+    <label htmlFor={inputId} className="block space-y-[var(--space-1)]">
+      <span className="block text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium">
+        {t('create.fields.name')}
+      </span>
+      <input
+        id={inputId}
+        type="text"
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={t('create.fields.namePlaceholder')}
+        required
+        className="w-full h-[var(--size-input-height)] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-3)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-[var(--duration-faster)]"
+      />
+    </label>
+  );
+}
+
+export interface FieldHelpProps {
+  children: ReactNode;
+}
+
+export function FieldHelp({ children }: FieldHelpProps) {
+  return (
+    <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-snug)] m-0">
+      {children}
+    </p>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/hub/DesignSystemsTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/DesignSystemsTab.tsx
@@ -1,0 +1,15 @@
+import { useT } from '@open-codesign/i18n';
+
+export function DesignSystemsTab() {
+  const t = useT();
+  return (
+    <section className="max-w-[60ch] space-y-[var(--space-2)]">
+      <h2 className="display text-[var(--text-lg)] tracking-[var(--tracking-heading)] text-[var(--color-text-primary)] m-0">
+        {t('hub.designSystems.title')}
+      </h2>
+      <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
+        {t('hub.designSystems.comingSoon')}
+      </p>
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/hub/DesignSystemsTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/DesignSystemsTab.tsx
@@ -3,7 +3,7 @@ import { useT } from '@open-codesign/i18n';
 export function DesignSystemsTab() {
   const t = useT();
   return (
-    <section className="max-w-[60ch] space-y-[var(--space-2)]">
+    <section className="max-w-[var(--size-prose-narrow)] space-y-[var(--space-2)]">
       <h2 className="display text-[var(--text-lg)] tracking-[var(--tracking-heading)] text-[var(--color-text-primary)] m-0">
         {t('hub.designSystems.title')}
       </h2>

--- a/apps/desktop/src/renderer/src/views/hub/ProjectGrid.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/ProjectGrid.tsx
@@ -13,21 +13,21 @@ export function ProjectGrid({ projects, emptyLabel }: ProjectGridProps) {
 
   if (projects.length === 0) {
     return (
-      <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)] max-w-[60ch]">
+      <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)] max-w-[var(--size-prose-narrow)]">
         {emptyLabel}
       </p>
     );
   }
 
   return (
-    <ul className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-[var(--space-4)] list-none p-0 m-0">
+    <ul className="grid grid-cols-[repeat(auto-fill,minmax(var(--size-card-min),1fr))] gap-[var(--space-4)] list-none p-0 m-0">
       {projects.map((p) => (
         <li key={p.id}>
           <button
             type="button"
             onClick={() => openProject(p.id)}
             aria-label={t('hub.your.openAria', { name: p.name })}
-            className="group w-full text-left flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-soft)] hover:shadow-[var(--shadow-card)] hover:border-[var(--color-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] transition-[box-shadow,border-color,transform] duration-[var(--duration-fast)] ease-[var(--ease-out)] hover:-translate-y-[1px]"
+            className="group w-full text-left flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-soft)] hover:shadow-[var(--shadow-card)] hover:border-[var(--color-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] transition-[box-shadow,border-color,transform] duration-[var(--duration-fast)] ease-[var(--ease-out)] hover:-translate-y-[var(--lift-card-hover)]"
           >
             <div className="aspect-[4/3] rounded-t-[var(--radius-xl)] bg-[var(--color-background-secondary)] border-b border-[var(--color-border-subtle)] flex items-center justify-center text-[var(--color-text-muted)] text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)]">
               {t(`hub.card.type.${p.type}`)}

--- a/apps/desktop/src/renderer/src/views/hub/ProjectGrid.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/ProjectGrid.tsx
@@ -1,0 +1,50 @@
+import { useT } from '@open-codesign/i18n';
+import type { Project } from '@open-codesign/shared';
+import { useCodesignStore } from '../../store';
+
+export interface ProjectGridProps {
+  projects: Project[];
+  emptyLabel: string;
+}
+
+export function ProjectGrid({ projects, emptyLabel }: ProjectGridProps) {
+  const t = useT();
+  const openProject = useCodesignStore((s) => s.openProject);
+
+  if (projects.length === 0) {
+    return (
+      <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] leading-[var(--leading-body)] max-w-[60ch]">
+        {emptyLabel}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-[var(--space-4)] list-none p-0 m-0">
+      {projects.map((p) => (
+        <li key={p.id}>
+          <button
+            type="button"
+            onClick={() => openProject(p.id)}
+            aria-label={t('hub.your.openAria', { name: p.name })}
+            className="group w-full text-left flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-soft)] hover:shadow-[var(--shadow-card)] hover:border-[var(--color-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] transition-[box-shadow,border-color,transform] duration-[var(--duration-fast)] ease-[var(--ease-out)] hover:-translate-y-[1px]"
+          >
+            <div className="aspect-[4/3] rounded-t-[var(--radius-xl)] bg-[var(--color-background-secondary)] border-b border-[var(--color-border-subtle)] flex items-center justify-center text-[var(--color-text-muted)] text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)]">
+              {t(`hub.card.type.${p.type}`)}
+            </div>
+            <div className="p-[var(--space-4)] space-y-[var(--space-1)]">
+              <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)] truncate">
+                {p.name}
+              </div>
+              <div className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                {t('hub.card.createdAt', {
+                  date: new Date(p.createdAt).toLocaleDateString(),
+                })}
+              </div>
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
@@ -1,0 +1,14 @@
+import { useT } from '@open-codesign/i18n';
+import { useCodesignStore } from '../../store';
+import { ProjectGrid } from './ProjectGrid';
+
+const RECENT_LIMIT = 6;
+
+export function RecentTab() {
+  const t = useT();
+  const projects = useCodesignStore((s) => s.projects);
+  const recent = [...projects]
+    .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+    .slice(0, RECENT_LIMIT);
+  return <ProjectGrid projects={recent} emptyLabel={t('hub.recent.empty')} />;
+}

--- a/apps/desktop/src/renderer/src/views/hub/YourDesignsTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/YourDesignsTab.tsx
@@ -1,0 +1,10 @@
+import { useT } from '@open-codesign/i18n';
+import { useCodesignStore } from '../../store';
+import { ProjectGrid } from './ProjectGrid';
+
+export function YourDesignsTab() {
+  const t = useT();
+  const projects = useCodesignStore((s) => s.projects);
+  const sorted = [...projects].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  return <ProjectGrid projects={sorted} emptyLabel={t('hub.your.empty')} />;
+}

--- a/packages/core/src/brand/tailwindExtractor.ts
+++ b/packages/core/src/brand/tailwindExtractor.ts
@@ -70,7 +70,7 @@ function extractBodyAt(text: string, bracePos: number): string | null {
   let inBlockComment = false;
 
   for (let i = bracePos; i < text.length; i++) {
-    const ch = text[i]!;
+    const ch = text[i] as string;
     const next = text[i + 1];
 
     if (inLineComment) {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -391,7 +391,8 @@
     "onboardingIncomplete": "Onboarding is not complete.",
     "modelListFailed": "Could not load model list.",
     "unknown": "Unknown error",
-    "localePersistFailed": "Failed to save language preference"
+    "localePersistFailed": "Failed to save language preference",
+    "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist."
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -450,5 +450,78 @@
     "pitch": "Generate the first 3 slides of a pitch deck for a fintech startup. Title slide, problem, solution.",
     "mobile": "Design a 3-screen mobile app onboarding flow. Welcome, permissions, first action.",
     "dashboard": "Build a data dashboard with 3 charts: bar chart for sales, line chart for retention, pie chart for segments. Use a clean dark theme."
+  },
+  "hub": {
+    "newDesign": "New design",
+    "backToHub": "All designs",
+    "tabs": {
+      "recent": "Recent",
+      "your": "Your designs",
+      "examples": "Examples",
+      "designSystems": "Design systems"
+    },
+    "recent": {
+      "title": "Recent",
+      "empty": "Nothing here yet — start a new design to see it pinned at the top."
+    },
+    "your": {
+      "title": "Your designs",
+      "empty": "No designs saved yet. Click \"New design\" to create your first one.",
+      "openAria": "Open {{name}}"
+    },
+    "examples": {
+      "title": "Examples",
+      "comingSoon": "A curated gallery of starter prompts is on the way."
+    },
+    "designSystems": {
+      "title": "Design systems",
+      "comingSoon": "Reusable brand systems and templates are on the way."
+    },
+    "card": {
+      "type": {
+        "prototype": "Prototype",
+        "slideDeck": "Slide deck",
+        "template": "From template",
+        "other": "Other"
+      },
+      "createdAt": "Created {{date}}"
+    }
+  },
+  "create": {
+    "title": "Start a new design",
+    "subtitle": "Pick a type so we can tailor the first prompt.",
+    "close": "Close",
+    "types": {
+      "prototype": "Prototype",
+      "slideDeck": "Slide deck",
+      "template": "From template",
+      "other": "Other"
+    },
+    "typeDescriptions": {
+      "prototype": "Interactive UI mockups with a phone or browser frame.",
+      "slideDeck": "A multi-slide deck for talks, pitches, or summaries.",
+      "template": "Start from one of the bundled starter prompts.",
+      "other": "A blank canvas — describe anything else you have in mind."
+    },
+    "fields": {
+      "name": "Project name",
+      "namePlaceholder": "Untitled design",
+      "fidelity": "Fidelity",
+      "fidelityWireframe": "Wireframe",
+      "fidelityWireframeHint": "Greyscale blocks, no imagery — quick exploration.",
+      "fidelityHigh": "High-fidelity",
+      "fidelityHighHint": "Polished colors, real-looking content.",
+      "fidelityComingSoon": "Wireframe vs. high-fidelity selection ships in a follow-up.",
+      "speakerNotes": "Include speaker notes",
+      "speakerNotesHint": "Adds a notes section under each slide for delivery cues.",
+      "template": "Template",
+      "templateHint": "Choose a starter — the first prompt will be pre-filled."
+    },
+    "cta": "Create",
+    "disabledHint": "Add a project name to continue.",
+    "help": {
+      "share": "Designs stay on this device. Sharing happens through bundle export — no cloud account needed.",
+      "templates": "More starters arrive in a follow-up; this list will keep growing."
+    }
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -449,5 +449,78 @@
     "pitch": "为一家金融科技创业公司生成演讲稿前 3 页：标题页、问题页、解决方案页。",
     "mobile": "设计一个 3 屏的移动端引导流程：欢迎、权限请求、第一个动作。",
     "dashboard": "做一个数据看板，含 3 张图：条形图（销量）、折线图（留存）、饼图（细分）。深色主题。"
+  },
+  "hub": {
+    "newDesign": "新建设计",
+    "backToHub": "全部设计",
+    "tabs": {
+      "recent": "最近",
+      "your": "我的设计",
+      "examples": "示例",
+      "designSystems": "设计系统"
+    },
+    "recent": {
+      "title": "最近",
+      "empty": "还没有最近项目——新建一个设计后会出现在这里。"
+    },
+    "your": {
+      "title": "我的设计",
+      "empty": "还没有保存的设计。点击「新建设计」开始第一个项目。",
+      "openAria": "打开 {{name}}"
+    },
+    "examples": {
+      "title": "示例",
+      "comingSoon": "策划中的范例提示词画廊即将上线。"
+    },
+    "designSystems": {
+      "title": "设计系统",
+      "comingSoon": "可复用的品牌系统与模板正在路上。"
+    },
+    "card": {
+      "type": {
+        "prototype": "原型",
+        "slideDeck": "演示稿",
+        "template": "模板",
+        "other": "其他"
+      },
+      "createdAt": "创建于 {{date}}"
+    }
+  },
+  "create": {
+    "title": "新建设计",
+    "subtitle": "选择类型后，我们会按需调整首条提示词。",
+    "close": "关闭",
+    "types": {
+      "prototype": "原型",
+      "slideDeck": "演示稿",
+      "template": "套用模板",
+      "other": "其他"
+    },
+    "typeDescriptions": {
+      "prototype": "带手机或浏览器外框的可点击 UI 原型。",
+      "slideDeck": "用于演讲、路演或总结的多页演示稿。",
+      "template": "从内置范例提示词出发。",
+      "other": "空白画布 — 任何其他想法都可以。"
+    },
+    "fields": {
+      "name": "项目名称",
+      "namePlaceholder": "未命名设计",
+      "fidelity": "保真度",
+      "fidelityWireframe": "线框图",
+      "fidelityWireframeHint": "灰阶方块、无图片 — 适合快速探索。",
+      "fidelityHigh": "高保真",
+      "fidelityHighHint": "完整配色与真实感内容。",
+      "fidelityComingSoon": "线框 / 高保真选择将在后续版本上线。",
+      "speakerNotes": "包含演讲备注",
+      "speakerNotesHint": "为每页幻灯片附加备注，便于现场讲解。",
+      "template": "模板",
+      "templateHint": "选一个起点 — 首条提示词会自动填好。"
+    },
+    "cta": "创建",
+    "disabledHint": "请先填写项目名称。",
+    "help": {
+      "share": "设计仅保存在本机。需要分享时通过打包导出，无需云端账号。",
+      "templates": "更多模板会陆续加入，列表会不断扩展。"
+    }
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -390,7 +390,8 @@
     "onboardingIncomplete": "引导流程尚未完成。",
     "modelListFailed": "无法加载模型列表。",
     "unknown": "未知错误",
-    "localePersistFailed": "无法保存语言偏好"
+    "localePersistFailed": "无法保存语言偏好",
+    "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。"
   },
   "demos": {
     "meditationApp": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -167,6 +167,36 @@ export const BRAND = {
   backgroundColor: '#faf8f3',
 } as const;
 
+export const PROJECT_SCHEMA_VERSION = 1 as const;
+
+export const ProjectType = z.enum(['prototype', 'slideDeck', 'template', 'other']);
+export type ProjectType = z.infer<typeof ProjectType>;
+
+export const ProjectFidelity = z.enum(['wireframe', 'highFidelity']);
+export type ProjectFidelity = z.infer<typeof ProjectFidelity>;
+
+export const Project = z.object({
+  schemaVersion: z.literal(PROJECT_SCHEMA_VERSION),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  type: ProjectType,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  fidelity: ProjectFidelity.optional(),
+  speakerNotes: z.boolean().optional(),
+  templateId: z.string().optional(),
+});
+export type Project = z.infer<typeof Project>;
+
+export const ProjectDraft = z.object({
+  name: z.string().min(1),
+  type: ProjectType,
+  fidelity: ProjectFidelity.optional(),
+  speakerNotes: z.boolean().optional(),
+  templateId: z.string().optional(),
+});
+export type ProjectDraft = z.infer<typeof ProjectDraft>;
+
 export class CodesignError extends Error {
   constructor(
     message: string,

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -128,6 +128,21 @@
   /* Minimum width for menus, popovers, and stage panels */
   --size-stage-min: 200px;
 
+  /* Hub sidebar (Designs hub left rail) */
+  --size-hub-sidebar: 360px;
+
+  /* Modal widths */
+  --size-modal-md: 560px;
+
+  /* Grid card minimum (project / artifact cards) */
+  --size-card-min: 240px;
+
+  /* Reading-width caps for prose / descriptions */
+  --size-prose-narrow: 60ch;
+
+  /* Card hover lift offset */
+  --lift-card-hover: 1px;
+
   /* Press feedback scale */
   --scale-hover-up: 1.04;
   --scale-press-down: 0.96;


### PR DESCRIPTION
## Summary

Implements PR-A from `docs/research/28-claude-design-ux-adoption.md` — adopts Claude Design's hub navigation and typed project creation flow.

- **Designs hub** (`HubView`) with four sibling tabs: Recent / Your designs / Examples / Design systems. Recent and Your designs are wired to a local project list; Examples and Design systems render placeholders that PR-B and PR-C will populate.
- **Create modal** with four type tabs (Prototype / Slide deck / From template / Other). Each tab shows only its own fields; the CTA stays disabled until the project name is non-empty (and a template is picked, for the From-template tab).
- **Project schema** lives in `packages/shared` (`Project`, `ProjectDraft`, `PROJECT_SCHEMA_VERSION = 1`). Persisted to `localStorage` for now; PR-C will move it to SQLite without a public API change.
- **App shell**: default view is now `hub`; the workspace gains a small "All designs" breadcrumb so users can return; ESC walks settings → workspace → hub.
- **i18n**: full coverage for both `en` and `zh-CN` under `hub.*` and `create.*`.
- **Tokens**: every value comes from `packages/ui` tokens — no hard-coded colors / spacing / typography.

## What was deferred (and why)

- **Wireframe vs high-fidelity cards** — owned by PR-F per the doc; the Prototype form leaves a labeled slot with helper copy.
- **Examples gallery contents** — owned by PR-B.
- **Design systems CRUD + SQLite tables** — owned by PR-C; main process untouched here per the file-ownership constraint.
- **Auto-suggest project name button** — listed as optional in the doc; deferred to keep the PR lean.
- **TopBar / global search / status footer** — owned by PR-D; left untouched.

## PRINCIPLES §5b

- Compatibility: green — no IPC / main / on-disk schema changes; existing 144-test suite passes unchanged.
- Upgradeability: green — `Project` carries `schemaVersion: 1`; localStorage payloads validated on read.
- No bloat: green — zero new dependencies; reuses lucide-react + zustand + tokens.
- Elegance: green — single store action per intent; per-type forms < 40 LOC; pure `buildDraft` helper makes the form testable without DOM.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing complexity warnings remain)
- [x] `pnpm test` — 144 / 144 pass, including new `CreateProjectModal.test.ts` (6 cases)
- [ ] Manual: launch app, land on hub, click "+ New design", create one of each type, confirm it appears in Recent + Your designs and the workspace opens with the correct breadcrumb
- [ ] Manual: switch language to zh-CN and re-walk the create flow

## Notes for reviewers

- Branch base is `main`; `wt/projects-management` was not yet pushed to origin when this branch was cut, so the Project schema is owned here per the doc's fallback clause.
- Modal uses `role="dialog"` on a `<div>` (rather than native `<dialog>`) so that the existing `--color-overlay` token + click-to-dismiss backdrop continue to behave consistently across themes; suppressed locally with a `biome-ignore` and a justification.