### PR TITLE
fix(desktop): bundle Plus Jakarta + JetBrains Mono locally (no Google Fonts CDN)

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -5,12 +5,6 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Open CoDesign</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

Removes the three `<link rel="preconnect|stylesheet">` tags pointing at `fonts.googleapis.com` / `fonts.gstatic.com` from `apps/desktop/src/renderer/index.html`. The renderer already loads Geist + Fraunces + JetBrains Mono locally via `@fontsource-variable/*` through `@open-codesign/ui/fonts` (wired from `apps/desktop/src/renderer/src/main.tsx:2`), so these CDN links were both **redundant** and a **hard-constraint violation**.

## Why this matters

1. **BYOK / no-telemetry violation (hard constraint #3).** Every cold start was firing two `preconnect`s and a stylesheet GET to Google before the app even rendered — i.e., a third-party network ping by default, no opt-in. CLAUDE.md is explicit: "no telemetry by default."
2. **Offline launch was broken.** This is an Electron desktop app; users on planes / behind firewalls / on captive networks would hang on the blocking `<link rel="stylesheet">` until the request timed out, then render with the system fallback.
3. **Multi-second FOUC.** `display=swap` meant first paint used `system-ui`, then re-flowed once the CDN font landed — visible flash on every launch.
4. **China / corp-network reliability.** `fonts.googleapis.com` is unreachable from many networks; users in those regions were getting permanent fallback rendering with no indication why.

## What I changed (and didn't change)

- `apps/desktop/src/renderer/index.html` — removed lines 8–13 (the 3 Google Fonts links). **One file, six lines deleted.**
- I did **not** add `@fontsource-variable/plus-jakarta-sans` to `packages/ui` as the audit suggested. After the `feat(ui): Anthropic-inspired warm aesthetic` refresh (commit 269658d), `--font-sans` resolves to `"Geist Variable"` and `--font-display` to `"Fraunces Variable"` (see `packages/ui/src/tokens.css:56-58`). The `Plus+Jakarta+Sans` family the CDN was loading is **not referenced by any token or component** — it was dead weight from a pre-refresh era. Adding the fontsource package would have shipped ~120KB of woff2 nobody renders.
- JetBrains Mono is already bundled via `@fontsource-variable/jetbrains-mono` in `packages/ui/src/fonts.ts:7`, so the CDN's mono load was also redundant.

## Verification

- `pnpm typecheck` — pass (10/10 turbo tasks)
- `pnpm lint` — only pre-existing warnings, no new findings
- `pnpm build` (electron-builder) — exit 0; ignored hdiutil cleanup quirks are unrelated to this change
- `pnpm test` (pre-commit hook) — 138/138 desktop, all packages green
- Built `apps/desktop/out/renderer/index.html` — `grep` for `fonts.googleapis|fonts.gstatic` returns 0 matches
- Built `assets/` directory contains all expected woff2 subsets (geist-*, fraunces-*, jetbrains-mono-*)
- **Install-size delta: net −6 lines of HTML, no new deps.** Bundle size strictly decreases.

## Test plan

- [ ] Launch app with network disabled — should render brand fonts immediately, no fallback flash
- [ ] DevTools Network tab on cold start — zero requests to `fonts.googleapis.com` / `fonts.gstatic.com`
- [ ] Visual regression on Welcome / TopBar / Wordmark — Geist + Fraunces + JetBrains Mono unchanged

## Principles checklist

- ✅ Compatibility — no API/IPC changes, schema-version untouched
- ✅ Upgradeability — fewer external dependencies → easier
- ✅ No bloat — removes weight, adds none
- ✅ Elegance — fewer moving parts, tokens are now the single source of truth for typography