### PR TITLE
fix(desktop): drop unused fileURLToPath import in main entry

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,5 @@
 import { stat } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { type CoreLogger, applyComment, generate } from '@open-codesign/core';
 import { detectProviderFromKey } from '@open-codesign/providers';
 import {


### PR DESCRIPTION
Removes the unused `fileURLToPath` import from `apps/desktop/src/main/index.ts`, eliminating the dev build warning:

> "fileURLToPath" is imported from external module "node:url" but never used