### PR TITLE
fix(desktop): localize Toast dismiss aria-label

### DIFF
--- a/apps/desktop/src/renderer/src/components/Toast.tsx
+++ b/apps/desktop/src/renderer/src/components/Toast.tsx
@@ -1,3 +1,4 @@
+import { useT } from '@open-codesign/i18n';
 import { CheckCircle2, Info, X, XCircle } from 'lucide-react';
 import { useEffect } from 'react';
 import { useCodesignStore } from '../store';
@@ -41,6 +42,7 @@ export function scheduleAutoDismiss(
 
 function ToastItem({ toast }: { toast: ToastModel }) {
   const dismiss = useCodesignStore((s) => s.dismissToast);
+  const t = useT();
   const Icon = iconFor[toast.variant];
   const isError = toast.variant === 'error';
   const autoMs = AUTO_DISMISS_MS[toast.variant];
@@ -71,7 +73,7 @@ function ToastItem({ toast }: { toast: ToastModel }) {
       </div>
       <button
         type="button"
-        aria-label="Dismiss notification"
+        aria-label={t('common.dismissNotification')}
         onClick={() => {
           dismiss(toast.id);
         }}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -6,6 +6,7 @@
     "retry": "Retry",
     "save": "Save",
     "close": "Close",
+    "dismissNotification": "Dismiss notification",
     "settings": "Settings",
     "advanced": "Advanced",
     "about": "About",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -6,6 +6,7 @@
     "retry": "重试",
     "save": "保存",
     "close": "关闭",
+    "dismissNotification": "关闭通知",
     "settings": "设置",
     "advanced": "高级",
     "about": "关于",


### PR DESCRIPTION
## Summary
- Toast close button shipped a hardcoded `aria-label=\"Dismiss notification\"`, which Codex flagged as the recurring i18n-bypass pattern on PRs #48 and #49 (stepper aria).
- Adds `common.dismissNotification` to en + zh-CN and pipes it through `useT()` in `Toast.tsx`.

## Test plan
- [ ] `pnpm test --filter @open-codesign/desktop` (no logic changed; smoke only)
- [ ] Manual: switch to Chinese, trigger any toast, screen reader announces 关闭通知

## PRINCIPLES
- Compatibility ✅ (token-only, no API change)
- Upgradeability ✅ (new locale key only)
- No bloat ✅ (3 lines added)
- Elegance ✅ (matches existing `aria-label={t(...)}` pattern in 11 other components)