### PR TITLE
fix(desktop): tokenize LanguageToggle hardcoded sizes/spacing

### DIFF
--- a/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
+++ b/apps/desktop/src/renderer/src/components/InlineCommentComposer.tsx
@@ -33,7 +33,8 @@ function InlineCommentComposerCard({ selectedElement }: InlineCommentComposerCar
         <div className="min-w-0">
           <div className="inline-flex items-center gap-2 text-[var(--text-xs)] font-medium text-[var(--color-text-primary)]">
             <MessageSquareText className="h-4 w-4 text-[var(--color-accent)]" />
-            {t('inlineComment.title')} <code className="text-[var(--text-xs)]">{selectedElement.tag}</code>
+            {t('inlineComment.title')}{' '}
+            <code className="text-[var(--text-xs)]">{selectedElement.tag}</code>
           </div>
           <p
             className="mt-1 truncate text-[var(--text-xs)] text-[var(--color-text-muted)]"

--- a/apps/desktop/src/renderer/src/components/LanguageToggle.tsx
+++ b/apps/desktop/src/renderer/src/components/LanguageToggle.tsx
@@ -34,11 +34,11 @@ export function LanguageToggle() {
       type="button"
       onClick={() => void handleToggle()}
       style={noDragStyle}
-      className="inline-flex items-center gap-2 h-8 px-3 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[12px] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+      className="inline-flex items-center gap-[var(--space-2)] h-[var(--size-control-sm)] px-[var(--space-3)] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
       aria-label={t('settings.language.label')}
       title={t('settings.language.label')}
     >
-      <Globe className="w-3.5 h-3.5 text-[var(--color-text-secondary)]" />
+      <Globe className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)] text-[var(--color-text-secondary)]" />
       <span>{localeLabel(locale)}</span>
     </button>
   );


### PR DESCRIPTION
Replaces hardcoded `gap-2` / `h-8` / `px-3` / `text-[12px]` / `w-3.5` in LanguageToggle.tsx with `--space-*` / `--size-*` / `--text-*` tokens per project UI-token hard constraint. Continues codex-flagged pattern (PRs #32, #50, #51, #57).

Drive-by: biome format on InlineCommentComposer.tsx to unblock pre-push hook (pre-existing format drift from #57).