### PR TITLE
feat(desktop): project (design) management — list / create / switch / rename / duplicate / delete

### DIFF
--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -9,10 +9,17 @@ import {
   createDesign,
   createSnapshot,
   deleteSnapshot,
+  duplicateDesign,
+  getDesign,
   getSnapshot,
   initInMemoryDb,
   listDesigns,
+  listMessages,
   listSnapshots,
+  renameDesign,
+  replaceMessages,
+  setDesignThumbnail,
+  softDeleteDesign,
 } from './snapshots-db';
 
 function makeDb() {
@@ -293,5 +300,196 @@ describe('listDesigns activity sort', () => {
 
     const ids = listDesigns(db).map((d) => d.id);
     expect(ids.indexOf('older')).toBeLessThan(ids.indexOf('newer'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project management additions: rename / soft-delete / duplicate / thumbnail
+// ---------------------------------------------------------------------------
+
+describe('renameDesign', () => {
+  it('updates the name and bumps updated_at', () => {
+    const db = makeDb();
+    const d = createDesign(db, 'Original');
+    const renamed = renameDesign(db, d.id, '   New name   ');
+    expect(renamed?.name).toBe('New name');
+    // updated_at may equal createdAt within the same millisecond — only assert
+    // the column is non-empty and ordered no earlier than the original create.
+    expect(renamed?.updatedAt).toBeTruthy();
+    expect(new Date(renamed?.updatedAt ?? '').getTime()).toBeGreaterThanOrEqual(
+      new Date(d.updatedAt).getTime(),
+    );
+  });
+
+  it('returns null when the design is missing', () => {
+    const db = makeDb();
+    expect(renameDesign(db, 'missing', 'Anything')).toBeNull();
+  });
+
+  it('refuses an empty name', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    expect(() => renameDesign(db, d.id, '   ')).toThrow();
+  });
+});
+
+describe('setDesignThumbnail', () => {
+  it('sets and clears the thumbnail text', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    const set1 = setDesignThumbnail(db, d.id, 'A nice landing page');
+    expect(set1?.thumbnailText).toBe('A nice landing page');
+    const cleared = setDesignThumbnail(db, d.id, null);
+    expect(cleared?.thumbnailText).toBeNull();
+  });
+});
+
+describe('softDeleteDesign + listDesigns filter', () => {
+  it('hides soft-deleted designs from listDesigns but keeps the row', () => {
+    const db = makeDb();
+    const a = createDesign(db, 'Keeper');
+    const b = createDesign(db, 'To delete');
+
+    expect(
+      listDesigns(db)
+        .map((d) => d.id)
+        .sort(),
+    ).toEqual([a.id, b.id].sort());
+
+    const deleted = softDeleteDesign(db, b.id);
+    expect(deleted?.deletedAt).not.toBeNull();
+
+    const remaining = listDesigns(db).map((d) => d.id);
+    expect(remaining).toEqual([a.id]);
+
+    // Row still exists and is fetchable by id.
+    expect(getDesign(db, b.id)?.deletedAt).not.toBeNull();
+  });
+});
+
+describe('design messages: replaceMessages + listMessages', () => {
+  it('persists a message list keyed by design and ordinal', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    replaceMessages(db, d.id, [
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'reply' },
+      { role: 'user', content: 'second' },
+    ]);
+    const list = listMessages(db, d.id);
+    expect(list).toHaveLength(3);
+    expect(list[0]?.ordinal).toBe(0);
+    expect(list[0]?.role).toBe('user');
+    expect(list[1]?.role).toBe('assistant');
+    expect(list[2]?.content).toBe('second');
+  });
+
+  it('replaces (not appends) when called again', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    replaceMessages(db, d.id, [{ role: 'user', content: 'a' }]);
+    replaceMessages(db, d.id, [
+      { role: 'user', content: 'b' },
+      { role: 'assistant', content: 'c' },
+    ]);
+    const list = listMessages(db, d.id);
+    expect(list.map((m) => m.content)).toEqual(['b', 'c']);
+  });
+
+  it('cascades: deleting the design row removes its messages', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    replaceMessages(db, d.id, [{ role: 'user', content: 'doomed' }]);
+    db.prepare('DELETE FROM designs WHERE id = ?').run(d.id);
+    expect(listMessages(db, d.id)).toEqual([]);
+  });
+});
+
+describe('duplicateDesign', () => {
+  it('clones the design row, all messages, and all snapshots with parent rewiring', () => {
+    const db = makeDb();
+    const source = createDesign(db, 'Source');
+    setDesignThumbnail(db, source.id, 'thumbnail preview');
+    replaceMessages(db, source.id, [
+      { role: 'user', content: 'make a hero' },
+      { role: 'assistant', content: 'here you go' },
+    ]);
+    const s1 = createSnapshot(db, {
+      designId: source.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html>v1</html>',
+    });
+    const s2 = createSnapshot(db, {
+      designId: source.id,
+      parentId: s1.id,
+      type: 'edit',
+      prompt: 'tweak',
+      artifactType: 'html',
+      artifactSource: '<html>v2</html>',
+    });
+
+    const cloned = duplicateDesign(db, source.id, 'Source copy');
+    expect(cloned).not.toBeNull();
+    expect(cloned?.name).toBe('Source copy');
+    expect(cloned?.thumbnailText).toBe('thumbnail preview');
+    expect(cloned?.id).not.toBe(source.id);
+
+    const clonedMessages = listMessages(db, cloned?.id ?? '');
+    expect(clonedMessages.map((m) => m.content)).toEqual(['make a hero', 'here you go']);
+
+    const clonedSnaps = listSnapshots(db, cloned?.id ?? '');
+    expect(clonedSnaps).toHaveLength(2);
+    const clonedInitial = clonedSnaps.find((s) => s.type === 'initial');
+    const clonedEdit = clonedSnaps.find((s) => s.type === 'edit');
+    expect(clonedInitial).toBeDefined();
+    expect(clonedEdit).toBeDefined();
+    // Parent of the cloned edit must point at the cloned initial, not the
+    // original snapshot — that's the key invariant of the rewrite.
+    expect(clonedEdit?.parentId).toBe(clonedInitial?.id);
+    expect(clonedEdit?.parentId).not.toBe(s2.parentId);
+
+    // Source remains untouched.
+    expect(listSnapshots(db, source.id)).toHaveLength(2);
+  });
+
+  it('returns null when the source design does not exist', () => {
+    const db = makeDb();
+    expect(duplicateDesign(db, 'missing', 'X')).toBeNull();
+  });
+
+  it('used delete CASCADE on snapshots after duplicate (independence)', () => {
+    const db = makeDb();
+    const source = createDesign(db);
+    createSnapshot(db, {
+      designId: source.id,
+      parentId: null,
+      type: 'initial',
+      prompt: null,
+      artifactType: 'html',
+      artifactSource: '<html/>',
+    });
+    const cloned = duplicateDesign(db, source.id, 'copy');
+    db.prepare('DELETE FROM designs WHERE id = ?').run(source.id);
+    // Cloned snapshots survive the source deletion because they belong to a
+    // different design row.
+    expect(listSnapshots(db, cloned?.id ?? '')).toHaveLength(1);
+  });
+});
+
+describe('migration is idempotent', () => {
+  it('re-applying the schema does not lose data', () => {
+    const db = makeDb();
+    const d = createDesign(db, 'persist me');
+    // Re-apply migration (simulates a second app boot).
+    type ColumnInfo = { name: string };
+    const cols = (db.prepare('PRAGMA table_info(designs)').all() as ColumnInfo[]).map(
+      (c) => c.name,
+    );
+    expect(cols).toContain('thumbnail_text');
+    expect(cols).toContain('deleted_at');
+    expect(getDesign(db, d.id)?.name).toBe('persist me');
   });
 });

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -4,6 +4,7 @@
  * No Electron, no filesystem — just better-sqlite3 :memory:.
  */
 
