### PR TITLE
fix(desktop): tokenize raw utilities in preview Loading/Error states

### DIFF
--- a/apps/desktop/src/renderer/src/preview/ErrorState.tsx
+++ b/apps/desktop/src/renderer/src/preview/ErrorState.tsx
@@ -20,9 +20,9 @@ export function ErrorState({ message, onRetry, onDismiss }: ErrorStateProps) {
   }
 
   return (
-    <div className="h-full flex items-center justify-center p-6">
-      <div className="max-w-lg w-full rounded-[var(--radius-2xl)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-card)] p-6">
-        <div className="flex items-start gap-3 mb-4">
+    <div className="h-full flex items-center justify-center p-[var(--space-6)]">
+      <div className="max-w-lg w-full rounded-[var(--radius-2xl)] bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-card)] p-[var(--space-6)]">
+        <div className="flex items-start gap-[var(--space-3)] mb-[var(--space-4)]">
           <div className="w-10 h-10 rounded-[var(--radius-full)] bg-[var(--color-accent-muted)] flex items-center justify-center shrink-0">
             <AlertTriangle className="w-5 h-5" style={{ color: 'var(--color-error)' }} />
           </div>
@@ -30,15 +30,15 @@ export function ErrorState({ message, onRetry, onDismiss }: ErrorStateProps) {
             <h3 className="text-[var(--text-base)] font-semibold text-[var(--color-text-primary)]">
               {t('preview.error.title')}
             </h3>
-            <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] mt-1">
+            <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] mt-[var(--space-1)]">
               {t('preview.error.body')}
             </p>
           </div>
         </div>
-        <pre className="text-[var(--text-xs)] text-[var(--color-text-secondary)] bg-[var(--color-surface-muted)] border border-[var(--color-border)] rounded-[var(--radius-md)] p-3 mb-4 whitespace-pre-wrap break-words font-[var(--font-mono)]">
+        <pre className="text-[var(--text-xs)] text-[var(--color-text-secondary)] bg-[var(--color-surface-muted)] border border-[var(--color-border)] rounded-[var(--radius-md)] p-[var(--space-3)] mb-[var(--space-4)] whitespace-pre-wrap break-words font-[var(--font-mono)]">
           {message}
         </pre>
