### PR TITLE
fix(desktop): tokenize ConnectionStatusDot tooltip values

### DIFF
--- a/apps/desktop/src/renderer/src/components/ConnectionStatusDot.tsx
+++ b/apps/desktop/src/renderer/src/components/ConnectionStatusDot.tsx
@@ -83,7 +83,7 @@ export function ConnectionStatusDot() {
       </button>
       <span
         role="tooltip"
-        className="pointer-events-none absolute bottom-full mb-1.5 left-1/2 -translate-x-1/2 z-50 whitespace-nowrap max-w-xs rounded-[var(--radius-sm)] bg-[var(--color-text-primary)] px-2 py-1 text-[11px] font-medium text-[var(--color-background)] opacity-0 transition-opacity duration-150 delay-[400ms] group-hover:opacity-100 shadow-[var(--shadow-card)]"
+        className="pointer-events-none absolute bottom-full mb-[var(--space-1_5)] left-1/2 -translate-x-1/2 z-50 whitespace-nowrap max-w-xs rounded-[var(--radius-sm)] bg-[var(--color-text-primary)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--text-2xs)] font-medium text-[var(--color-background)] opacity-0 transition-opacity duration-[var(--duration-faster)] delay-[400ms] group-hover:opacity-100 shadow-[var(--shadow-card)]"
       >
         {buildTooltip()}
       </span>

--- a/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
@@ -33,7 +33,8 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
         <div className="min-w-0">
           <div className="inline-flex items-center gap-2 text-[var(--text-xs)] font-medium text-[var(--color-text-primary)]">
             <MessageSquareText className="h-4 w-4 text-[var(--color-accent)]" />
-            {t('inlineComment.title')} <code className="text-[var(--text-xs)]">{selectedElement.tag}</code>
+            {t('inlineComment.title')}{' '}
+            <code className="text-[var(--text-xs)]">{selectedElement.tag}</code>
           </div>
           <p
             className="mt-1 truncate text-[var(--text-xs)] text-[var(--color-text-muted)]"


### PR DESCRIPTION
Tooltip className had hardcoded mb-1.5 / px-2 py-1 / text-[11px] / duration-150 in ConnectionStatusDot.tsx, bypassing the --space-/--text-/--duration- token system. Replaces them with token vars per the codex-flagged hardcoded-value pattern (PRs #32, #50, #57).

Also includes a one-line biome auto-format on InlineCommentComposer.tsx (pre-existing format issue on main blocking pre-push hook).