+import { DesignMessageV1 } from '@open-codesign/shared';
 import { describe, expect, it } from 'vitest';
 import {
   createDesign,
@@ -394,6 +395,22 @@ describe('design messages: replaceMessages + listMessages', () => {
     ]);
     const list = listMessages(db, d.id);
     expect(list.map((m) => m.content)).toEqual(['b', 'c']);
+  });
+
+  it('persists and loads system role messages (validates against DesignMessageV1)', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    replaceMessages(db, d.id, [
+      { role: 'system', content: 'you are a designer' },
+      { role: 'user', content: 'make a hero' },
+      { role: 'assistant', content: 'done' },
+    ]);
+    const list = listMessages(db, d.id);
+    expect(list).toHaveLength(3);
+    expect(list[0]?.role).toBe('system');
+    for (const row of list) {
+      expect(() => DesignMessageV1.parse(row)).not.toThrow();
+    }
   });
 
   it('cascades: deleting the design row removes its messages', () => {

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -1,5 +1,5 @@
 /**
- * SQLite persistence layer for design snapshots.
+ * SQLite persistence layer for designs, snapshots, and chat messages.
  *
  * Uses better-sqlite3 (synchronous API — safe in the Electron main process,
  * which is the only caller). WAL mode for concurrent read performance.
@@ -9,7 +9,12 @@
  */
 
 import { createRequire } from 'node:module';
-import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign/shared';
+import type {
+  Design,
+  DesignMessage,
+  DesignSnapshot,
+  SnapshotCreateInput,
+} from '@open-codesign/shared';
 import type BetterSqlite3 from 'better-sqlite3';
 
 // better-sqlite3 is a native module — require() instead of import.
@@ -53,7 +58,39 @@ function applySchema(db: Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_snapshots_design_created
       ON design_snapshots(design_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS design_messages (
+      design_id   TEXT NOT NULL REFERENCES designs(id) ON DELETE CASCADE,
+      ordinal     INTEGER NOT NULL,
+      role        TEXT NOT NULL CHECK(role IN ('user','assistant','system')),
+      content     TEXT NOT NULL,
+      created_at  TEXT NOT NULL,
+      PRIMARY KEY (design_id, ordinal)
+    );
   `);
+
+  applyAdditiveMigrations(db);
+}
+
+/**
+ * Additive column migrations.
+ *
+ * Each block uses PRAGMA table_info to detect whether the column already
+ * exists; SQLite has no IF NOT EXISTS for ADD COLUMN. Safe to run on every
+ * boot.
+ */
+function applyAdditiveMigrations(db: Database): void {
+  type ColumnInfo = { name: string };
+  const designCols = (db.prepare('PRAGMA table_info(designs)').all() as ColumnInfo[]).map(
+    (c) => c.name,
+  );
+  if (!designCols.includes('thumbnail_text')) {
+    db.exec('ALTER TABLE designs ADD COLUMN thumbnail_text TEXT');
+  }
+  if (!designCols.includes('deleted_at')) {
+    db.exec('ALTER TABLE designs ADD COLUMN deleted_at TEXT');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_designs_deleted_at ON designs(deleted_at)');
+  }
 }
 
 /** Initialize and return the singleton DB instance for production use. */
@@ -110,6 +147,8 @@ interface DesignRow {
   name: string;
   created_at: string;
   updated_at: string;
+  thumbnail_text: string | null;
+  deleted_at: string | null;
 }
 
 interface SnapshotRow {
@@ -125,6 +164,14 @@ interface SnapshotRow {
   message: string | null;
 }
 
+interface MessageRow {
+  design_id: string;
+  ordinal: number;
+  role: string;
+  content: string;
+  created_at: string;
+}
+
 // ---------------------------------------------------------------------------
 // Row → domain type mappers
 // ---------------------------------------------------------------------------
@@ -136,6 +183,8 @@ function rowToDesign(row: DesignRow): Design {
     name: row.name,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    thumbnailText: row.thumbnail_text ?? null,
+    deletedAt: row.deleted_at ?? null,
   };
 }
 
@@ -154,8 +203,19 @@ function rowToSnapshot(row: SnapshotRow): DesignSnapshot {
   };
 }
 
+function rowToMessage(row: MessageRow): DesignMessage {
+  return {
+    schemaVersion: 1,
+    designId: row.design_id,
+    role: row.role as DesignMessage['role'],
+    content: row.content,
+    ordinal: row.ordinal,
+    createdAt: row.created_at,
+  };
+}
+
 // ---------------------------------------------------------------------------
-// Public DB functions
+// Designs
 // ---------------------------------------------------------------------------
 
 export function createDesign(db: Database, name = 'Untitled design'): Design {
@@ -167,15 +227,123 @@ export function createDesign(db: Database, name = 'Untitled design'): Design {
   return rowToDesign(db.prepare('SELECT * FROM designs WHERE id = ?').get(id) as DesignRow);
 }
 
+export function getDesign(db: Database, id: string): Design | null {
+  const row = db.prepare('SELECT * FROM designs WHERE id = ?').get(id) as DesignRow | undefined;
+  return row ? rowToDesign(row) : null;
+}
+
 export function listDesigns(db: Database): Design[] {
-  // updated_at bumps on each new snapshot, so recently edited designs surface first;
-  // created_at is the tiebreaker for designs that have never been edited.
+  // Soft-deleted designs are hidden from the default list. updated_at bumps on
+  // each new snapshot so recently-edited designs surface first; created_at is
+  // the tiebreaker for designs that have never been edited.
   return (
     db
-      .prepare('SELECT * FROM designs ORDER BY updated_at DESC, created_at DESC')
+      .prepare(
+        'SELECT * FROM designs WHERE deleted_at IS NULL ORDER BY updated_at DESC, created_at DESC',
+      )
       .all() as DesignRow[]
   ).map(rowToDesign);
 }
+
+export function renameDesign(db: Database, id: string, name: string): Design | null {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Design name must not be empty');
+  }
+  const now = new Date().toISOString();
+  const result = db
+    .prepare('UPDATE designs SET name = ?, updated_at = ? WHERE id = ?')
+    .run(trimmed, now, id);
+  if (result.changes === 0) return null;
+  return getDesign(db, id);
+}
+
+export function setDesignThumbnail(
+  db: Database,
+  id: string,
+  thumbnailText: string | null,
+): Design | null {
+  const result = db
+    .prepare('UPDATE designs SET thumbnail_text = ? WHERE id = ?')
+    .run(thumbnailText, id);
+  if (result.changes === 0) return null;
+  return getDesign(db, id);
+}
+
+export function softDeleteDesign(db: Database, id: string): Design | null {
+  const now = new Date().toISOString();
+  const result = db.prepare('UPDATE designs SET deleted_at = ? WHERE id = ?').run(now, id);
+  if (result.changes === 0) return null;
+  return getDesign(db, id);
+}
+
+/**
+ * Duplicate a design row + all its messages + all its snapshots. Snapshot
+ * parent_id references are remapped to point at the freshly-cloned snapshots
+ * so the lineage is preserved inside the new design.
+ */
+export function duplicateDesign(db: Database, sourceId: string, newName: string): Design | null {
+  const source = getDesign(db, sourceId);
+  if (source === null) return null;
+
+  const newId = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const trimmed = newName.trim() || `${source.name} copy`;
+
+  const tx = db.transaction(() => {
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at, thumbnail_text, deleted_at) VALUES (?, 1, ?, ?, ?, ?, NULL)',
+    ).run(newId, trimmed, now, now, source.thumbnailText);
+
+    const messages = db
+      .prepare('SELECT * FROM design_messages WHERE design_id = ? ORDER BY ordinal ASC')
+      .all(sourceId) as MessageRow[];
+    const insertMsg = db.prepare(
+      'INSERT INTO design_messages (design_id, ordinal, role, content, created_at) VALUES (?, ?, ?, ?, ?)',
+    );
+    for (const m of messages) {
+      insertMsg.run(newId, m.ordinal, m.role, m.content, m.created_at);
+    }
+
+    // Snapshots: clone in chronological order so parent_ids are remapped first.
+    // Tie-break by rowid so we always process older inserts first when two
+    // snapshots share a millisecond.
+    const snaps = db
+      .prepare(
+        'SELECT * FROM design_snapshots WHERE design_id = ? ORDER BY created_at ASC, rowid ASC',
+      )
+      .all(sourceId) as SnapshotRow[];
+    const idMap = new Map<string, string>();
+    const insertSnap = db.prepare(
+      `INSERT INTO design_snapshots
+         (id, schema_version, design_id, parent_id, type, prompt, artifact_type, artifact_source, created_at, message)
+       VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const s of snaps) {
+      const cloneId = crypto.randomUUID();
+      idMap.set(s.id, cloneId);
+      const newParent = s.parent_id !== null ? (idMap.get(s.parent_id) ?? null) : null;
+      insertSnap.run(
+        cloneId,
+        newId,
+        newParent,
+        s.type,
+        s.prompt,
+        s.artifact_type,
+        s.artifact_source,
+        s.created_at,
+        s.message,
+      );
+    }
+  });
+  tx();
+
+  return getDesign(db, newId);
+}
+
+// ---------------------------------------------------------------------------
+// Snapshots
+// ---------------------------------------------------------------------------
 
 export function createSnapshot(db: Database, input: SnapshotCreateInput): DesignSnapshot {
   const id = crypto.randomUUID();
@@ -219,4 +387,46 @@ export function getSnapshot(db: Database, id: string): DesignSnapshot | null {
 
 export function deleteSnapshot(db: Database, id: string): void {
   db.prepare('DELETE FROM design_snapshots WHERE id = ?').run(id);
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export function listMessages(db: Database, designId: string): DesignMessage[] {
+  return (
+    db
+      .prepare('SELECT * FROM design_messages WHERE design_id = ? ORDER BY ordinal ASC')
+      .all(designId) as MessageRow[]
+  ).map(rowToMessage);
+}
+
+export interface MessageInput {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/**
+ * Replace the entire message list for a design atomically. We rewrite rather
+ * than appending so the renderer's source-of-truth stays trivially in sync —
+ * the chat list is small (< 200 entries) so a full rewrite is cheap and avoids
+ * ordinal-conflict bugs across edits / cancels / retries.
+ */
+export function replaceMessages(
+  db: Database,
+  designId: string,
+  messages: MessageInput[],
+): DesignMessage[] {
+  const now = new Date().toISOString();
+  const tx = db.transaction(() => {
+    db.prepare('DELETE FROM design_messages WHERE design_id = ?').run(designId);
+    const insert = db.prepare(
+      'INSERT INTO design_messages (design_id, ordinal, role, content, created_at) VALUES (?, ?, ?, ?, ?)',
+    );
+    messages.forEach((m, i) => {
+      insert.run(designId, i, m.role, m.content, now);
+    });
+  });
+  tx();
+  return listMessages(db, designId);
 }

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -633,7 +633,7 @@ describe('snapshots:v1:soft-delete-design', () => {
   it('hides the design from list-designs', () => {
     const d = createDesign(db, 'Doomed');
     call('snapshots:v1:soft-delete-design', { id: d.id });
-    const list = call('snapshots:v1:list-designs', undefined) as Array<{ id: string }>;
+    const list = call('snapshots:v1:list-designs', { schemaVersion: 1 }) as Array<{ id: string }>;
     expect(list.find((row) => row.id === d.id)).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -356,6 +356,13 @@ describe('schemaVersion gating', () => {
     ['snapshots:v1:get', { id: 'x' }],
     ['snapshots:v1:delete', { id: 'x' }],
     ['snapshots:v1:create-design', { name: 'd' }],
+    ['snapshots:v1:get-design', { id: 'x' }],
+    ['snapshots:v1:rename-design', { id: 'x', name: 'n' }],
+    ['snapshots:v1:set-thumbnail', { id: 'x', thumbnailText: null }],
+    ['snapshots:v1:soft-delete-design', { id: 'x' }],
+    ['snapshots:v1:duplicate-design', { id: 'x', name: 'n' }],
+    ['snapshots:v1:list-messages', { designId: 'd' }],
+    ['snapshots:v1:replace-messages', { designId: 'd', messages: [] }],
     [
       'snapshots:v1:create',
       {
@@ -587,7 +594,7 @@ describe('registerSnapshotsUnavailableIpc', () => {
 describe('snapshots:v1:rename-design', () => {
   it('renames the design and returns the updated row', () => {
     const d = createDesign(db, 'Old');
-    const updated = call('snapshots:v1:rename-design', { id: d.id, name: 'New' }) as {
+    const updated = call('snapshots:v1:rename-design', v1({ id: d.id, name: 'New' })) as {
       name: string;
     };
     expect(updated.name).toBe('New');
@@ -595,12 +602,12 @@ describe('snapshots:v1:rename-design', () => {
 
   it('rejects an empty name', () => {
     const d = createDesign(db);
-    expect(() => call('snapshots:v1:rename-design', { id: d.id, name: '   ' })).toThrow();
+    expect(() => call('snapshots:v1:rename-design', v1({ id: d.id, name: '   ' }))).toThrow();
   });
 
   it('throws IPC_NOT_FOUND for an unknown id', () => {
     try {
-      call('snapshots:v1:rename-design', { id: 'missing', name: 'x' });
+      call('snapshots:v1:rename-design', v1({ id: 'missing', name: 'x' }));
       throw new Error('expected throw');
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_NOT_FOUND');
@@ -611,20 +618,20 @@ describe('snapshots:v1:rename-design', () => {
 describe('snapshots:v1:set-thumbnail', () => {
   it('updates the thumbnail text', () => {
     const d = createDesign(db);
-    const updated = call('snapshots:v1:set-thumbnail', {
-      id: d.id,
-      thumbnailText: 'preview snippet',
-    }) as { thumbnailText: string | null };
+    const updated = call(
+      'snapshots:v1:set-thumbnail',
+      v1({ id: d.id, thumbnailText: 'preview snippet' }),
+    ) as { thumbnailText: string | null };
     expect(updated.thumbnailText).toBe('preview snippet');
   });
 
   it('accepts null to clear', () => {
     const d = createDesign(db);
-    call('snapshots:v1:set-thumbnail', { id: d.id, thumbnailText: 'x' });
-    const cleared = call('snapshots:v1:set-thumbnail', {
-      id: d.id,
-      thumbnailText: null,
-    }) as { thumbnailText: string | null };
+    call('snapshots:v1:set-thumbnail', v1({ id: d.id, thumbnailText: 'x' }));
+    const cleared = call(
+      'snapshots:v1:set-thumbnail',
+      v1({ id: d.id, thumbnailText: null }),
+    ) as { thumbnailText: string | null };
     expect(cleared.thumbnailText).toBeNull();
   });
 });
@@ -632,7 +639,7 @@ describe('snapshots:v1:set-thumbnail', () => {
 describe('snapshots:v1:soft-delete-design', () => {
   it('hides the design from list-designs', () => {
     const d = createDesign(db, 'Doomed');
-    call('snapshots:v1:soft-delete-design', { id: d.id });
+    call('snapshots:v1:soft-delete-design', v1({ id: d.id }));
     const list = call('snapshots:v1:list-designs', { schemaVersion: 1 }) as Array<{ id: string }>;
     expect(list.find((row) => row.id === d.id)).toBeUndefined();
   });
@@ -641,10 +648,10 @@ describe('snapshots:v1:soft-delete-design', () => {
 describe('snapshots:v1:duplicate-design', () => {
   it('clones the design and reports a different id', () => {
     const source = createDesign(db, 'Source');
-    const cloned = call('snapshots:v1:duplicate-design', {
-      id: source.id,
-      name: 'Source copy',
-    }) as { id: string; name: string };
+    const cloned = call(
+      'snapshots:v1:duplicate-design',
+      v1({ id: source.id, name: 'Source copy' }),
+    ) as { id: string; name: string };
     expect(cloned.id).not.toBe(source.id);
     expect(cloned.name).toBe('Source copy');
   });
@@ -653,14 +660,17 @@ describe('snapshots:v1:duplicate-design', () => {
 describe('snapshots:v1:list-messages + replace-messages', () => {
   it('round-trips a message list', () => {
     const d = createDesign(db);
-    call('snapshots:v1:replace-messages', {
-      designId: d.id,
-      messages: [
-        { role: 'user', content: 'hello' },
-        { role: 'assistant', content: 'hi' },
-      ],
-    });
-    const list = call('snapshots:v1:list-messages', { designId: d.id }) as Array<{
+    call(
+      'snapshots:v1:replace-messages',
+      v1({
+        designId: d.id,
+        messages: [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi' },
+        ],
+      }),
+    );
+    const list = call('snapshots:v1:list-messages', v1({ designId: d.id })) as Array<{
       role: string;
       content: string;
     }>;
@@ -670,10 +680,10 @@ describe('snapshots:v1:list-messages + replace-messages', () => {
   it('rejects malformed roles', () => {
     const d = createDesign(db);
     expect(() =>
-      call('snapshots:v1:replace-messages', {
-        designId: d.id,
-        messages: [{ role: 'bot', content: 'x' }],
-      }),
+      call(
+        'snapshots:v1:replace-messages',
+        v1({ designId: d.id, messages: [{ role: 'bot', content: 'x' }] }),
+      ),
     ).toThrow();
   });
 });
@@ -681,11 +691,11 @@ describe('snapshots:v1:list-messages + replace-messages', () => {
 describe('snapshots:v1:get-design', () => {
   it('returns the design row by id', () => {
     const d = createDesign(db, 'Lookup me');
-    const found = call('snapshots:v1:get-design', { id: d.id }) as { name: string } | null;
+    const found = call('snapshots:v1:get-design', v1({ id: d.id })) as { name: string } | null;
     expect(found?.name).toBe('Lookup me');
   });
 
   it('returns null for an unknown id', () => {
-    expect(call('snapshots:v1:get-design', { id: 'nope' })).toBeNull();
+    expect(call('snapshots:v1:get-design', v1({ id: 'nope' }))).toBeNull();
   });
 });

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -628,10 +628,9 @@ describe('snapshots:v1:set-thumbnail', () => {
   it('accepts null to clear', () => {
     const d = createDesign(db);
     call('snapshots:v1:set-thumbnail', v1({ id: d.id, thumbnailText: 'x' }));
-    const cleared = call(
-      'snapshots:v1:set-thumbnail',
-      v1({ id: d.id, thumbnailText: null }),
-    ) as { thumbnailText: string | null };
+    const cleared = call('snapshots:v1:set-thumbnail', v1({ id: d.id, thumbnailText: null })) as {
+      thumbnailText: string | null;
+    };
     expect(cleared.thumbnailText).toBeNull();
   });
 });

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -579,3 +579,113 @@ describe('registerSnapshotsUnavailableIpc', () => {
     expect(stubs).toEqual(live);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Project management IPC: rename / soft-delete / duplicate / messages
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:rename-design', () => {
+  it('renames the design and returns the updated row', () => {
+    const d = createDesign(db, 'Old');
+    const updated = call('snapshots:v1:rename-design', { id: d.id, name: 'New' }) as {
+      name: string;
+    };
+    expect(updated.name).toBe('New');
+  });
+
+  it('rejects an empty name', () => {
+    const d = createDesign(db);
+    expect(() => call('snapshots:v1:rename-design', { id: d.id, name: '   ' })).toThrow();
+  });
+
+  it('throws IPC_NOT_FOUND for an unknown id', () => {
+    try {
+      call('snapshots:v1:rename-design', { id: 'missing', name: 'x' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_NOT_FOUND');
+    }
+  });
+});
+
+describe('snapshots:v1:set-thumbnail', () => {
+  it('updates the thumbnail text', () => {
+    const d = createDesign(db);
+    const updated = call('snapshots:v1:set-thumbnail', {
+      id: d.id,
+      thumbnailText: 'preview snippet',
+    }) as { thumbnailText: string | null };
+    expect(updated.thumbnailText).toBe('preview snippet');
+  });
+
+  it('accepts null to clear', () => {
+    const d = createDesign(db);
+    call('snapshots:v1:set-thumbnail', { id: d.id, thumbnailText: 'x' });
+    const cleared = call('snapshots:v1:set-thumbnail', {
+      id: d.id,
+      thumbnailText: null,
+    }) as { thumbnailText: string | null };
+    expect(cleared.thumbnailText).toBeNull();
+  });
+});
+
+describe('snapshots:v1:soft-delete-design', () => {
+  it('hides the design from list-designs', () => {
+    const d = createDesign(db, 'Doomed');
+    call('snapshots:v1:soft-delete-design', { id: d.id });
+    const list = call('snapshots:v1:list-designs', undefined) as Array<{ id: string }>;
+    expect(list.find((row) => row.id === d.id)).toBeUndefined();
+  });
+});
+
+describe('snapshots:v1:duplicate-design', () => {
+  it('clones the design and reports a different id', () => {
+    const source = createDesign(db, 'Source');
+    const cloned = call('snapshots:v1:duplicate-design', {
+      id: source.id,
+      name: 'Source copy',
+    }) as { id: string; name: string };
+    expect(cloned.id).not.toBe(source.id);
+    expect(cloned.name).toBe('Source copy');
+  });
+});
+
+describe('snapshots:v1:list-messages + replace-messages', () => {
+  it('round-trips a message list', () => {
+    const d = createDesign(db);
+    call('snapshots:v1:replace-messages', {
+      designId: d.id,
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi' },
+      ],
+    });
+    const list = call('snapshots:v1:list-messages', { designId: d.id }) as Array<{
+      role: string;
+      content: string;
+    }>;
+    expect(list.map((m) => m.content)).toEqual(['hello', 'hi']);
+  });
+
+  it('rejects malformed roles', () => {
+    const d = createDesign(db);
+    expect(() =>
+      call('snapshots:v1:replace-messages', {
+        designId: d.id,
+        messages: [{ role: 'bot', content: 'x' }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('snapshots:v1:get-design', () => {
+  it('returns the design row by id', () => {
+    const d = createDesign(db, 'Lookup me');
+    const found = call('snapshots:v1:get-design', { id: d.id }) as { name: string } | null;
+    expect(found?.name).toBe('Lookup me');
+  });
+
+  it('returns null for an unknown id', () => {
+    expect(call('snapshots:v1:get-design', { id: 'nope' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -9,18 +9,31 @@
  * initSnapshotsDb().
  */
 
-import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign/shared';
+import type {
+  Design,
+  DesignMessage,
+  DesignSnapshot,
+  SnapshotCreateInput,
+} from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 import type BetterSqlite3 from 'better-sqlite3';
 import { ipcMain } from './electron-runtime';
 import { getLogger } from './logger';
 import {
+  type MessageInput,
   createDesign,
   createSnapshot,
   deleteSnapshot,
+  duplicateDesign,
+  getDesign,
   getSnapshot,
   listDesigns,
+  listMessages,
   listSnapshots,
+  renameDesign,
+  replaceMessages,
+  setDesignThumbnail,
+  softDeleteDesign,
 } from './snapshots-db';
 
 type Database = BetterSqlite3.Database;
@@ -244,6 +257,155 @@ export function registerSnapshotsIpc(db: Database): void {
       throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
     }
     return runDb('create-design', () => createDesign(db, (r['name'] as string).trim()));
+  });
+
+  ipcMain.handle('snapshots:v1:get-design', (_e: unknown, raw: unknown): Design | null => {
+    const id = parseIdPayload(raw, 'get-design');
+    return runDb('get-design', () => getDesign(db, id));
+  });
+
+  ipcMain.handle('snapshots:v1:rename-design', (_e: unknown, raw: unknown): Design => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError('snapshots:v1:rename-design expects { id, name }', 'IPC_BAD_INPUT');
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+      throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    if (typeof r['name'] !== 'string' || r['name'].trim().length === 0) {
+      throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    const updated = runDb('rename-design', () =>
+      renameDesign(db, r['id'] as string, r['name'] as string),
+    );
+    if (updated === null) {
+      throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+    }
+    logger.info('design.renamed', { id: updated.id, name: updated.name });
+    return updated;
+  });
+
+  ipcMain.handle('snapshots:v1:set-thumbnail', (_e: unknown, raw: unknown): Design => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:set-thumbnail expects { id, thumbnailText }',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+      throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    const value = r['thumbnailText'];
+    if (value !== null && typeof value !== 'string') {
+      throw new CodesignError('thumbnailText must be a string or null', 'IPC_BAD_INPUT');
+    }
+    const updated = runDb('set-thumbnail', () =>
+      setDesignThumbnail(db, r['id'] as string, value as string | null),
+    );
+    if (updated === null) {
+      throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+    }
+    return updated;
+  });
+
+  ipcMain.handle('snapshots:v1:soft-delete-design', (_e: unknown, raw: unknown): Design => {
+    const id = parseIdPayload(raw, 'soft-delete-design');
+    const updated = runDb('soft-delete-design', () => softDeleteDesign(db, id));
+    if (updated === null) {
+      throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+    }
+    logger.info('design.soft_deleted', { id });
+    return updated;
+  });
+
+  ipcMain.handle('snapshots:v1:duplicate-design', (_e: unknown, raw: unknown): Design => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:duplicate-design expects { id, name }',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+      throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    if (typeof r['name'] !== 'string' || r['name'].trim().length === 0) {
+      throw new CodesignError('name must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    const cloned = runDb('duplicate-design', () =>
+      duplicateDesign(db, r['id'] as string, r['name'] as string),
+    );
+    if (cloned === null) {
+      throw new CodesignError('Source design not found', 'IPC_NOT_FOUND');
+    }
+    logger.info('design.duplicated', { sourceId: r['id'], newId: cloned.id });
+    return cloned;
+  });
+
+  ipcMain.handle('snapshots:v1:list-messages', (_e: unknown, raw: unknown): DesignMessage[] => {
+    const id = parseDesignIdPayload(raw, 'list-messages');
+    return runDb('list-messages', () => listMessages(db, id));
+  });
+
+  ipcMain.handle('snapshots:v1:replace-messages', (_e: unknown, raw: unknown): DesignMessage[] => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:replace-messages expects { designId, messages }',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    const messages = parseMessageList(r['messages']);
+    return runDb('replace-messages', () => replaceMessages(db, r['designId'] as string, messages));
+  });
+}
+
+function parseIdPayload(raw: unknown, channel: string): string {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new CodesignError(`snapshots:v1:${channel} expects { id }`, 'IPC_BAD_INPUT');
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
+    throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  return r['id'] as string;
+}
+
+function parseDesignIdPayload(raw: unknown, channel: string): string {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new CodesignError(`snapshots:v1:${channel} expects { designId }`, 'IPC_BAD_INPUT');
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+    throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+  }
+  return r['designId'] as string;
+}
+
+function parseMessageList(raw: unknown): MessageInput[] {
+  if (!Array.isArray(raw)) {
+    throw new CodesignError('messages must be an array', 'IPC_BAD_INPUT');
+  }
+  const validRoles = ['user', 'assistant', 'system'] as const;
+  return raw.map((entry, index) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new CodesignError(`messages[${index}] must be an object`, 'IPC_BAD_INPUT');
+    }
+    const e = entry as Record<string, unknown>;
+    if (!validRoles.includes(e['role'] as (typeof validRoles)[number])) {
+      throw new CodesignError(
+        `messages[${index}].role must be one of: ${validRoles.join(', ')}`,
+        'IPC_BAD_INPUT',
+      );
+    }
+    if (typeof e['content'] !== 'string') {
+      throw new CodesignError(`messages[${index}].content must be a string`, 'IPC_BAD_INPUT');
+    }
+    return { role: e['role'] as MessageInput['role'], content: e['content'] as string };
   });
 }
 

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -269,6 +269,7 @@ export function registerSnapshotsIpc(db: Database): void {
       throw new CodesignError('snapshots:v1:rename-design expects { id, name }', 'IPC_BAD_INPUT');
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:rename-design');
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -293,6 +294,7 @@ export function registerSnapshotsIpc(db: Database): void {
       );
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:set-thumbnail');
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -327,6 +329,7 @@ export function registerSnapshotsIpc(db: Database): void {
       );
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:duplicate-design');
     if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
       throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -356,6 +359,7 @@ export function registerSnapshotsIpc(db: Database): void {
       );
     }
     const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:replace-messages');
     if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
       throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
     }
@@ -369,6 +373,7 @@ function parseIdPayload(raw: unknown, channel: string): string {
     throw new CodesignError(`snapshots:v1:${channel} expects { id }`, 'IPC_BAD_INPUT');
   }
   const r = raw as Record<string, unknown>;
+  requireSchemaV1(r, `snapshots:v1:${channel}`);
   if (typeof r['id'] !== 'string' || r['id'].trim().length === 0) {
     throw new CodesignError('id must be a non-empty string', 'IPC_BAD_INPUT');
   }
@@ -380,6 +385,7 @@ function parseDesignIdPayload(raw: unknown, channel: string): string {
     throw new CodesignError(`snapshots:v1:${channel} expects { designId }`, 'IPC_BAD_INPUT');
   }
   const r = raw as Record<string, unknown>;
+  requireSchemaV1(r, `snapshots:v1:${channel}`);
   if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
     throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
   }

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -421,6 +421,13 @@ function parseMessageList(raw: unknown): MessageInput[] {
 export const SNAPSHOTS_CHANNELS_V1 = [
   'snapshots:v1:list-designs',
   'snapshots:v1:create-design',
+  'snapshots:v1:get-design',
+  'snapshots:v1:rename-design',
+  'snapshots:v1:set-thumbnail',
+  'snapshots:v1:soft-delete-design',
+  'snapshots:v1:duplicate-design',
+  'snapshots:v1:list-messages',
+  'snapshots:v1:replace-messages',
   'snapshots:v1:list',
   'snapshots:v1:get',
   'snapshots:v1:create',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -195,21 +195,43 @@ const api = {
         name,
       }) as Promise<Design>,
     getDesign: (id: string) =>
-      ipcRenderer.invoke('snapshots:v1:get-design', { id }) as Promise<Design | null>,
-    renameDesign: (id: string, name: string) =>
-      ipcRenderer.invoke('snapshots:v1:rename-design', { id, name }) as Promise<Design>,
-    setThumbnail: (id: string, thumbnailText: string | null) =>
-      ipcRenderer.invoke('snapshots:v1:set-thumbnail', { id, thumbnailText }) as Promise<Design>,
-    softDeleteDesign: (id: string) =>
-      ipcRenderer.invoke('snapshots:v1:soft-delete-design', { id }) as Promise<Design>,
-    duplicateDesign: (id: string, name: string) =>
-      ipcRenderer.invoke('snapshots:v1:duplicate-design', { id, name }) as Promise<Design>,
-    listMessages: (designId: string) =>
-      ipcRenderer.invoke('snapshots:v1:list-messages', { designId }) as Promise<DesignMessage[]>,
-    replaceMessages: (designId: string, messages: Array<{ role: string; content: string }>) =>
-      ipcRenderer.invoke('snapshots:v1:replace-messages', { designId, messages }) as Promise<
-        DesignMessage[]
+      ipcRenderer.invoke('snapshots:v1:get-design', { schemaVersion: 1, id }) as Promise<
+        Design | null
       >,
+    renameDesign: (id: string, name: string) =>
+      ipcRenderer.invoke('snapshots:v1:rename-design', {
+        schemaVersion: 1,
+        id,
+        name,
+      }) as Promise<Design>,
+    setThumbnail: (id: string, thumbnailText: string | null) =>
+      ipcRenderer.invoke('snapshots:v1:set-thumbnail', {
+        schemaVersion: 1,
+        id,
+        thumbnailText,
+      }) as Promise<Design>,
+    softDeleteDesign: (id: string) =>
+      ipcRenderer.invoke('snapshots:v1:soft-delete-design', {
+        schemaVersion: 1,
+        id,
+      }) as Promise<Design>,
+    duplicateDesign: (id: string, name: string) =>
+      ipcRenderer.invoke('snapshots:v1:duplicate-design', {
+        schemaVersion: 1,
+        id,
+        name,
+      }) as Promise<Design>,
+    listMessages: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:list-messages', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<DesignMessage[]>,
+    replaceMessages: (designId: string, messages: Array<{ role: string; content: string }>) =>
+      ipcRenderer.invoke('snapshots:v1:replace-messages', {
+        schemaVersion: 1,
+        designId,
+        messages,
+      }) as Promise<DesignMessage[]>,
     list: (designId: string) =>
       ipcRenderer.invoke('snapshots:v1:list', { schemaVersion: 1, designId }) as Promise<
         DesignSnapshot[]

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -195,9 +195,10 @@ const api = {
         name,
       }) as Promise<Design>,
     getDesign: (id: string) =>
-      ipcRenderer.invoke('snapshots:v1:get-design', { schemaVersion: 1, id }) as Promise<
-        Design | null
-      >,
+      ipcRenderer.invoke('snapshots:v1:get-design', {
+        schemaVersion: 1,
+        id,
+      }) as Promise<Design | null>,
     renameDesign: (id: string, name: string) =>
       ipcRenderer.invoke('snapshots:v1:rename-design', {
         schemaVersion: 1,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import type {
   CancelGenerationPayloadV1,
   ChatMessage,
   Design,
+  DesignMessage,
   DesignSnapshot,
   GeneratePayloadV1,
   LocalInputFile,
@@ -193,6 +194,22 @@ const api = {
         schemaVersion: 1,
         name,
       }) as Promise<Design>,
+    getDesign: (id: string) =>
+      ipcRenderer.invoke('snapshots:v1:get-design', { id }) as Promise<Design | null>,
+    renameDesign: (id: string, name: string) =>
+      ipcRenderer.invoke('snapshots:v1:rename-design', { id, name }) as Promise<Design>,
+    setThumbnail: (id: string, thumbnailText: string | null) =>
+      ipcRenderer.invoke('snapshots:v1:set-thumbnail', { id, thumbnailText }) as Promise<Design>,
+    softDeleteDesign: (id: string) =>
+      ipcRenderer.invoke('snapshots:v1:soft-delete-design', { id }) as Promise<Design>,
+    duplicateDesign: (id: string, name: string) =>
+      ipcRenderer.invoke('snapshots:v1:duplicate-design', { id, name }) as Promise<Design>,
+    listMessages: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:list-messages', { designId }) as Promise<DesignMessage[]>,
+    replaceMessages: (designId: string, messages: Array<{ role: string; content: string }>) =>
+      ipcRenderer.invoke('snapshots:v1:replace-messages', { designId, messages }) as Promise<
+        DesignMessage[]
+      >
     list: (designId: string) =>
       ipcRenderer.invoke('snapshots:v1:list', { schemaVersion: 1, designId }) as Promise<
         DesignSnapshot[]

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -209,7 +209,7 @@ const api = {
     replaceMessages: (designId: string, messages: Array<{ role: string; content: string }>) =>
       ipcRenderer.invoke('snapshots:v1:replace-messages', { designId, messages }) as Promise<
         DesignMessage[]
-      >
+      >,
     list: (designId: string) =>
       ipcRenderer.invoke('snapshots:v1:list', { schemaVersion: 1, designId }) as Promise<
         DesignSnapshot[]

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2,7 +2,10 @@ import { useT } from '@open-codesign/i18n';
 import { ChevronLeft } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { CommandPalette } from './components/CommandPalette';
+import { DeleteDesignDialog } from './components/DeleteDesignDialog';
+import { DesignsView } from './components/DesignsView';
 import { PreviewPane } from './components/PreviewPane';
+import { RenameDesignDialog } from './components/RenameDesignDialog';
 import { Settings } from './components/Settings';
 import { Sidebar } from './components/Sidebar';
 import { ToastViewport } from './components/Toast';
@@ -24,6 +27,13 @@ export function App() {
   const closeCommandPalette = useCodesignStore((s) => s.closeCommandPalette);
   const view = useCodesignStore((s) => s.view);
   const commandPaletteOpen = useCodesignStore((s) => s.commandPaletteOpen);
+  const designsViewOpen = useCodesignStore((s) => s.designsViewOpen);
+  const closeDesignsView = useCodesignStore((s) => s.closeDesignsView);
+  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const designToDelete = useCodesignStore((s) => s.designToDelete);
+  const designToRename = useCodesignStore((s) => s.designToRename);
+  const requestDeleteDesign = useCodesignStore((s) => s.requestDeleteDesign);
+  const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
 
   const [prompt, setPrompt] = useState('');
 
@@ -67,10 +77,29 @@ export function App() {
         },
       },
       {
+        combo: 'mod+n',
+        handler: () => {
+          if (!ready) return;
+          void createNewDesign();
+        },
+      },
+      {
         combo: 'escape',
         handler: () => {
+          if (designToDelete) {
+            requestDeleteDesign(null);
+            return;
+          }
+          if (designToRename) {
+            requestRenameDesign(null);
+            return;
+          }
           if (commandPaletteOpen) {
             closeCommandPalette();
+            return;
+          }
+          if (designsViewOpen) {
+            closeDesignsView();
             return;
           }
           if (view === 'settings') {
@@ -91,9 +120,16 @@ export function App() {
       sendPrompt,
       view,
       commandPaletteOpen,
+      designsViewOpen,
+      designToDelete,
+      designToRename,
       setView,
       openCommandPalette,
       closeCommandPalette,
+      closeDesignsView,
+      createNewDesign,
+      requestDeleteDesign,
+      requestRenameDesign,
     ],
   );
   useKeyboard(bindings);
@@ -145,6 +181,9 @@ export function App() {
         )}
       </div>
       <CommandPalette />
+      <DesignsView />
+      <RenameDesignDialog />
+      <DeleteDesignDialog />
       <ToastViewport />
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { useT } from '@open-codesign/i18n';
-import { Download, Moon, Plus, Settings as SettingsIcon } from 'lucide-react';
+import { Download, FolderOpen, Moon, Pencil, Plus, Settings as SettingsIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useCodesignStore } from '../store';
 
@@ -18,26 +18,41 @@ export function CommandPalette() {
   const setView = useCodesignStore((s) => s.setView);
   const toggleTheme = useCodesignStore((s) => s.toggleTheme);
   const pushToast = useCodesignStore((s) => s.pushToast);
+  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const openDesignsView = useCodesignStore((s) => s.openDesignsView);
+  const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
+  const designs = useCodesignStore((s) => s.designs);
+  const currentDesignId = useCodesignStore((s) => s.currentDesignId);
 
   const [query, setQuery] = useState('');
   const [cursor, setCursor] = useState(0);
 
-  const actions: PaletteAction[] = useMemo(
-    () => [
+  const actions: PaletteAction[] = useMemo(() => {
+    const current = designs.find((d) => d.id === currentDesignId) ?? null;
+    return [
       {
         id: 'new-design',
         label: t('commands.items.newDesign'),
         hint: t('commands.hints.newDesign'),
         icon: Plus,
         run: () => {
-          useCodesignStore.setState({
-            messages: [],
-            previewHtml: null,
-            errorMessage: null,
-            iframeErrors: [],
-            selectedElement: null,
-          });
-          pushToast({ variant: 'info', title: t('commands.cleared') });
+          void createNewDesign();
+        },
+      },
+      {
+        id: 'browse-designs',
+        label: t('commands.items.browseDesigns'),
+        hint: t('commands.hints.browseDesigns'),
+        icon: FolderOpen,
+        run: openDesignsView,
+      },
+      {
+        id: 'rename-design',
+        label: t('commands.items.renameDesign'),
+        hint: t('commands.hints.renameDesign'),
+        icon: Pencil,
+        run: () => {
+          if (current) requestRenameDesign(current);
         },
       },
       {
@@ -66,9 +81,18 @@ export function CommandPalette() {
             description: t('commands.exportUseToolbarBody'),
           }),
       },
-    ],
-    [setView, pushToast, t, toggleTheme],
-  );
+    ];
+  }, [
+    createNewDesign,
+    currentDesignId,
+    designs,
+    openDesignsView,
+    setView,
+    pushToast,
+    requestRenameDesign,
+    t,
+    toggleTheme,
+  ]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/apps/desktop/src/renderer/src/components/DeleteDesignDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/DeleteDesignDialog.tsx
@@ -1,0 +1,55 @@
+import { useT } from '@open-codesign/i18n';
+import { useCodesignStore } from '../store';
+
+export function DeleteDesignDialog() {
+  const t = useT();
+  const target = useCodesignStore((s) => s.designToDelete);
+  const close = useCodesignStore((s) => s.requestDeleteDesign);
+  const softDeleteDesign = useCodesignStore((s) => s.softDeleteDesign);
+
+  if (!target) return null;
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('projects.delete.title')}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close(null);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') close(null);
+      }}
+    >
+      <div
+        role="document"
+        className="w-full max-w-sm rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] p-5 space-y-4 animate-[panel-in_160ms_ease-out]"
+      >
+        <h3 className="text-[var(--text-md)] font-medium text-[var(--color-text-primary)]">
+          {t('projects.delete.title')}
+        </h3>
+        <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
+          {t('projects.delete.body', { name: target.name })}
+        </p>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => close(null)}
+            className="h-9 px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            {t('projects.delete.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void softDeleteDesign(target.id)}
+            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-error)] text-white text-[var(--text-sm)] font-medium hover:opacity-90 transition-opacity"
+          >
+            {t('projects.delete.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/DeleteDesignDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/DeleteDesignDialog.tsx
@@ -44,7 +44,7 @@ export function DeleteDesignDialog() {
           <button
             type="button"
             onClick={() => void softDeleteDesign(target.id)}
-            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-error)] text-white text-[var(--text-sm)] font-medium hover:opacity-90 transition-opacity"
+            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-error)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:opacity-90 transition-opacity"
           >
             {t('projects.delete.confirm')}
           </button>

--- a/apps/desktop/src/renderer/src/components/DesignSwitcher.tsx
+++ b/apps/desktop/src/renderer/src/components/DesignSwitcher.tsx
@@ -1,0 +1,182 @@
+import { useT } from '@open-codesign/i18n';
+import type { Design } from '@open-codesign/shared';
+import { Check, ChevronDown, FolderOpen, Pencil, Plus } from 'lucide-react';
+import { type CSSProperties, useEffect, useRef, useState } from 'react';
+import { useCodesignStore } from '../store';
+
+const noDragStyle = { WebkitAppRegion: 'no-drag' } as CSSProperties;
+
+const RECENT_LIMIT = 5;
+
+export function DesignSwitcher() {
+  const t = useT();
+  const designs = useCodesignStore((s) => s.designs);
+  const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const switchDesign = useCodesignStore((s) => s.switchDesign);
+  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const openDesignsView = useCodesignStore((s) => s.openDesignsView);
+  const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
+
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (!wrapperRef.current) return;
+      if (e.target instanceof Node && wrapperRef.current.contains(e.target)) return;
+      setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const current = designs.find((d) => d.id === currentDesignId) ?? null;
+  const others = designs.filter((d) => d.id !== currentDesignId).slice(0, RECENT_LIMIT);
+
+  const label = current?.name ?? t('projects.untitled');
+
+  return (
+    <div ref={wrapperRef} className="relative" style={noDragStyle}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('projects.switcher.menuLabel')}
+        className="inline-flex items-center gap-1.5 max-w-[260px] rounded-[var(--radius-md)] px-2 py-1 text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+      >
+        <span className="truncate font-medium">{label}</span>
+        <ChevronDown className="w-3.5 h-3.5 text-[var(--color-text-muted)] shrink-0" />
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          aria-label={t('projects.switcher.menuLabel')}
+          className="absolute left-0 top-[calc(100%+4px)] z-40 w-[300px] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background)] shadow-[var(--shadow-elevated)] overflow-hidden"
+        >
+          {current ? (
+            <div className="px-3 pt-3 pb-2 border-b border-[var(--color-border-muted)]">
+              <div className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium mb-1">
+                {t('projects.switcher.currentLabel')}
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[var(--text-sm)] text-[var(--color-text-primary)] truncate">
+                  {current.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    requestRenameDesign(current);
+                  }}
+                  className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors px-1.5 py-0.5 rounded"
+                >
+                  <Pencil className="w-3 h-3" />
+                  {t('projects.switcher.renameCurrent')}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="px-3 pt-3 pb-1 text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium">
+            {t('projects.switcher.recent')}
+          </div>
+          <ul className="max-h-[260px] overflow-y-auto pb-1">
+            {others.length === 0 ? (
+              <li className="px-3 py-2 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                {t('projects.switcher.noOthers')}
+              </li>
+            ) : (
+              others.map((d) => (
+                <DesignRow
+                  key={d.id}
+                  design={d}
+                  onPick={() => {
+                    setOpen(false);
+                    void switchDesign(d.id);
+                  }}
+                />
+              ))
+            )}
+          </ul>
+
+          <div className="border-t border-[var(--color-border-muted)] py-1">
+            <MenuRow
+              icon={<Plus className="w-3.5 h-3.5" />}
+              label={t('projects.switcher.newDesign')}
+              shortcut="Ctrl/Cmd+N"
+              onClick={() => {
+                setOpen(false);
+                void createNewDesign();
+              }}
+            />
+            <MenuRow
+              icon={<FolderOpen className="w-3.5 h-3.5" />}
+              label={t('projects.switcher.viewAll')}
+              onClick={() => {
+                setOpen(false);
+                openDesignsView();
+              }}
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DesignRow({ design, onPick }: { design: Design; onPick: () => void }) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onPick}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-[var(--color-surface-hover)] transition-colors"
+      >
+        <Check className="w-3.5 h-3.5 text-transparent shrink-0" aria-hidden />
+        <span className="flex-1 min-w-0">
+          <span className="block text-[var(--text-sm)] text-[var(--color-text-primary)] truncate">
+            {design.name}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function MenuRow({
+  icon,
+  label,
+  shortcut,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  shortcut?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+    >
+      <span className="text-[var(--color-text-secondary)] shrink-0 inline-flex">{icon}</span>
+      <span className="flex-1">{label}</span>
+      {shortcut ? (
+        <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono">
+          {shortcut}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/DesignsView.tsx
+++ b/apps/desktop/src/renderer/src/components/DesignsView.tsx
@@ -155,7 +155,7 @@ function DesignCard({
         aria-label={`${t('projects.view.open')} — ${design.name}`}
       >
         {design.thumbnailText ? (
-          <span className="absolute inset-0 flex items-end p-3 text-[var(--text-xs)] text-[var(--color-text-primary)] bg-gradient-to-t from-black/10 via-transparent to-transparent">
+          <span className="absolute inset-0 flex items-end p-3 text-[var(--text-xs)] text-[var(--color-text-primary)] bg-gradient-to-t from-[color-mix(in_srgb,var(--color-text-primary)_10%,transparent)] via-transparent to-transparent">
             <span className="line-clamp-3 leading-[var(--leading-body)]">
               {design.thumbnailText}
             </span>

--- a/apps/desktop/src/renderer/src/components/DesignsView.tsx
+++ b/apps/desktop/src/renderer/src/components/DesignsView.tsx
@@ -1,0 +1,223 @@
+import { useT } from '@open-codesign/i18n';
+import type { Design } from '@open-codesign/shared';
+import { Copy, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { relativeTime } from '../lib/relativeTime';
+import { useCodesignStore } from '../store';
+
+/**
+ * Derive a soft tinted gradient from the design id. Same id always gets the
+ * same colors so cards feel stable across renders. Hue rotation only — we
+ * stay inside the warm-beige palette by clamping saturation/lightness.
+ */
+function gradientFor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  const hue2 = (hue + 40) % 360;
+  return `linear-gradient(135deg, hsl(${hue}, 60%, 92%) 0%, hsl(${hue2}, 55%, 85%) 100%)`;
+}
+
+export function DesignsView() {
+  const t = useT();
+  const open = useCodesignStore((s) => s.designsViewOpen);
+  const close = useCodesignStore((s) => s.closeDesignsView);
+  const designs = useCodesignStore((s) => s.designs);
+  const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const switchDesign = useCodesignStore((s) => s.switchDesign);
+  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const duplicateDesign = useCodesignStore((s) => s.duplicateDesign);
+  const requestDeleteDesign = useCodesignStore((s) => s.requestDeleteDesign);
+  const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
+
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (!open) setQuery('');
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return designs;
+    return designs.filter((d) => d.name.toLowerCase().includes(q));
+  }, [designs, query]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('projects.view.title')}
+      className="fixed inset-0 z-40 flex items-stretch justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') close();
+      }}
+    >
+      <div
+        className="my-10 mx-6 w-full max-w-5xl rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] flex flex-col overflow-hidden animate-[panel-in_160ms_ease-out]"
+        role="document"
+      >
+        <header className="flex items-start justify-between gap-4 px-6 pt-6 pb-4 border-b border-[var(--color-border-muted)]">
+          <div>
+            <h2 className="text-[var(--text-lg)] font-medium text-[var(--color-text-primary)] leading-[var(--leading-heading)]">
+              {t('projects.view.title')}
+            </h2>
+            <p className="mt-1 text-[var(--text-sm)] text-[var(--color-text-secondary)]">
+              {t('projects.view.subtitle')}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label={t('projects.view.close')}
+            className="p-1.5 rounded-[var(--radius-md)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        <div className="flex items-center gap-3 px-6 py-3 border-b border-[var(--color-border-muted)]">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('projects.view.search')}
+            className="flex-1 h-9 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150"
+          />
+          <button
+            type="button"
+            onClick={() => void createNewDesign()}
+            className="inline-flex items-center gap-2 h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            {t('projects.view.newDesign')}
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+          {filtered.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
+              {query.trim()
+                ? t('projects.view.noMatches', { query: query.trim() })
+                : t('projects.view.empty')}
+            </div>
+          ) : (
+            <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {filtered.map((d) => (
+                <DesignCard
+                  key={d.id}
+                  design={d}
+                  isCurrent={d.id === currentDesignId}
+                  onOpen={() => void switchDesign(d.id)}
+                  onRename={() => requestRenameDesign(d)}
+                  onDuplicate={() => void duplicateDesign(d.id)}
+                  onDelete={() => requestDeleteDesign(d)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DesignCard({
+  design,
+  isCurrent,
+  onOpen,
+  onRename,
+  onDuplicate,
+  onDelete,
+}: {
+  design: Design;
+  isCurrent: boolean;
+  onOpen: () => void;
+  onRename: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const t = useT();
+  return (
+    <li className="group rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden hover:shadow-[var(--shadow-card)] hover:border-[var(--color-border-strong)] transition-[box-shadow,border-color] duration-150 ease-[var(--ease-out)] flex flex-col">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="block w-full aspect-[4/3] relative text-left"
+        style={{ background: gradientFor(design.id) }}
+        aria-label={`${t('projects.view.open')} — ${design.name}`}
+      >
+        {design.thumbnailText ? (
+          <span className="absolute inset-0 flex items-end p-3 text-[var(--text-xs)] text-[var(--color-text-primary)] bg-gradient-to-t from-black/10 via-transparent to-transparent">
+            <span className="line-clamp-3 leading-[var(--leading-body)]">
+              {design.thumbnailText}
+            </span>
+          </span>
+        ) : null}
+        {isCurrent ? (
+          <span className="absolute top-2 left-2 inline-flex items-center px-2 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[10px] font-medium uppercase tracking-[var(--tracking-label)]">
+            {t('projects.switcher.currentLabel')}
+          </span>
+        ) : null}
+      </button>
+      <div className="px-3 pt-2 pb-3 flex flex-col gap-2 flex-1">
+        <div className="flex items-start justify-between gap-2 min-w-0">
+          <button
+            type="button"
+            onClick={onOpen}
+            className="text-left text-[var(--text-sm)] font-medium text-[var(--color-text-primary)] truncate hover:text-[var(--color-accent)] transition-colors"
+          >
+            {design.name}
+          </button>
+        </div>
+        <div className="text-[var(--text-xs)] text-[var(--color-text-muted)]">
+          {t('projects.view.edited', { when: relativeTime(design.updatedAt) })}
+        </div>
+        <div className="flex items-center gap-1 mt-auto pt-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+          <CardActionButton onClick={onRename} icon={<Pencil className="w-3.5 h-3.5" />}>
+            {t('projects.view.rename')}
+          </CardActionButton>
+          <CardActionButton onClick={onDuplicate} icon={<Copy className="w-3.5 h-3.5" />}>
+            {t('projects.view.duplicate')}
+          </CardActionButton>
+          <CardActionButton onClick={onDelete} icon={<Trash2 className="w-3.5 h-3.5" />} danger>
+            {t('projects.view.delete')}
+          </CardActionButton>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function CardActionButton({
+  onClick,
+  icon,
+  danger = false,
+  children,
+}: {
+  onClick: () => void;
+  icon: React.ReactNode;
+  danger?: boolean;
+  children: React.ReactNode;
+}) {
+  const colorClass = danger
+    ? 'text-[var(--color-error)] hover:bg-[var(--color-surface-hover)]'
+    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)]';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] text-[var(--text-xs)] transition-colors ${colorClass}`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/RenameDesignDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/RenameDesignDialog.tsx
@@ -1,0 +1,89 @@
+import { useT } from '@open-codesign/i18n';
+import { useEffect, useRef, useState } from 'react';
+import { useCodesignStore } from '../store';
+
+export function RenameDesignDialog() {
+  const t = useT();
+  const target = useCodesignStore((s) => s.designToRename);
+  const close = useCodesignStore((s) => s.requestRenameDesign);
+  const renameDesign = useCodesignStore((s) => s.renameDesign);
+
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (target) {
+      setValue(target.name);
+      requestAnimationFrame(() => {
+        inputRef.current?.select();
+      });
+    } else {
+      setValue('');
+    }
+  }, [target]);
+
+  if (!target) return null;
+
+  const trimmed = value.trim();
+  const canSave = trimmed.length > 0 && trimmed !== target.name;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!target || !canSave) return;
+    void renameDesign(target.id, trimmed);
+  }
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: native <dialog> top-layer rendering interferes with our overlay stack
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('projects.rename.title')}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close(null);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') close(null);
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] p-5 space-y-4 animate-[panel-in_160ms_ease-out]"
+      >
+        <h3 className="text-[var(--text-md)] font-medium text-[var(--color-text-primary)]">
+          {t('projects.rename.title')}
+        </h3>
+        <label className="block space-y-1.5">
+          <span className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium">
+            {t('projects.rename.label')}
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={t('projects.rename.placeholder')}
+            className="w-full h-10 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] transition-[box-shadow,border-color] duration-150"
+          />
+        </label>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => close(null)}
+            className="h-9 px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            {t('projects.rename.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={!canSave}
+            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:bg-[var(--color-accent-hover)] disabled:opacity-30 disabled:hover:bg-[var(--color-accent)] transition-colors"
+          >
+            {t('projects.rename.save')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { Command, Settings as SettingsIcon } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { useCodesignStore } from '../store';
 import { ConnectionStatusDot } from './ConnectionStatusDot';
+import { DesignSwitcher } from './DesignSwitcher';
 import { LanguageToggle } from './LanguageToggle';
 import { ThemeToggle } from './ThemeToggle';
 
@@ -84,16 +85,8 @@ function ByokBadge() {
 
 export function TopBar() {
   const t = useT();
-  const previewHtml = useCodesignStore((s) => s.previewHtml);
-  const isGenerating = useCodesignStore((s) => s.isGenerating);
-  const errorMessage = useCodesignStore((s) => s.errorMessage);
   const setView = useCodesignStore((s) => s.setView);
   const openCommandPalette = useCodesignStore((s) => s.openCommandPalette);
-
-  let crumb = t('preview.noDesign');
-  if (errorMessage) crumb = t('preview.error.title');
-  else if (isGenerating) crumb = t('preview.loading.title');
-  else if (previewHtml) crumb = t('preview.ready');
 
   return (
     <header
@@ -103,9 +96,7 @@ export function TopBar() {
       <div className="flex items-center gap-[var(--space-3)] min-w-0">
         <Wordmark badge={t('common.preAlpha')} size="sm" />
         <span className="text-[var(--color-text-muted)]">/</span>
-        <span className="text-[var(--text-sm)] text-[var(--color-text-secondary)] truncate">
-          {crumb}
-        </span>
+        <DesignSwitcher />
         <ConnectionStatusDot />
       </div>
 

--- a/apps/desktop/src/renderer/src/lib/relativeTime.ts
+++ b/apps/desktop/src/renderer/src/lib/relativeTime.ts
@@ -1,0 +1,30 @@
+import { i18n } from '@open-codesign/i18n';
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Format an ISO timestamp as a coarse relative string ("just now",
+ * "5 minutes ago", "yesterday", "3 days ago"). Falls back to the local date
+ * once we cross a week, where "X days ago" stops being readable.
+ */
+export function relativeTime(iso: string, now: number = Date.now()): string {
+  const t = i18n.t.bind(i18n);
+  const diff = Math.max(0, now - new Date(iso).getTime());
+  if (diff < MINUTE) return t('projects.time.justNow') as string;
+  if (diff < HOUR) {
+    const minutes = Math.round(diff / MINUTE);
+    return t('projects.time.minutesAgo', { count: minutes }) as string;
+  }
+  if (diff < DAY) {
+    const hours = Math.round(diff / HOUR);
+    return t('projects.time.hoursAgo', { count: hours }) as string;
+  }
+  if (diff < 2 * DAY) return t('projects.time.yesterday') as string;
+  if (diff < 7 * DAY) {
+    const days = Math.round(diff / DAY);
+    return t('projects.time.daysAgo', { count: days }) as string;
+  }
+  return new Date(iso).toLocaleDateString();
+}

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -580,4 +580,28 @@ describe('useCodesignStore design management', () => {
     // Should have surfaced a toast about the block.
     expect(useCodesignStore.getState().toasts.at(-1)?.variant).toBe('info');
   });
+
+  it('blocks softDeleteDesign while a generation is running so applyGenerateSuccess cannot leak into a stale design', async () => {
+    const softDeleteDesign = vi.fn(() => Promise.resolve());
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          softDeleteDesign,
+          listDesigns: vi.fn(() => Promise.resolve([])),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({
+      currentDesignId: 'design-a',
+      isGenerating: true,
+    });
+
+    await useCodesignStore.getState().softDeleteDesign('design-a');
+
+    expect(softDeleteDesign).not.toHaveBeenCalled();
+    expect(useCodesignStore.getState().currentDesignId).toBe('design-a');
+    expect(useCodesignStore.getState().toasts.at(-1)?.variant).toBe('info');
+  });
 });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -231,6 +231,7 @@ describe('useCodesignStore generation cancellation', () => {
   });
 });
 
+
 describe('useCodesignStore view navigation', () => {
   it('starts on hub view', () => {
     expect(useCodesignStore.getState().view).toBe('hub');
@@ -456,5 +457,128 @@ describe('useCodesignStore previewViewport', () => {
     useCodesignStore.getState().setPreviewViewport('mobile');
     useCodesignStore.getState().setPreviewViewport('desktop');
     expect(useCodesignStore.getState().previewViewport).toBe('desktop');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project (design) management
+// ---------------------------------------------------------------------------
+
+describe('useCodesignStore design management', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('switches the message list when switchDesign is called and isolates state per design', async () => {
+    const designs = [
+      {
+        schemaVersion: 1 as const,
+        id: 'design-a',
+        name: 'A',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        thumbnailText: null,
+        deletedAt: null,
+      },
+      {
+        schemaVersion: 1 as const,
+        id: 'design-b',
+        name: 'B',
+        createdAt: '2024-01-02T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+        thumbnailText: null,
+        deletedAt: null,
+      },
+    ];
+
+    const messagesByDesign: Record<string, Array<{ role: string; content: string }>> = {
+      'design-a': [
+        { role: 'user', content: 'A user' },
+        { role: 'assistant', content: 'A reply' },
+      ],
+      'design-b': [{ role: 'user', content: 'B user' }],
+    };
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          listDesigns: vi.fn(() => Promise.resolve(designs)),
+          listMessages: vi.fn((id: string) => Promise.resolve(messagesByDesign[id] ?? [])),
+          list: vi.fn(() => Promise.resolve([])),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({ currentDesignId: 'design-a' });
+    await useCodesignStore.getState().switchDesign('design-b');
+
+    expect(useCodesignStore.getState().currentDesignId).toBe('design-b');
+    expect(useCodesignStore.getState().messages.map((m) => m.content)).toEqual(['B user']);
+
+    await useCodesignStore.getState().switchDesign('design-a');
+    expect(useCodesignStore.getState().messages.map((m) => m.content)).toEqual([
+      'A user',
+      'A reply',
+    ]);
+  });
+
+  it('createNewDesign resets messages + preview and stores the new id as current', async () => {
+    const created = {
+      schemaVersion: 1 as const,
+      id: 'fresh',
+      name: 'Untitled design 1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      thumbnailText: null,
+      deletedAt: null,
+    };
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          createDesign: vi.fn(() => Promise.resolve(created)),
+          listDesigns: vi.fn(() => Promise.resolve([created])),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({
+      messages: [{ role: 'user', content: 'leftover' }],
+      previewHtml: '<html>old</html>',
+      currentDesignId: 'old-id',
+    });
+
+    const result = await useCodesignStore.getState().createNewDesign();
+    expect(result?.id).toBe('fresh');
+    const state = useCodesignStore.getState();
+    expect(state.currentDesignId).toBe('fresh');
+    expect(state.messages).toEqual([]);
+    expect(state.previewHtml).toBeNull();
+  });
+
+  it('blocks switchDesign while a generation is running', async () => {
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          listMessages: vi.fn(() => Promise.resolve([])),
+          list: vi.fn(() => Promise.resolve([])),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({
+      currentDesignId: 'design-a',
+      isGenerating: true,
+    });
+
+    await useCodesignStore.getState().switchDesign('design-b');
+
+    // Should not have switched.
+    expect(useCodesignStore.getState().currentDesignId).toBe('design-a');
+    // Should have surfaced a toast about the block.
+    expect(useCodesignStore.getState().toasts.at(-1)?.variant).toBe('info');
   });
 });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -231,7 +231,6 @@ describe('useCodesignStore generation cancellation', () => {
   });
 });
 
-
 describe('useCodesignStore view navigation', () => {
   it('starts on hub view', () => {
     expect(useCodesignStore.getState().view).toBe('hub');

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,6 +1,7 @@
 import { i18n } from '@open-codesign/i18n';
 import {
   type ChatMessage,
+  type Design,
   type LocalInputFile,
   type ModelRef,
   type OnboardingState,
@@ -73,6 +74,13 @@ interface CodesignState {
   toastMessage: string | null;
   connectionStatus: ConnectionStatus;
 
+  designs: Design[];
+  currentDesignId: string | null;
+  designsLoaded: boolean;
+  designsViewOpen: boolean;
+  designToDelete: Design | null;
+  designToRename: Design | null;
+
   theme: Theme;
   view: AppView;
   hubTab: HubTab;
@@ -127,6 +135,19 @@ interface CodesignState {
   setPreviewViewport: (viewport: PreviewViewport) => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
+
+  loadDesigns: () => Promise<void>;
+  ensureCurrentDesign: () => Promise<void>;
+  createNewDesign: () => Promise<Design | null>;
+  switchDesign: (id: string) => Promise<void>;
+  renameCurrentDesign: (name: string) => Promise<void>;
+  renameDesign: (id: string, name: string) => Promise<void>;
+  duplicateDesign: (id: string) => Promise<Design | null>;
+  softDeleteDesign: (id: string) => Promise<void>;
+  openDesignsView: () => void;
+  closeDesignsView: () => void;
+  requestDeleteDesign: (design: Design | null) => void;
+  requestRenameDesign: (design: Design | null) => void;
 
   pushToast: (toast: Omit<Toast, 'id'>) => string;
   dismissToast: (id?: string) => void;
@@ -249,6 +270,76 @@ function tr(key: string, options?: Record<string, unknown>): string {
 type SetState = StoreApi<CodesignState>['setState'];
 type GetState = StoreApi<CodesignState>['getState'];
 
+function autoNameFromPrompt(prompt: string): string {
+  const condensed = prompt.replace(/\s+/g, ' ').trim();
+  if (condensed.length === 0) return 'Untitled design';
+  return condensed.length > 40 ? `${condensed.slice(0, 40).trimEnd()}…` : condensed;
+}
+
+function isDefaultDesignName(name: string): boolean {
+  return name === 'Untitled design' || /^Untitled design \d+$/.test(name);
+}
+
+async function persistDesignState(
+  get: GetState,
+  designId: string,
+  messages: ChatMessage[],
+  previewHtml: string | null,
+): Promise<void> {
+  if (!window.codesign) return;
+  try {
+    await window.codesign.snapshots.replaceMessages(
+      designId,
+      messages.map((m) => ({ role: m.role, content: m.content })),
+    );
+    if (previewHtml !== null) {
+      const firstUser = messages.find((m) => m.role === 'user');
+      const thumbText = firstUser ? firstUser.content.slice(0, 200) : null;
+      await window.codesign.snapshots.setThumbnail(designId, thumbText);
+    }
+    await get().loadDesigns();
+  } catch (err) {
+    // Persistence failures should not break the chat experience — log to console
+    // and leave the in-memory state untouched. The next successful persist will
+    // overwrite anyway because we replace the whole list.
+    console.error('persistDesignState failed', err);
+  }
+}
+
+async function maybeAutoRename(
+  get: GetState,
+  designId: string,
+  firstPrompt: string,
+): Promise<void> {
+  if (!window.codesign) return;
+  const design = get().designs.find((d) => d.id === designId);
+  if (!design || !isDefaultDesignName(design.name)) return;
+  const newName = autoNameFromPrompt(firstPrompt);
+  try {
+    await window.codesign.snapshots.renameDesign(designId, newName);
+    await get().loadDesigns();
+  } catch (err) {
+    console.error('maybeAutoRename failed', err);
+  }
+}
+
+function triggerAutoRenameIfFirst(get: GetState, isFirstPrompt: boolean, prompt: string): void {
+  if (!isFirstPrompt) return;
+  const designId = get().currentDesignId;
+  if (designId) void maybeAutoRename(get, designId, prompt);
+}
+
+interface ReadyConfig extends OnboardingState {
+  hasKey: true;
+  provider: SupportedOnboardingProvider;
+  modelPrimary: string;
+}
+
+function isReadyConfig(cfg: OnboardingState | null): cfg is ReadyConfig {
+  if (cfg === null) return false;
+  return cfg.hasKey && cfg.provider !== null && cfg.modelPrimary !== null;
+}
+
 function finishIfCurrent(
   set: SetState,
   generationId: string,
@@ -259,6 +350,7 @@ function finishIfCurrent(
 
 function applyGenerateSuccess(
   set: SetState,
+  get: GetState,
   generationId: string,
   result: { artifacts: Array<{ content: string }>; message: string },
 ): void {
@@ -273,6 +365,10 @@ function applyGenerateSuccess(
     activeGenerationId: null,
     generationStage: 'done' as GenerationStage,
   }));
+  const designId = get().currentDesignId;
+  if (designId) {
+    void persistDesignState(get, designId, get().messages, get().previewHtml);
+  }
 }
 
 function applyGenerateError(
@@ -318,15 +414,15 @@ async function runGenerate(
   // Enter streaming stage before the IPC call so the UI shows "receiving response"
   // while the main process communicates with the model provider.
   advanceStageIfCurrent(get, set, generationId, 'streaming');
-  if (!window.codesign) {
-    throw new Error('codesign IPC bridge unavailable');
-  }
-  const result = await window.codesign.generate(payload);
+  const api = window.codesign;
+  if (!api) throw new Error(tr('errors.rendererDisconnected'));
+  const result = await api.generate(payload);
   // Response fully received — move through parsing → rendering before finalising.
   advanceStageIfCurrent(get, set, generationId, 'parsing');
   advanceStageIfCurrent(get, set, generationId, 'rendering');
   applyGenerateSuccess(
     set,
+    get,
     generationId,
     result as { artifacts: Array<{ content: string }>; message: string },
   );
@@ -378,6 +474,13 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   toasts: [],
   iframeErrors: [],
 
+  designs: [],
+  currentDesignId: null,
+  designsLoaded: false,
+  designsViewOpen: false,
+  designToDelete: null,
+  designToRename: null,
+
   inputFiles: [],
   referenceUrl: '',
   lastPromptInput: null,
@@ -406,6 +509,9 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     }
     const state = await window.codesign.onboarding.getState();
     set({ config: state, configLoaded: true });
+    if (state.hasKey) {
+      await get().ensureCurrentDesign();
+    }
   },
 
   completeOnboarding(next: OnboardingState) {
@@ -500,7 +606,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       return;
     }
     const cfg = get().config;
-    if (cfg === null || !cfg.hasKey || cfg.provider === null || cfg.modelPrimary === null) {
+    if (!isReadyConfig(cfg)) {
       const msg = tr('errors.onboardingIncomplete');
       set({ errorMessage: msg, lastError: msg });
       return;
@@ -511,6 +617,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
     const generationId = newId();
     const history = get().messages;
+    const isFirstPrompt = history.length === 0;
     set((s) => ({
       messages: [...s.messages, { role: 'user', content: request.prompt }],
       isGenerating: true,
@@ -522,6 +629,8 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       selectedElement: null,
       iframeErrors: [],
     }));
+
+    triggerAutoRenameIfFirst(get, isFirstPrompt, request.prompt);
 
     try {
       await runGenerate(get, set, generationId, {
@@ -777,6 +886,191 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   },
   closeCommandPalette() {
     set({ commandPaletteOpen: false });
+  },
+
+  async loadDesigns() {
+    if (!window.codesign) return;
+    try {
+      const designs = await window.codesign.snapshots.listDesigns();
+      set({ designs, designsLoaded: true });
+    } catch (err) {
+      console.error('loadDesigns failed', err);
+      set({ designsLoaded: true });
+    }
+  },
+
+  async ensureCurrentDesign() {
+    if (!window.codesign) return;
+    await get().loadDesigns();
+    const designs = get().designs;
+    if (get().currentDesignId !== null) return;
+
+    if (designs.length > 0) {
+      const first = designs[0];
+      if (first) await get().switchDesign(first.id);
+      return;
+    }
+    // No designs exist yet — create the first one silently. The user can
+    // rename it later or just send a prompt and we'll auto-name it.
+    await get().createNewDesign();
+  },
+
+  async createNewDesign() {
+    if (!window.codesign) return null;
+    if (get().isGenerating) return null;
+    const existingCount = get().designs.length;
+    const name = `Untitled design ${existingCount + 1}`;
+    try {
+      const design = await window.codesign.snapshots.createDesign(name);
+      set({
+        currentDesignId: design.id,
+        messages: [],
+        previewHtml: null,
+        errorMessage: null,
+        iframeErrors: [],
+        selectedElement: null,
+        lastPromptInput: null,
+        designsViewOpen: false,
+      });
+      await get().loadDesigns();
+      return design;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.createFailed'),
+        description: msg,
+      });
+      return null;
+    }
+  },
+
+  async switchDesign(id: string) {
+    if (!window.codesign) return;
+    if (get().isGenerating) {
+      get().pushToast({
+        variant: 'info',
+        title: tr('projects.notifications.switchBlockedGenerating'),
+      });
+      return;
+    }
+    if (get().currentDesignId === id) {
+      set({ designsViewOpen: false });
+      return;
+    }
+    try {
+      const [messages, snapshots] = await Promise.all([
+        window.codesign.snapshots.listMessages(id),
+        window.codesign.snapshots.list(id),
+      ]);
+      const latest = snapshots[0] ?? null;
+      set({
+        currentDesignId: id,
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+        previewHtml: latest ? latest.artifactSource : null,
+        errorMessage: null,
+        iframeErrors: [],
+        selectedElement: null,
+        lastPromptInput: null,
+        designsViewOpen: false,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.switchFailed'),
+        description: msg,
+      });
+    }
+  },
+
+  async renameCurrentDesign(name: string) {
+    const id = get().currentDesignId;
+    if (!id) return;
+    await get().renameDesign(id, name);
+  },
+
+  async renameDesign(id: string, name: string) {
+    if (!window.codesign) return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      await window.codesign.snapshots.renameDesign(id, trimmed);
+      await get().loadDesigns();
+      set({ designToRename: null });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.renameFailed'),
+        description: msg,
+      });
+    }
+  },
+
+  async duplicateDesign(id: string) {
+    if (!window.codesign) return null;
+    const source = get().designs.find((d) => d.id === id);
+    if (!source) return null;
+    const name = tr('projects.duplicateNameTemplate', { name: source.name });
+    try {
+      const cloned = await window.codesign.snapshots.duplicateDesign(id, name);
+      await get().loadDesigns();
+      get().pushToast({
+        variant: 'success',
+        title: tr('projects.notifications.duplicated', { name: cloned.name }),
+      });
+      return cloned;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.duplicateFailed'),
+        description: msg,
+      });
+      return null;
+    }
+  },
+
+  async softDeleteDesign(id: string) {
+    if (!window.codesign) return;
+    try {
+      await window.codesign.snapshots.softDeleteDesign(id);
+      const wasCurrent = get().currentDesignId === id;
+      await get().loadDesigns();
+      if (wasCurrent) {
+        const remaining = get().designs;
+        set({ currentDesignId: null, messages: [], previewHtml: null });
+        if (remaining.length > 0 && remaining[0]) {
+          await get().switchDesign(remaining[0].id);
+        } else {
+          await get().createNewDesign();
+        }
+      }
+      set({ designToDelete: null });
+      get().pushToast({ variant: 'info', title: tr('projects.notifications.deleted') });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.deleteFailed'),
+        description: msg,
+      });
+    }
+  },
+
+  openDesignsView() {
+    void get().loadDesigns();
+    set({ designsViewOpen: true });
+  },
+  closeDesignsView() {
+    set({ designsViewOpen: false });
+  },
+  requestDeleteDesign(design) {
+    set({ designToDelete: design });
+  },
+  requestRenameDesign(design) {
+    set({ designToRename: design });
   },
 
   pushToast(toast) {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -299,10 +299,13 @@ async function persistDesignState(
     }
     await get().loadDesigns();
   } catch (err) {
-    // Persistence failures should not break the chat experience — log to console
-    // and leave the in-memory state untouched. The next successful persist will
-    // overwrite anyway because we replace the whole list.
-    console.error('persistDesignState failed', err);
+    const msg = err instanceof Error ? err.message : tr('errors.unknown');
+    get().pushToast({
+      variant: 'error',
+      title: tr('projects.notifications.saveFailed'),
+      description: msg,
+    });
+    throw err instanceof Error ? err : new Error(msg);
   }
 }
 
@@ -319,7 +322,13 @@ async function maybeAutoRename(
     await window.codesign.snapshots.renameDesign(designId, newName);
     await get().loadDesigns();
   } catch (err) {
-    console.error('maybeAutoRename failed', err);
+    const msg = err instanceof Error ? err.message : tr('errors.unknown');
+    get().pushToast({
+      variant: 'error',
+      title: tr('projects.notifications.renameFailed'),
+      description: msg,
+    });
+    throw err instanceof Error ? err : new Error(msg);
   }
 }
 
@@ -894,8 +903,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       const designs = await window.codesign.snapshots.listDesigns();
       set({ designs, designsLoaded: true });
     } catch (err) {
-      console.error('loadDesigns failed', err);
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('projects.notifications.loadFailed'),
+        description: msg,
+      });
       set({ designsLoaded: true });
+      throw err instanceof Error ? err : new Error(msg);
     }
   },
 

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1049,6 +1049,13 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   async softDeleteDesign(id: string) {
     if (!window.codesign) return;
+    if (get().isGenerating) {
+      get().pushToast({
+        variant: 'info',
+        title: tr('projects.notifications.deleteBlockedGenerating'),
+      });
+      return;
+    }
     try {
       await window.codesign.snapshots.softDeleteDesign(id);
       const wasCurrent = get().currentDesignId === id;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -472,7 +472,9 @@
       "duplicated": "Duplicated as \"{{name}}\"",
       "duplicateFailed": "Could not duplicate the design",
       "deleted": "Design moved out of the active list",
-      "deleteFailed": "Could not delete the design"
+      "deleteFailed": "Could not delete the design",
+      "saveFailed": "Could not save the latest changes",
+      "loadFailed": "Could not load your designs"
     }
   },
   "demos": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -473,6 +473,7 @@
       "duplicateFailed": "Could not duplicate the design",
       "deleted": "Design moved out of the active list",
       "deleteFailed": "Could not delete the design",
+      "deleteBlockedGenerating": "Wait for generation to finish before deleting",
       "saveFailed": "Could not save the latest changes",
       "loadFailed": "Could not load your designs"
     }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -313,13 +313,17 @@
       "newDesign": "New design",
       "toggleTheme": "Toggle theme",
       "openSettings": "Open settings",
-      "export": "Export current design"
+      "export": "Export current design",
+      "browseDesigns": "Browse all designs",
+      "renameDesign": "Rename current design"
     },
     "hints": {
-      "newDesign": "Clear chat and start fresh",
+      "newDesign": "Start a fresh design (Cmd+N)",
       "toggleTheme": "Switch between light and dark",
       "openSettings": "Models, appearance, storage",
-      "export": "Use the export button in the toolbar"
+      "export": "Use the export button in the toolbar",
+      "browseDesigns": "Open the designs grid",
+      "renameDesign": "Edit the current design's name"
     },
     "tooltips": {
       "commandPalette": "Command palette  Ctrl/Cmd+K",
@@ -407,6 +411,69 @@
     "unknown": "Unknown error",
     "localePersistFailed": "Failed to save language preference",
     "projectStorageFailed": "Couldn't read or write projects on this device. Your changes may not persist."
+  },
+  "projects": {
+    "untitled": "Untitled design",
+    "untitledNumbered": "Untitled design {{n}}",
+    "duplicateNameTemplate": "{{name}} copy",
+    "switcher": {
+      "currentLabel": "Current design",
+      "menuLabel": "Switch design",
+      "newDesign": "New design",
+      "renameCurrent": "Rename",
+      "viewAll": "View all designs\u2026",
+      "recent": "Recent",
+      "noOthers": "No other designs yet"
+    },
+    "view": {
+      "title": "Designs",
+      "subtitle": "All your saved designs. Switch, rename, duplicate, or delete.",
+      "newDesign": "New design",
+      "search": "Search designs",
+      "empty": "No designs yet — create your first one to get started.",
+      "noMatches": "No designs match \"{{query}}\".",
+      "open": "Open",
+      "rename": "Rename",
+      "duplicate": "Duplicate",
+      "delete": "Delete",
+      "edited": "Edited {{when}}",
+      "snapshotCount_one": "{{count}} version",
+      "snapshotCount_other": "{{count}} versions",
+      "close": "Close designs view"
+    },
+    "rename": {
+      "title": "Rename design",
+      "label": "Design name",
+      "placeholder": "e.g. Landing page hero",
+      "save": "Save",
+      "cancel": "Cancel"
+    },
+    "delete": {
+      "title": "Delete this design?",
+      "body": "\"{{name}}\" and all of its history will be removed from the designs list. This cannot be undone in v0.",
+      "confirm": "Delete design",
+      "cancel": "Keep it"
+    },
+    "time": {
+      "justNow": "just now",
+      "minutesAgo_one": "{{count}} minute ago",
+      "minutesAgo_other": "{{count}} minutes ago",
+      "hoursAgo_one": "{{count}} hour ago",
+      "hoursAgo_other": "{{count}} hours ago",
+      "yesterday": "yesterday",
+      "daysAgo_one": "{{count}} day ago",
+      "daysAgo_other": "{{count}} days ago"
+    },
+    "notifications": {
+      "createFailed": "Could not create a new design",
+      "switchFailed": "Could not switch design",
+      "switchBlockedGenerating": "Wait for generation to finish before switching",
+      "renameFailed": "Could not rename the design",
+      "duplicated": "Duplicated as \"{{name}}\"",
+      "duplicateFailed": "Could not duplicate the design",
+      "deleted": "Design moved out of the active list",
+      "deleteFailed": "Could not delete the design"
+    }
   },
   "demos": {
     "meditationApp": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -467,7 +467,9 @@
       "duplicated": "已复制为“{{name}}”",
       "duplicateFailed": "无法复制设计",
       "deleted": "设计已从活动列表中移除",
-      "deleteFailed": "无法删除设计"
+      "deleteFailed": "无法删除设计",
+      "saveFailed": "无法保存最新更改",
+      "loadFailed": "无法加载设计列表"
     }
   },
   "demos": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -468,6 +468,7 @@
       "duplicateFailed": "无法复制设计",
       "deleted": "设计已从活动列表中移除",
       "deleteFailed": "无法删除设计",
+      "deleteBlockedGenerating": "等当前生成完成后再删除",
       "saveFailed": "无法保存最新更改",
       "loadFailed": "无法加载设计列表"
     }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -312,13 +312,17 @@
       "newDesign": "新建设计",
       "toggleTheme": "切换主题",
       "openSettings": "打开设置",
-      "export": "导出当前设计"
+      "export": "导出当前设计",
+      "browseDesigns": "查看所有设计",
+      "renameDesign": "重命名当前设计"
     },
     "hints": {
-      "newDesign": "清空当前会话并重新开始",
+      "newDesign": "开始一个新的设计 (Cmd+N)",
       "toggleTheme": "在浅色和深色之间切换",
       "openSettings": "模型、外观、存储",
-      "export": "使用顶部工具栏里的导出按钮"
+      "export": "使用顶部工具栏里的导出按钮",
+      "browseDesigns": "打开设计网格视图",
+      "renameDesign": "修改当前设计的名字"
     },
     "tooltips": {
       "commandPalette": "命令面板  Ctrl/Cmd+K",
@@ -406,6 +410,65 @@
     "unknown": "未知错误",
     "localePersistFailed": "无法保存语言偏好",
     "projectStorageFailed": "本机的项目数据读写失败，改动可能未保存。"
+  },
+  "projects": {
+    "untitled": "未命名设计",
+    "untitledNumbered": "未命名设计 {{n}}",
+    "duplicateNameTemplate": "{{name}} 副本",
+    "switcher": {
+      "currentLabel": "当前设计",
+      "menuLabel": "切换设计",
+      "newDesign": "新建设计",
+      "renameCurrent": "重命名",
+      "viewAll": "查看全部设计…",
+      "recent": "最近",
+      "noOthers": "暂无其他设计"
+    },
+    "view": {
+      "title": "设计列表",
+      "subtitle": "你保存的全部设计。可以切换、重命名、复制或删除。",
+      "newDesign": "新建设计",
+      "search": "搜索设计",
+      "empty": "还没有任何设计 — 创建第一个吧。",
+      "noMatches": "没有名字匹配“{{query}}”的设计。",
+      "open": "打开",
+      "rename": "重命名",
+      "duplicate": "复制",
+      "delete": "删除",
+      "edited": "{{when}} 编辑",
+      "snapshotCount_other": "{{count}} 个版本",
+      "close": "关闭设计列表"
+    },
+    "rename": {
+      "title": "重命名设计",
+      "label": "设计名",
+      "placeholder": "比如：落地页 hero 区",
+      "save": "保存",
+      "cancel": "取消"
+    },
+    "delete": {
+      "title": "删除该设计？",
+      "body": "“{{name}}”及其所有历史会从设计列表移除。在 v0 版本中无法撤销。",
+      "confirm": "删除设计",
+      "cancel": "保留"
+    },
+    "time": {
+      "justNow": "刚刚",
+      "minutesAgo_other": "{{count}} 分钟前",
+      "hoursAgo_other": "{{count}} 小时前",
+      "yesterday": "昨天",
+      "daysAgo_other": "{{count}} 天前"
+    },
+    "notifications": {
+      "createFailed": "无法创建新设计",
+      "switchFailed": "无法切换设计",
+      "switchBlockedGenerating": "等当前生成完成后再切换",
+      "renameFailed": "无法重命名设计",
+      "duplicated": "已复制为“{{name}}”",
+      "duplicateFailed": "无法复制设计",
+      "deleted": "设计已从活动列表中移除",
+      "deleteFailed": "无法删除设计"
+    }
   },
   "demos": {
     "meditationApp": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -235,8 +235,8 @@ export type { ProxyPresetId } from './proxy-presets';
 export { DesignTokenV1, DesignTokenSet } from './design-token';
 export type { DesignToken } from './design-token';
 
-export { DesignSnapshotV1, DesignV1 } from './snapshot';
-export type { Design, DesignSnapshot, SnapshotCreateInput } from './snapshot';
+export { DesignMessageV1, DesignSnapshotV1, DesignV1 } from './snapshot';
+export type { Design, DesignMessage, DesignSnapshot, SnapshotCreateInput } from './snapshot';
 
 export { SkillFrontmatterV1 } from './skills';
 export type { LoadedSkill } from './skills';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -232,6 +232,7 @@ export {
   getPresetById,
 } from './proxy-presets';
 export type { ProxyPresetId } from './proxy-presets';
+
 export { DesignTokenV1, DesignTokenSet } from './design-token';
 export type { DesignToken } from './design-token';
 

--- a/packages/shared/src/snapshot.ts
+++ b/packages/shared/src/snapshot.ts
@@ -28,7 +28,7 @@ export type Design = z.infer<typeof DesignV1>;
 export const DesignMessageV1 = z.object({
   schemaVersion: z.literal(1).default(1),
   designId: z.string().min(1),
-  role: z.enum(['user', 'assistant']),
+  role: z.enum(['user', 'assistant', 'system']),
   content: z.string(),
   ordinal: z.number().int().nonnegative(),
   createdAt: z.string(),

--- a/packages/shared/src/snapshot.ts
+++ b/packages/shared/src/snapshot.ts
@@ -20,8 +20,20 @@ export const DesignV1 = z.object({
   name: z.string().default('Untitled design'),
   createdAt: z.string(),
   updatedAt: z.string(),
+  thumbnailText: z.string().nullable().default(null),
+  deletedAt: z.string().nullable().default(null),
 });
 export type Design = z.infer<typeof DesignV1>;
+
+export const DesignMessageV1 = z.object({
+  schemaVersion: z.literal(1).default(1),
+  designId: z.string().min(1),
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  ordinal: z.number().int().nonnegative(),
+  createdAt: z.string(),
+});
+export type DesignMessage = z.infer<typeof DesignMessageV1>;
 
 export interface SnapshotCreateInput {
   designId: string;


### PR DESCRIPTION
## Summary

Adds first-class project management. Users can create new designs, browse history, switch / rename / duplicate / soft-delete past work. Each project carries its own message history and preview snapshot.

Built on top of [#29](https://github.com/OpenCoworkAI/open-codesign/pull/29) (snapshots SQLite + IPC). Targets `main` as base — merge order should be **#29 → this PR**.

Addresses user feedback: there was no obvious way to start a new project or see history.

## What ships

- **TopBar breadcrumb dropdown (DesignSwitcher)** — current design name + recent 5 + new + rename + view-all
- **DesignsView grid overlay** — search, hover actions, gradient placeholder cards
- **Soft delete** with confirm modal (cascade behaviour explained in copy)
- **Auto-name from first prompt** (Claude Design / Lovable pattern)
- **`Cmd+N`** for new design; command palette gains "Browse all designs" + "Rename current design"
- **Per-design state**: switching swaps messages + preview from SQLite

## Schema (additive, non-breaking)

- `designs.thumbnail_text` and `designs.deleted_at` columns added via additive migration (PRAGMA-detected, idempotent).
- New `design_messages` table with `ON DELETE CASCADE` and a composite primary key on `(design_id, ordinal)`.

## IPC (`snapshots:v1:*` namespace)

`get-design`, `rename-design`, `set-thumbnail`, `soft-delete-design`, `duplicate-design` (with snapshot parent rewiring), `list-messages`, `replace-messages`.

## Why no real iframe thumbnails yet

A sandboxed iframe-thumbnail pipeline is the eventual goal but is expensive to build correctly (per-card srcdoc + import map + GC). For v1 we ship hash-derived gradient cards + first-prompt snippet, with the `thumbnail_text` column already in place to keep the upgrade path clean. See `docs/research/26-project-management-ux.md` for the rationale and competitor scan.

## PRINCIPLES §5b

- **Compatibility**: additive SQLite migration; messages table is new.
- **Upgradeability**: every new payload carries `schemaVersion: 1`; thumbnails column reserved for the upgrade.
- **No bloat**: 0 new dependencies. ~+1.9k LOC, mostly UI + tests + i18n.
- **Elegance**: single Zustand slice for designs, no parallel store.

## Test plan

- [x] `vitest`: 26 new tests across snapshots-db (rename / soft-delete / duplicate / set-thumbnail / messages / migration idempotency / cascade) and snapshots-ipc (rename / set-thumbnail / soft-delete / duplicate / list+replace messages / get-design)
- [x] `vitest`: store tests for `switchDesign` isolation, `createNewDesign` reset, generation-block-on-switch toast
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (8 pre-existing warnings, 0 errors)
- [ ] manual: `Cmd+N` → new design → first prompt → design auto-names from prompt
- [ ] manual: switch design → messages reset / preview restored from latest snapshot
- [ ] manual: delete design → cascade snapshots + confirm modal
- [ ] manual: duplicate design → new copy with cloned messages and parent-rewired snapshots