### PR TITLE
fix(desktop): toast polish — auto-dismiss, countdown bar, a11y

### DIFF
--- a/apps/desktop/src/renderer/src/components/Toast.tsx
+++ b/apps/desktop/src/renderer/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle2, Info, X, XCircle } from 'lucide-react';
+import { useEffect } from 'react';
 import { useCodesignStore } from '../store';
 import type { Toast as ToastModel, ToastVariant } from '../store';
 
@@ -20,14 +21,46 @@ const accentFor: Record<ToastVariant, string> = {
   info: 'var(--color-accent)',
 };
 
+export const AUTO_DISMISS_MS: Record<ToastVariant, number | null> = {
+  success: 5000,
+  info: 5000,
+  error: null,
+};
+
+export function scheduleAutoDismiss(
+  variant: ToastVariant,
+  onDismiss: () => void,
+): (() => void) | null {
+  const ms = AUTO_DISMISS_MS[variant];
+  if (ms === null) return null;
+  const id = setTimeout(onDismiss, ms);
+  return () => {
+    clearTimeout(id);
+  };
+}
+
 function ToastItem({ toast }: { toast: ToastModel }) {
   const dismiss = useCodesignStore((s) => s.dismissToast);
   const Icon = iconFor[toast.variant];
+  const isError = toast.variant === 'error';
+  const autoMs = AUTO_DISMISS_MS[toast.variant];
+
+  useEffect(() => {
+    const cleanup = scheduleAutoDismiss(toast.variant, () => {
+      dismiss(toast.id);
+    });
+    return cleanup ?? undefined;
+  }, [toast.id, toast.variant, dismiss]);
+
   return (
-    <output className="flex items-start gap-3 w-80 px-4 py-3 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] animate-[toast-in_180ms_ease-out]">
+    <div
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      className="relative overflow-hidden flex items-start gap-3 min-w-72 max-w-96 px-4 py-3 rounded-[var(--radius-lg)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] animate-[toast-in_180ms_ease-out] motion-reduce:animate-none"
+    >
       <Icon className="w-5 h-5 mt-0.5 shrink-0" style={{ color: accentFor[toast.variant] }} />
       <div className="flex-1 min-w-0">
-        <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)]">
+        <div className="text-[var(--text-sm)] font-medium text-[var(--color-text-primary)] break-words">
           {toast.title}
         </div>
         {toast.description ? (
@@ -39,12 +72,21 @@ function ToastItem({ toast }: { toast: ToastModel }) {
       <button
         type="button"
         aria-label="Dismiss notification"
-        onClick={() => dismiss(toast.id)}
+        onClick={() => {
+          dismiss(toast.id);
+        }}
         className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
       >
         <X className="w-4 h-4" />
       </button>
-    </output>
+      {autoMs !== null ? (
+        <div
+          aria-hidden="true"
+          className="absolute bottom-0 left-0 right-0 h-0.5 origin-left bg-[var(--color-text-muted)]/30 motion-safe:animate-[toast-countdown_linear_forwards]"
+          style={{ animationDuration: `${autoMs}ms` }}
+        />
+      ) : null}
+    </div>
   );
 }
 
@@ -52,10 +94,7 @@ export function ToastViewport() {
   const toasts = useCodesignStore((s) => s.toasts);
   if (toasts.length === 0) return null;
   return (
-    <div
-      aria-live="polite"
-      className="pointer-events-none fixed bottom-4 right-4 z-[60] flex flex-col gap-2 items-end"
-    >
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[60] flex flex-col gap-2 items-end">
       {toasts.map((t) => (
         <div key={t.id} className="pointer-events-auto">
           <ToastItem toast={t} />

--- a/apps/desktop/src/renderer/src/components/__tests__/Toast.test.tsx
+++ b/apps/desktop/src/renderer/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUTO_DISMISS_MS, scheduleAutoDismiss } from '../Toast';
+
+describe('Toast auto-dismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('dismisses success toasts after 5s', () => {
+    const onDismiss = vi.fn();
+    scheduleAutoDismiss('success', onDismiss);
+    vi.advanceTimersByTime(4999);
+    expect(onDismiss).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses info toasts after 5s', () => {
+    const onDismiss = vi.fn();
+    scheduleAutoDismiss('info', onDismiss);
+    vi.advanceTimersByTime(5000);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto-dismiss error toasts', () => {
+    const onDismiss = vi.fn();
+    const cleanup = scheduleAutoDismiss('error', onDismiss);
+    expect(cleanup).toBeNull();
+    vi.advanceTimersByTime(60_000);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('cleanup cancels the pending timer', () => {
+    const onDismiss = vi.fn();
+    const cleanup = scheduleAutoDismiss('success', onDismiss);
+    expect(cleanup).not.toBeNull();
+    cleanup?.();
+    vi.advanceTimersByTime(10_000);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('exposes 5s for non-error variants and null for error', () => {
+    expect(AUTO_DISMISS_MS.success).toBe(5000);
+    expect(AUTO_DISMISS_MS.info).toBe(5000);
+    expect(AUTO_DISMISS_MS.error).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/index.css
+++ b/apps/desktop/src/renderer/src/index.css
@@ -92,6 +92,15 @@ h3,
   }
 }
 
+@keyframes toast-countdown {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
 @keyframes shimmer-pulse {
   0% {
     background-position: -200% 0;

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -623,11 +623,6 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     const id = newId();
     const next: Toast = { id, ...toast };
     set((s) => ({ toasts: [...s.toasts, next] }));
-    if (typeof window !== 'undefined') {
-      window.setTimeout(() => {
-        get().dismissToast(id);
-      }, 4000);
-    }
     return id;
   },
 


### PR DESCRIPTION
## Summary

Implements audit 27 §B2 — Toast system polish.

### §B2 checklist

- [x] **5s auto-dismiss for `success`/`info`; `error` persists.** `useEffect` timer keyed on toast id, cleaned up on unmount. Removed the unconditional 4s `setTimeout` in `pushToast`.
- [x] **`min-w-72 max-w-96`** instead of fixed `w-80`. Long titles/descriptions wrap (`break-words`) instead of getting truncated.
- [x] **A11y roles per variant.** Each toast item is now its own `role="status" aria-live="polite"` (success/info) or `role="alert" aria-live="assertive"` (error). The misused `<output>` element is replaced by `<div>`. Dismiss button keeps its `aria-label`.
- [x] **Countdown progress bar.** Thin (`h-0.5`) bar at the bottom of auto-dismissing toasts, animated via a new `@keyframes toast-countdown` (linear scaleX 1 → 0). Uses `--color-text-muted` at 30% alpha. `motion-safe:` variant means `prefers-reduced-motion: reduce` users see only a static bar — no animation.
- [x] **No new dependencies.** Pure Tailwind v4 + CSS variables + one CSS keyframe.

### Files changed

- `apps/desktop/src/renderer/src/components/Toast.tsx` — main rewrite (per-toast role/aria-live, useEffect timer, sizing, countdown bar). Exports `scheduleAutoDismiss` + `AUTO_DISMISS_MS` for unit testing.
- `apps/desktop/src/renderer/src/store.ts` — drop the 4s blanket `setTimeout` from `pushToast`; the component owns the timer now.
- `apps/desktop/src/renderer/src/index.css` — add `@keyframes toast-countdown`.
- `apps/desktop/src/renderer/src/components/__tests__/Toast.test.tsx` — new Vitest unit test (5 cases) using fake timers: success/info dismiss after 5s, error never auto-dismisses, cleanup cancels the timer, `AUTO_DISMISS_MS` map values.

Net diff: ~106 LOC added (test included).

### PRINCIPLES check

- 🟢 **Compatibility** — toast public API unchanged (`pushToast`, `dismissToast`, `useToast` signatures preserved). Only the internal timer location moved.
- 🟢 **Upgradeability** — auto-dismiss durations live in a single typed `Record<ToastVariant, number | null>` map; adding a new variant or tweaking timing is a one-line change.
- 🟢 **No bloat** — zero new dependencies, zero new packages. One CSS keyframe + one helper function.
- 🟢 **Elegance** — pure Tailwind variants for `prefers-reduced-motion`; per-toast role/aria-live aligns with WAI-ARIA notification patterns; component owns its own lifecycle.

## Test plan

- [x] `pnpm --filter @open-codesign/desktop test` — 19 files / 143 tests pass (5 new Toast tests).
- [x] `pnpm lint` — clean (only pre-existing warnings unrelated to this PR).
- [x] `pnpm typecheck` — clean across the workspace.
- [ ] Manual smoke: trigger success/info toast → auto-dismisses after 5s with visible countdown bar; trigger error toast → persists until X clicked; OS-level "Reduce motion" → countdown bar visible but static.