-        <div className="flex items-center gap-2 justify-end">
+        <div className="flex items-center gap-[var(--space-2)] justify-end">
           {onDismiss ? (
             <Button variant="ghost" size="sm" onClick={onDismiss}>
               {t('common.close')}

--- a/apps/desktop/src/renderer/src/preview/LoadingState.tsx
+++ b/apps/desktop/src/renderer/src/preview/LoadingState.tsx
@@ -74,26 +74,26 @@ export function LoadingState({ stage: stageProp, tokenCount: tokenProp }: Loadin
   const progress = STAGE_PROGRESS[stage];
 
   return (
-    <div className="h-full p-6">
+    <div className="h-full p-[var(--space-6)]">
       <div className="h-full w-full rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden flex flex-col">
         {/* Skeleton header */}
-        <div className="px-6 py-5 border-b border-[var(--color-border-subtle)] space-y-3">
+        <div className="px-[var(--space-6)] py-[var(--space-5)] border-b border-[var(--color-border-subtle)] space-y-3">
           <div className="shimmer h-4 w-40 rounded-[var(--radius-sm)]" />
           <div className="shimmer h-3 w-64 rounded-[var(--radius-sm)]" />
         </div>
         {/* Skeleton body */}
-        <div className="flex-1 grid grid-cols-3 gap-4 p-6">
+        <div className="flex-1 grid grid-cols-3 gap-[var(--space-4)] p-[var(--space-6)]">
           <div className="shimmer rounded-[var(--radius-lg)]" />
           <div className="shimmer rounded-[var(--radius-lg)]" />
           <div className="shimmer rounded-[var(--radius-lg)]" />
         </div>
         {/* Stage feedback bar */}
-        <div className="px-6 py-4 border-t border-[var(--color-border-subtle)] flex flex-col gap-2">
-          <div className="loading-stages flex items-center gap-2 text-[var(--color-text-secondary)] text-sm">
+        <div className="px-[var(--space-6)] py-[var(--space-4)] border-t border-[var(--color-border-subtle)] flex flex-col gap-[var(--space-2)]">
+          <div className="loading-stages flex items-center gap-[var(--space-2)] text-[var(--color-text-secondary)] text-[var(--text-sm)]">
             <StageIcon stage={activeStage} />
             <span className="stage-label">{t(`loading.stage.${activeStage}`)}</span>
             {activeStage === 'streaming' && tokenCount > 0 && (
-              <span className="font-mono text-xs text-[var(--color-text-tertiary)]">
+              <span className="font-mono text-[var(--text-xs)] text-[var(--color-text-tertiary)]">
                 {t('loading.tokens', { count: tokenCount })}
               </span>
             )}

--- a/apps/desktop/src/renderer/src/preview/LoadingState.tsx
+++ b/apps/desktop/src/renderer/src/preview/LoadingState.tsx
@@ -77,7 +77,7 @@ export function LoadingState({ stage: stageProp, tokenCount: tokenProp }: Loadin
     <div className="h-full p-[var(--space-6)]">
       <div className="h-full w-full rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden flex flex-col">
         {/* Skeleton header */}
-        <div className="px-[var(--space-6)] py-[var(--space-5)] border-b border-[var(--color-border-subtle)] space-y-3">
+        <div className="px-[var(--space-6)] py-[var(--space-5)] border-b border-[var(--color-border-subtle)] space-y-[var(--space-3)]">
           <div className="shimmer h-4 w-40 rounded-[var(--radius-sm)]" />
           <div className="shimmer h-3 w-64 rounded-[var(--radius-sm)]" />
         </div>


### PR DESCRIPTION
## Summary

Replaces remaining raw Tailwind numeric utilities in the two preview state components with the `var(--…)` design tokens defined in `packages/ui/src/tokens.css`. Same pattern as #62 (PreviewToolbar tokenization).

### LoadingState.tsx
- `p-6`, `px-6`, `py-5`, `py-4` → `p-[var(--space-6)]` / `px-[var(--space-6)]` / `py-[var(--space-5)]` / `py-[var(--space-4)]`
- `gap-4`, `gap-2` → `gap-[var(--space-4)]` / `gap-[var(--space-2)]`
- `text-sm`, `text-xs` → `text-[var(--text-sm)]` / `text-[var(--text-xs)]`

### ErrorState.tsx
- `p-6`, `p-3` → `p-[var(--space-6)]` / `p-[var(--space-3)]`
- `mb-4`, `mt-1` → `mb-[var(--space-4)]` / `mt-[var(--space-1)]`
- `gap-3`, `gap-2` → `gap-[var(--space-3)]` / `gap-[var(--space-2)]`
- `max-w-lg` left as-is — no `--size-*` token covers `max-width` sizes.

Skeleton dimensions (`h-4 w-40` etc.) and icon `w-4 h-4` left untouched — out of scope for this pass; PR #62 set the precedent of doing icon sizing as a separate, surgical change.

## PRINCIPLES check
- ✅ Compatibility — purely visual, no API change.
- ✅ Upgradeability — values now flow from `tokens.css`; theme/scale changes propagate automatically.
- ✅ No bloat — no new deps, no abstractions; mechanical swap.
- ✅ Elegance — removes the inconsistency where these two components diverged from `EmptyState.tsx`/`PreviewToolbar` after #57/#62.

## Test plan
- [ ] Visual diff on the Loading and Error preview states (light + dark) — spacing/typography unchanged.
- [ ] `pnpm --filter @open-codesign/desktop typecheck` clean (worktree had no node_modules; verified locally that no new diagnostics introduced beyond pre-existing missing-deps noise).