### PR TITLE
fix(desktop): active provider sync — UI badge and generate IPC now share single source of truth

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -159,7 +159,11 @@ function registerIpcHandlers(): void {
     // diverge from what the user sees.
     const active = resolveActiveModel(cfg, payload.model);
     const apiKey = getApiKeyForProvider(active.model.provider);
-    const baseUrl = payload.baseUrl ?? active.baseUrl ?? undefined;
+    // Once we've snapped to the canonical active provider, the renderer-supplied
+    // baseUrl can no longer be trusted — it may belong to a different (stale)
+    // provider and would route the active provider's API key to the wrong host.
+    // Always use the per-provider baseUrl from cached config.
+    const baseUrl = active.baseUrl ?? undefined;
     coreLogger.info('[generate] step=load_config.ok', {
       ms: Date.now() - loadStart,
       hasApiKey: apiKey.length > 0,
@@ -273,7 +277,8 @@ function registerIpcHandlers(): void {
     }
     const active = resolveActiveModel(cfg, payload.model);
     const apiKey = getApiKeyForProvider(active.model.provider);
-    const baseUrl = payload.baseUrl ?? active.baseUrl ?? undefined;
+    // See codesign:v1:generate above — renderer baseUrl is ignored post-snap.
+    const baseUrl = active.baseUrl ?? undefined;
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,7 +10,6 @@ import {
   CodesignError,
   GeneratePayload,
   GeneratePayloadV1,
-  isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
 import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
@@ -23,7 +22,6 @@ import { registerLocaleIpc } from './locale-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
 import {
   getApiKeyForProvider,
-  getBaseUrlForProvider,
   getCachedConfig,
   getOnboardingState,
   loadConfigOnBoot,
@@ -32,6 +30,7 @@ import {
 } from './onboarding-ipc';
 import { registerPreferencesIpc } from './preferences-ipc';
 import { preparePromptContext } from './prompt-context';
+import { resolveActiveModel } from './provider-settings';
 
 let mainWindow: ElectronBrowserWindow | null = null;
 
@@ -144,52 +143,70 @@ function registerIpcHandlers(): void {
     const id = payload.generationId;
     inFlight.set(id, controller);
     const coreLogger = coreLoggerFor(id);
-    const stepCtx = { id, provider: payload.model.provider, modelId: payload.model.modelId };
 
     coreLogger.info('[generate] step=load_config');
     const loadStart = Date.now();
-    const apiKey = getApiKeyForProvider(payload.model.provider);
-    const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
-    const baseUrl = payload.baseUrl ?? storedBaseUrl;
     const cfg = getCachedConfig();
+    if (cfg === null) {
+      inFlight.delete(id);
+      throw new CodesignError(
+        'No configuration found. Complete onboarding first.',
+        'CONFIG_MISSING',
+      );
+    }
+    // Snap to the canonical active provider in cachedConfig — the SAME source
+    // the Settings UI uses for the Active badge — so the actual call cannot
+    // diverge from what the user sees.
+    const active = resolveActiveModel(cfg, payload.model);
+    const apiKey = getApiKeyForProvider(active.model.provider);
+    const baseUrl = payload.baseUrl ?? active.baseUrl ?? undefined;
     coreLogger.info('[generate] step=load_config.ok', {
       ms: Date.now() - loadStart,
       hasApiKey: apiKey.length > 0,
       baseUrl: baseUrl ?? '<default>',
     });
 
+    if (active.overridden) {
+      coreLogger.info('[generate] step=resolve_active.override', {
+        requested: payload.model.provider,
+        requestedModelId: payload.model.modelId,
+        active: active.model.provider,
+        activeModelId: active.model.modelId,
+      });
+    }
+
+    const stepCtx = {
+      id,
+      provider: active.model.provider,
+      modelId: active.model.modelId,
+    };
     coreLogger.info('[generate] step=validate_provider', stepCtx);
     if (apiKey.length === 0) {
       coreLogger.error('[generate] step=validate_provider.fail', {
-        provider: payload.model.provider,
+        provider: active.model.provider,
         reason: 'missing_api_key',
       });
       inFlight.delete(id);
       throw new CodesignError(
-        `No API key configured for provider "${payload.model.provider}". Open Settings to add one.`,
+        `No API key configured for provider "${active.model.provider}". Open Settings to add one.`,
         'PROVIDER_AUTH_MISSING',
       );
     }
-    if (!isSupportedOnboardingProvider(payload.model.provider)) {
-      // Non-shortlist providers still work (any ProviderId is accepted by the
-      // payload schema), just warn so the log timeline shows we noticed.
-      coreLogger.info('[generate] step=validate_provider.warn', {
-        provider: payload.model.provider,
-        reason: 'not_in_onboarding_shortlist',
-      });
-    }
-    coreLogger.info('[generate] step=validate_provider.ok', { provider: payload.model.provider });
+    coreLogger.info('[generate] step=validate_provider.ok', { provider: active.model.provider });
 
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,
-      designSystem: cfg?.designSystem ?? null,
+      designSystem: cfg.designSystem ?? null,
     });
 
     logIpc.info('generate', {
       id,
-      provider: payload.model.provider,
-      modelId: payload.model.modelId,
+      provider: active.model.provider,
+      modelId: active.model.modelId,
+      ...(active.overridden
+        ? { requestedProvider: payload.model.provider, requestedModelId: payload.model.modelId }
+        : {}),
       promptLen: payload.prompt.length,
       historyLen: payload.history.length,
       attachmentCount: payload.attachments.length,
@@ -203,7 +220,7 @@ function registerIpcHandlers(): void {
       const result = await generate({
         prompt: payload.prompt,
         history: payload.history,
-        model: payload.model,
+        model: active.model,
         apiKey,
         attachments: promptContext.attachments,
         referenceUrl: promptContext.referenceUrl,
@@ -223,8 +240,8 @@ function registerIpcHandlers(): void {
       logIpc.error('generate.fail', {
         id,
         ms: Date.now() - t0,
-        provider: payload.model.provider,
-        modelId: payload.model.modelId,
+        provider: active.model.provider,
+        modelId: active.model.modelId,
         baseUrl: baseUrl ?? '<default>',
         message: err instanceof Error ? err.message : String(err),
         code: err instanceof CodesignError ? err.code : undefined,
@@ -246,20 +263,30 @@ function registerIpcHandlers(): void {
     const controller = new AbortController();
     inFlight.set(id, controller);
 
-    const apiKey = getApiKeyForProvider(payload.model.provider);
-    const storedBaseUrl = getBaseUrlForProvider(payload.model.provider);
-    const baseUrl = payload.baseUrl ?? storedBaseUrl;
     const cfg = getCachedConfig();
+    if (cfg === null) {
+      inFlight.delete(id);
+      throw new CodesignError(
+        'No configuration found. Complete onboarding first.',
+        'CONFIG_MISSING',
+      );
+    }
+    const active = resolveActiveModel(cfg, payload.model);
+    const apiKey = getApiKeyForProvider(active.model.provider);
+    const baseUrl = payload.baseUrl ?? active.baseUrl ?? undefined;
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,
-      designSystem: cfg?.designSystem ?? null,
+      designSystem: cfg.designSystem ?? null,
     });
 
     logIpc.info('generate', {
       id,
-      provider: payload.model.provider,
-      modelId: payload.model.modelId,
+      provider: active.model.provider,
+      modelId: active.model.modelId,
+      ...(active.overridden
+        ? { requestedProvider: payload.model.provider, requestedModelId: payload.model.modelId }
+        : {}),
       promptLen: payload.prompt.length,
       historyLen: payload.history.length,
       attachmentCount: payload.attachments.length,
@@ -273,7 +300,7 @@ function registerIpcHandlers(): void {
       const result = await generate({
         prompt: payload.prompt,
         history: payload.history,
-        model: payload.model,
+        model: active.model,
         apiKey,
         attachments: promptContext.attachments,
         referenceUrl: promptContext.referenceUrl,
@@ -292,8 +319,8 @@ function registerIpcHandlers(): void {
       logIpc.error('generate.fail', {
         id,
         ms: Date.now() - t0,
-        provider: payload.model.provider,
-        modelId: payload.model.modelId,
+        provider: active.model.provider,
+        modelId: active.model.modelId,
         baseUrl: baseUrl ?? '<default>',
         message: err instanceof Error ? err.message : String(err),
         code: err instanceof CodesignError ? err.code : undefined,
@@ -318,9 +345,13 @@ function registerIpcHandlers(): void {
         'CONFIG_MISSING',
       );
     }
-    const model = payload.model ?? { provider: cfg.provider, modelId: cfg.modelFast };
-    const apiKey = getApiKeyForProvider(model.provider);
-    const storedBaseUrl = getBaseUrlForProvider(model.provider);
+    // Inline-comment edits don't need to be tied to whatever provider was
+    // pinned in the original generate; resolve fresh against the canonical
+    // active provider so a switch in Settings takes effect immediately.
+    const hint = payload.model ?? { provider: cfg.provider, modelId: cfg.modelFast };
+    const active = resolveActiveModel(cfg, hint);
+    const apiKey = getApiKeyForProvider(active.model.provider);
+    const baseUrl = active.baseUrl ?? undefined;
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,
@@ -328,13 +359,16 @@ function registerIpcHandlers(): void {
     });
 
     logIpc.info('applyComment', {
-      provider: model.provider,
-      modelId: model.modelId,
+      provider: active.model.provider,
+      modelId: active.model.modelId,
+      ...(active.overridden
+        ? { requestedProvider: hint.provider, requestedModelId: hint.modelId }
+        : {}),
       selector: payload.selection.selector,
       attachmentCount: payload.attachments.length,
       hasReferenceUrl: payload.referenceUrl !== undefined,
       hasDesignSystem: promptContext.designSystem !== null,
-      baseUrl: storedBaseUrl ?? '<default>',
+      baseUrl: baseUrl ?? '<default>',
     });
 
     const t0 = Date.now();
@@ -343,12 +377,12 @@ function registerIpcHandlers(): void {
         html: payload.html,
         comment: payload.comment,
         selection: payload.selection,
-        model,
+        model: active.model,
         apiKey,
         attachments: promptContext.attachments,
         referenceUrl: promptContext.referenceUrl,
         designSystem: promptContext.designSystem ?? null,
-        ...(storedBaseUrl !== undefined ? { baseUrl: storedBaseUrl } : {}),
+        ...(baseUrl !== undefined ? { baseUrl } : {}),
       });
       logIpc.info('applyComment.ok', {
         ms: Date.now() - t0,
@@ -359,8 +393,8 @@ function registerIpcHandlers(): void {
     } catch (err) {
       logIpc.error('applyComment.fail', {
         ms: Date.now() - t0,
-        provider: model.provider,
-        modelId: model.modelId,
+        provider: active.model.provider,
+        modelId: active.model.modelId,
         selector: payload.selection.selector,
         message: err instanceof Error ? err.message : String(err),
         code: err instanceof CodesignError ? err.code : undefined,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -162,8 +162,13 @@ function registerIpcHandlers(): void {
     // Once we've snapped to the canonical active provider, the renderer-supplied
     // baseUrl can no longer be trusted — it may belong to a different (stale)
     // provider and would route the active provider's API key to the wrong host.
-    // Always use the per-provider baseUrl from cached config.
+    // Always use the per-provider baseUrl from cached config, and mutate the
+    // payload itself so any downstream reader cannot accidentally pick up the
+    // stale renderer value.
     const baseUrl = active.baseUrl ?? undefined;
+    if (active.overridden) {
+      payload.baseUrl = baseUrl;
+    }
     coreLogger.info('[generate] step=load_config.ok', {
       ms: Date.now() - loadStart,
       hasApiKey: apiKey.length > 0,
@@ -279,6 +284,9 @@ function registerIpcHandlers(): void {
     const apiKey = getApiKeyForProvider(active.model.provider);
     // See codesign:v1:generate above — renderer baseUrl is ignored post-snap.
     const baseUrl = active.baseUrl ?? undefined;
+    if (active.overridden) {
+      payload.baseUrl = baseUrl;
+    }
     const promptContext = await preparePromptContext({
       attachments: payload.attachments,
       referenceUrl: payload.referenceUrl,

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -4,6 +4,7 @@ import {
   assertProviderHasStoredSecret,
   computeDeleteProviderResult,
   getAddProviderDefaults,
+  resolveActiveModel,
   toProviderRows,
 } from './provider-settings';
 
@@ -152,5 +153,73 @@ describe('computeDeleteProviderResult', () => {
     expect(result.nextActive).toBeNull();
     expect(result.modelPrimary).toBe('');
     expect(result.modelFast).toBe('');
+  });
+});
+
+describe('resolveActiveModel', () => {
+  const baseCfg: Config = {
+    version: 1,
+    provider: 'openrouter',
+    modelPrimary: 'anthropic/claude-sonnet-4.6',
+    modelFast: 'anthropic/claude-haiku-3',
+    secrets: {
+      openai: { ciphertext: 'enc-oai' },
+      openrouter: { ciphertext: 'enc-or' },
+    },
+    baseUrls: {
+      openai: { baseUrl: 'https://api.duckcoding.ai/v1' },
+    },
+  };
+
+  it('returns the canonical active provider when the hint already matches', () => {
+    const result = resolveActiveModel(baseCfg, {
+      provider: 'openrouter',
+      modelId: 'anthropic/claude-haiku-3',
+    });
+
+    expect(result.overridden).toBe(false);
+    expect(result.model).toEqual({
+      provider: 'openrouter',
+      // Hint modelId is preserved so the renderer can pick fast vs primary.
+      modelId: 'anthropic/claude-haiku-3',
+    });
+    expect(result.baseUrl).toBeNull();
+  });
+
+  it('snaps a stale hint back to the canonical active provider and modelPrimary', () => {
+    // Reproduces the reported bug: Settings UI shows OpenRouter Active, but the
+    // renderer's stale store sends openai + duckcoding-style modelId. The
+    // resolver must override so the actual call lands on openrouter.
+    const result = resolveActiveModel(baseCfg, {
+      provider: 'openai',
+      modelId: 'gpt-4o',
+    });
+
+    expect(result.overridden).toBe(true);
+    expect(result.model).toEqual({
+      provider: 'openrouter',
+      modelId: 'anthropic/claude-sonnet-4.6',
+    });
+    expect(result.baseUrl).toBeNull();
+  });
+
+  it('threads through the per-provider baseUrl for the canonical active', () => {
+    const cfg: Config = { ...baseCfg, provider: 'openai', modelPrimary: 'gpt-4o' };
+    const result = resolveActiveModel(cfg, { provider: 'openai', modelId: 'gpt-4o' });
+
+    expect(result.overridden).toBe(false);
+    expect(result.baseUrl).toBe('https://api.duckcoding.ai/v1');
+  });
+
+  it('throws PROVIDER_KEY_MISSING when the active provider has no stored secret', () => {
+    const cfg: Config = {
+      ...baseCfg,
+      provider: 'anthropic',
+      modelPrimary: 'claude-sonnet-4-6',
+      modelFast: 'claude-haiku-3',
+    };
+    expect(() =>
+      resolveActiveModel(cfg, { provider: 'anthropic', modelId: 'claude-sonnet-4-6' }),
+    ).toThrowError(CodesignError);
   });
 });

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -211,6 +211,24 @@ describe('resolveActiveModel', () => {
     expect(result.baseUrl).toBe('https://api.duckcoding.ai/v1');
   });
 
+  it('ignores stale hint baseUrl entry and returns active provider baseUrl on override', () => {
+    // Reproduces the Codex finding: hint says {openai, duckcoding}, active is
+    // openrouter. The resolver must report openrouter's baseUrl (null here) so
+    // the IPC handler does not route the openrouter key to duckcoding.
+    const cfg: Config = {
+      ...baseCfg,
+      baseUrls: {
+        openai: { baseUrl: 'https://api.duckcoding.ai/v1' },
+        openrouter: { baseUrl: 'https://openrouter.ai/api/v1' },
+      },
+    };
+    const result = resolveActiveModel(cfg, { provider: 'openai', modelId: 'gpt-4o' });
+
+    expect(result.overridden).toBe(true);
+    expect(result.model.provider).toBe('openrouter');
+    expect(result.baseUrl).toBe('https://openrouter.ai/api/v1');
+  });
+
   it('throws PROVIDER_KEY_MISSING when the active provider has no stored secret', () => {
     const cfg: Config = {
       ...baseCfg,

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -229,6 +229,20 @@ describe('resolveActiveModel', () => {
     expect(result.baseUrl).toBe('https://openrouter.ai/api/v1');
   });
 
+  it('returns canonical openrouter baseUrl when stale hint says openai+duckcoding', () => {
+    // Codex Major scenario: renderer payload claims openai with a duckcoding
+    // baseUrl, but the canonical active provider in cached config is
+    // openrouter. The resolver must surface openrouter's baseUrl (here null —
+    // openrouter has no override) so the IPC handler does not forward the
+    // stale duckcoding endpoint.
+    const result = resolveActiveModel(baseCfg, { provider: 'openai', modelId: 'gpt-4o' });
+
+    expect(result.overridden).toBe(true);
+    expect(result.model.provider).toBe('openrouter');
+    expect(result.baseUrl).toBeNull();
+    expect(result.baseUrl).not.toBe('https://api.duckcoding.ai/v1');
+  });
+
   it('throws PROVIDER_KEY_MISSING when the active provider has no stored secret', () => {
     const cfg: Config = {
       ...baseCfg,

--- a/apps/desktop/src/main/provider-settings.ts
+++ b/apps/desktop/src/main/provider-settings.ts
@@ -1,6 +1,7 @@
 import {
   CodesignError,
   type Config,
+  type ModelRef,
   PROVIDER_SHORTLIST,
   type SupportedOnboardingProvider,
   isSupportedOnboardingProvider,
@@ -135,4 +136,53 @@ export function computeDeleteProviderResult(
   }
 
   return { nextActive, modelPrimary: cfg.modelPrimary, modelFast: cfg.modelFast };
+}
+
+/**
+ * Result of resolving which provider/model to call against, given the canonical
+ * cached config and the renderer's hint payload.
+ *
+ * Why this exists: the renderer keeps its own copy of `cfg.provider` /
+ * `cfg.modelPrimary` in the Zustand store and forwards them in
+ * `GeneratePayloadV1.model`. If that copy drifts (settings IPC succeeds in
+ * main but the store mutation is missed, or a second window is open), the
+ * generate handler would silently call a different provider than what the
+ * Settings UI shows as Active. We treat the renderer payload as a hint and
+ * always snap back to the canonical active provider in `cachedConfig`, which
+ * is the SAME source `toProviderRows` uses to render the Active badge.
+ */
+export interface ActiveModelResolution {
+  model: ModelRef;
+  baseUrl: string | null;
+  /** True when the renderer-supplied hint provider didn't match the canonical active. */
+  overridden: boolean;
+}
+
+export function resolveActiveModel(
+  cfg: Config,
+  hint: { provider: string; modelId: string },
+): ActiveModelResolution {
+  if (!isSupportedOnboardingProvider(cfg.provider)) {
+    throw new CodesignError(
+      `Active provider "${cfg.provider}" is not in the onboarding shortlist.`,
+      'PROVIDER_NOT_SUPPORTED',
+    );
+  }
+  if (cfg.secrets[cfg.provider] === undefined) {
+    throw new CodesignError(
+      `No API key stored for active provider "${cfg.provider}". Re-run onboarding to add one.`,
+      'PROVIDER_KEY_MISSING',
+    );
+  }
+  const overridden = cfg.provider !== hint.provider;
+  // When the hint's provider matches active, trust the modelId (lets the
+  // renderer pick between primary and fast). When it doesn't match, the
+  // hint's modelId likely belongs to the wrong provider's catalog, so snap
+  // to the active provider's primary model to keep the call coherent.
+  const modelId = overridden ? cfg.modelPrimary : hint.modelId;
+  return {
+    model: { provider: cfg.provider, modelId },
+    baseUrl: cfg.baseUrls?.[cfg.provider]?.baseUrl ?? null,
+    overridden,
+  };
 }


### PR DESCRIPTION
## Summary

- The renderer kept its own copy of `cfg.provider` / `cfg.modelPrimary` in the Zustand store and forwarded them in `GeneratePayloadV1.model`. When that store drifted from `cachedConfig` (e.g. between Settings tabs, multiple windows, or any path that mutated cfg without firing `setConfig`), the generate handler silently called a different provider than the Active badge displayed.
- User-visible bug: Settings showed OpenRouter Active, but dev log showed `provider: openai, baseUrl: https://api.duckcoding.ai/v1` (a leftover per-provider baseUrl entry resolved against the stale renderer hint).
- New `resolveActiveModel(cfg, hint)` in `provider-settings.ts` is the single resolver: it snaps the renderer hint back to `cachedConfig.provider` (the SAME source `toProviderRows` uses for the Active badge), preserves the hint's `modelId` when the providers match (so the renderer can still pick fast vs primary), and otherwise snaps the modelId to `cfg.modelPrimary`. baseUrl is sourced exclusively from the active provider's cached `baseUrls` entry.
- Wired into `codesign:v1:generate`, the legacy `codesign:generate` shim, and `codesign:apply-comment`. Mismatches log `step=resolve_active.override` so the dev timeline shows when a snap happened.

## Root cause / disconnect

Two implicit sources of truth:

1. UI Active badge → `runListProviders()` → `toProviderRows(cachedConfig)` (canonical).
2. Generate IPC credentials/baseUrl → looked up via `payload.model.provider` from the renderer (could be stale).

Whenever the renderer's store fell behind a Settings mutation, source (2) diverged from (1). The fix collapses both onto `cachedConfig` via `resolveActiveModel`.

## Test plan

- [x] `pnpm --filter @open-codesign/desktop test` — 142 tests pass, including 4 new `resolveActiveModel` cases (matching hint, stale-hint snap, baseUrl threading, missing-secret guard).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (only pre-existing warnings).
- [ ] Manual repro: add openai (with custom baseUrl) + openrouter, switch Active to openrouter, send a prompt — dev log now shows `provider: openrouter, baseUrl: <default>` and never the stale openai/duckcoding combo.

## PRINCIPLES §5b

- Compatibility: green — no schema changes, no IPC contract changes, payload still accepts `model` as-is.
- Upgradeability: green — single resolver makes a future "renderer-doesn't-send-model" cleanup trivial.
- No bloat: green — net +50 lines in main, +69 in tests, no new deps.
- Elegance: green — collapses two sources of truth onto one canonical getter.