### PR TITLE
fix(desktop): replace hardcoded text-[Npx] with --text-* tokens (preview + inline-comment)

### DIFF
--- a/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
@@ -31,12 +31,12 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
     <div className="absolute bottom-10 right-10 z-10 w-[min(420px,calc(100%-3rem))] overflow-hidden rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)]">
       <div className="flex items-start justify-between gap-3 border-b border-[var(--color-border-muted)] px-4 py-3">
         <div className="min-w-0">
-          <div className="inline-flex items-center gap-2 text-[12px] font-medium text-[var(--color-text-primary)]">
+          <div className="inline-flex items-center gap-2 text-[var(--text-xs)] font-medium text-[var(--color-text-primary)]">
             <MessageSquareText className="h-4 w-4 text-[var(--color-accent)]" />
-            {t('inlineComment.title')} <code className="text-[11px]">{selectedElement.tag}</code>
+            {t('inlineComment.title')} <code className="text-[var(--text-xs)]">{selectedElement.tag}</code>
           </div>
           <p
-            className="mt-1 truncate text-[11px] text-[var(--color-text-muted)]"
+            className="mt-1 truncate text-[var(--text-xs)] text-[var(--color-text-muted)]"
             title={selectedElement.selector}
           >
             {selectedElement.selector}
@@ -53,7 +53,7 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
       </div>
 
       <div className="space-y-3 p-4">
-        <p className="text-[12px] leading-[1.5] text-[var(--color-text-secondary)]">
+        <p className="text-[var(--text-xs)] leading-[1.5] text-[var(--color-text-secondary)]">
           {t('inlineComment.description')}
         </p>
         <textarea
@@ -62,13 +62,13 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
           placeholder={t('inlineComment.placeholder')}
           rows={4}
           disabled={isGenerating}
-          className="w-full resize-none rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[13px] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] transition-[box-shadow,border-color] duration-150 focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] focus:outline-none"
+          className="w-full resize-none rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-2 text-[var(--text-sm)] leading-[1.5] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] transition-[box-shadow,border-color] duration-150 focus:border-[var(--color-accent)] focus:shadow-[0_0_0_3px_var(--color-focus-ring)] focus:outline-none"
         />
         <div className="flex items-center justify-between gap-3">
           <button
             type="button"
             onClick={clearCanvasElement}
-            className="text-[12px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+            className="text-[var(--text-xs)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
           >
             {t('common.cancel')}
           </button>
@@ -80,7 +80,7 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
               type="button"
               disabled={!draft.trim() || isGenerating}
               onClick={() => void applyInlineComment(draft)}
-              className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent)] px-3 py-2 text-[12px] font-medium text-white shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:pointer-events-none disabled:opacity-40"
+              className="inline-flex items-center justify-center rounded-[var(--radius-md)] bg-[var(--color-accent)] px-3 py-2 text-[var(--text-xs)] font-medium text-white shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-accent-hover)] disabled:pointer-events-none disabled:opacity-40"
             >
               {isGenerating ? t('inlineComment.applying') : t('inlineComment.applyChange')}
             </button>

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -88,7 +88,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     body = (
       <div className="h-full p-6">
         <div className="relative h-full">
-          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[11px] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
+          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
             {t('preview.clickToComment')}
           </div>
           <iframe

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -67,7 +67,7 @@ export function PreviewToolbar(): ReactElement {
   return (
     <div className="flex items-center justify-end gap-2 px-6 py-2 border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)]">
       {toastMessage && (
-        <output className="mr-auto text-[12px] text-[var(--color-text-secondary)] truncate max-w-[60%]">
+        <output className="mr-auto text-[var(--text-xs)] text-[var(--color-text-secondary)] truncate max-w-[60%]">
           {toastMessage}
         </output>
       )}
@@ -78,7 +78,7 @@ export function PreviewToolbar(): ReactElement {
             type="button"
             disabled={disabled}
             onClick={() => setOpen((v) => !v)}
-            className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-[var(--radius-md)] text-[13px] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]"
             aria-haspopup="menu"
             aria-expanded={open}
           >
@@ -103,11 +103,11 @@ export function PreviewToolbar(): ReactElement {
                   setOpen(false);
                   void exportActive(item.format);
                 }}
-                className="w-full flex items-center justify-between gap-3 px-3 py-2 text-[13px] text-left text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent disabled:cursor-not-allowed transition-colors duration-100"
+                className="w-full flex items-center justify-between gap-3 px-3 py-2 text-[var(--text-sm)] text-left text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:hover:bg-transparent disabled:cursor-not-allowed transition-colors duration-100"
               >
                 <span>{item.label}</span>
                 {item.hint && (
-                  <span className="text-[11px] text-[var(--color-text-muted)] truncate max-w-[60%]">
+                  <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] truncate max-w-[60%]">
                     {item.hint}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- Codex marked hardcoded `text-[Npx]` a Blocker on PRs #50 and #51. Sweeps the chat-adjacent surface that no in-flight worktree covers (`InlineCommentComposer`, `PreviewToolbar`, `PreviewPane`).
- Mappings: `text-[11px]` -> `text-[var(--text-xs)]` (12px, closest token), `text-[12px]` -> `text-[var(--text-xs)]`, `text-[13px]` -> `text-[var(--text-sm)]`.
- Out of scope (follow-up): `bg-[rgba(255,255,255,0.88)]` frosted pill in PreviewPane needs a new translucent surface token.

## Test plan
- [ ] `pnpm lint` clean
- [ ] Visual: comment composer + preview toolbar look identical at 100% zoom
- [ ] `pnpm typecheck`

## PRINCIPLES
- Compatibility ✅ (1px shift on a few labels — visually negligible)
- Upgradeability ✅ (now scales with token system)
- No bloat ✅ (no new tokens introduced)
- Elegance ✅ (matches Toast.tsx and Settings.tsx)