### PR TITLE
feat(exporters): Markdown export of generated artifact

### DIFF
--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -8,6 +8,7 @@ const FORMAT_FILTERS: Record<ExporterFormat, Electron.FileFilter[]> = {
   pdf: [{ name: 'PDF', extensions: ['pdf'] }],
   pptx: [{ name: 'PowerPoint', extensions: ['pptx'] }],
   zip: [{ name: 'ZIP archive', extensions: ['zip'] }],
+  markdown: [{ name: 'Markdown', extensions: ['md'] }],
 };
 
 export interface ExportRequest {
@@ -30,7 +31,13 @@ export function parseRequest(raw: unknown): ExportRequest {
   const format = r['format'];
   const html = r['htmlContent'];
   const defaultFilename = r['defaultFilename'];
-  if (format !== 'html' && format !== 'pdf' && format !== 'pptx' && format !== 'zip') {
+  if (
+    format !== 'html' &&
+    format !== 'pdf' &&
+    format !== 'pptx' &&
+    format !== 'zip' &&
+    format !== 'markdown'
+  ) {
     throw new CodesignError(`Unknown export format: ${String(format)}`, 'EXPORTER_UNKNOWN');
   }
   if (typeof html !== 'string' || html.length === 0) {

--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -54,9 +54,10 @@ export function registerExporterIpc(getWindow: () => BrowserWindow | null): void
   ipcMain.handle('codesign:export', async (_evt, raw: unknown): Promise<ExportResponse> => {
     const req = parseRequest(raw);
     const win = getWindow();
+    const defaultExt = req.format === 'markdown' ? 'md' : req.format;
     const opts: Electron.SaveDialogOptions = {
       title: `Export design as ${req.format.toUpperCase()}`,
-      defaultPath: req.defaultFilename ?? `design.${req.format}`,
+      defaultPath: req.defaultFilename ?? `design.${defaultExt}`,
       filters: FORMAT_FILTERS[req.format],
     };
     const picked = win ? await dialog.showSaveDialog(win, opts) : await dialog.showSaveDialog(opts);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -30,7 +30,7 @@ export interface ValidateKeyError {
   message: string;
 }
 
-export type ExportFormat = 'html' | 'pdf' | 'pptx' | 'zip';
+export type ExportFormat = 'html' | 'pdf' | 'pptx' | 'zip' | 'markdown';
 export interface ExportInvokeResponse {
   status: 'saved' | 'cancelled';
   path?: string;

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -62,6 +62,12 @@ export function PreviewToolbar(): ReactElement {
       ready: true,
       hint: t('export.items.zip.hint'),
     },
+    {
+      format: 'markdown',
+      label: t('export.items.markdown.label'),
+      ready: true,
+      hint: t('export.items.markdown.hint'),
+    },
   ];
 
   return (

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -575,10 +575,11 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     }
     try {
       const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      const ext = format === 'markdown' ? 'md' : format;
       const res = await window.codesign.export({
         format,
         htmlContent: html,
-        defaultFilename: `codesign-${stamp}.${format}`,
+        defaultFilename: `codesign-${stamp}.${ext}`,
       });
       if (res.status === 'saved' && res.path) {
         set({ toastMessage: tr('notifications.exportedTo', { path: res.path }) });

--- a/packages/exporters/package.json
+++ b/packages/exporters/package.json
@@ -10,7 +10,8 @@
     "./html": "./src/html.ts",
     "./pdf": "./src/pdf.ts",
     "./pptx": "./src/pptx.ts",
-    "./zip": "./src/zip.ts"
+    "./zip": "./src/zip.ts",
+    "./markdown": "./src/markdown.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/exporters/src/index.ts
+++ b/packages/exporters/src/index.ts
@@ -9,7 +9,7 @@
 
 import { CodesignError } from '@open-codesign/shared';
 
-export const EXPORTER_FORMATS = ['html', 'pdf', 'pptx', 'zip'] as const;
+export const EXPORTER_FORMATS = ['html', 'pdf', 'pptx', 'zip', 'markdown'] as const;
 export type ExporterFormat = (typeof EXPORTER_FORMATS)[number];
 
 export interface ExportOptions {
@@ -30,6 +30,8 @@ export type { ExportHtmlOptions } from './html';
 export type { ExportPdfOptions } from './pdf';
 export type { ExportPptxOptions } from './pptx';
 export type { ExportZipOptions, ZipAsset } from './zip';
+export type { ExportMarkdownOptions, MarkdownMeta } from './markdown';
+export { htmlToMarkdown } from './markdown';
 
 export async function exportHtml(
   htmlContent: string,
@@ -59,6 +61,10 @@ export async function exportArtifact(
   if (format === 'zip') {
     const mod = await import('./zip');
     return mod.exportZip(htmlContent, destinationPath);
+  }
+  if (format === 'markdown') {
+    const mod = await import('./markdown');
+    return mod.exportMarkdown(htmlContent, destinationPath);
   }
   throw new CodesignError(`Unknown exporter format: ${format as string}`, 'EXPORTER_UNKNOWN');
 }

--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { htmlToMarkdown } from './markdown';
+
+const META = { title: 'Demo', schemaVersion: 1 as const };
+
+describe('htmlToMarkdown', () => {
+  it('writes a YAML frontmatter with title and schemaVersion', () => {
+    const out = htmlToMarkdown('<p>hi</p>', META);
+    expect(out.startsWith('---\ntitle: Demo\nschemaVersion: 1\n---\n')).toBe(true);
+    expect(out).toContain('hi');
+  });
+
+  it('converts headings h1..h6', () => {
+    const html = '<h1>One</h1><h2>Two</h2><h3>Three</h3><h6>Six</h6>';
+    const out = htmlToMarkdown(html, META);
+    expect(out).toContain('# One');
+    expect(out).toContain('## Two');
+    expect(out).toContain('### Three');
+    expect(out).toContain('###### Six');
+  });
+
+  it('converts paragraphs to blank-line wrapped text', () => {
+    const out = htmlToMarkdown('<p>First</p><p>Second</p>', META);
+    expect(out).toMatch(/First\n\nSecond/);
+  });
+
+  it('converts links and images', () => {
+    const out = htmlToMarkdown(
+      '<a href="https://example.com">site</a><img src="/a.png" alt="logo" />',
+      META,
+    );
+    expect(out).toContain('[site](https://example.com)');
+    expect(out).toContain('![logo](/a.png)');
+  });
+
+  it('converts unordered and ordered lists', () => {
+    const ul = htmlToMarkdown('<ul><li>a</li><li>b</li></ul>', META);
+    expect(ul).toContain('- a');
+    expect(ul).toContain('- b');
+    const ol = htmlToMarkdown('<ol><li>x</li><li>y</li></ol>', META);
+    expect(ol).toContain('1. x');
+    expect(ol).toContain('2. y');
+  });
+
+  it('converts strong/em/code/pre', () => {
+    const out = htmlToMarkdown(
+      '<p><strong>bold</strong> and <em>italic</em> with <code>x</code></p><pre>line1\nline2</pre>',
+      META,
+    );
+    expect(out).toContain('**bold**');
+    expect(out).toContain('*italic*');
+    expect(out).toContain('`x`');
+    expect(out).toContain('```\nline1\nline2\n```');
+  });
+
+  it('strips script/style/head and unknown tags', () => {
+    const out = htmlToMarkdown(
+      '<head><title>x</title></head><script>evil()</script><style>.a{}</style><div><p>kept</p></div>',
+      META,
+    );
+    expect(out).not.toContain('evil');
+    expect(out).not.toContain('.a{}');
+    expect(out).toContain('kept');
+  });
+
+  it('decodes entities', () => {
+    const out = htmlToMarkdown('<p>A &amp; B &lt; C</p>', META);
+    expect(out).toContain('A & B < C');
+  });
+
+  it('handles empty input gracefully', () => {
+    const out = htmlToMarkdown('', META);
+    expect(out).toContain('schemaVersion: 1');
+  });
+
+  it('handles malformed HTML without throwing', () => {
+    const out = htmlToMarkdown('<p>open<strong>bold<p>next', META);
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -78,4 +78,49 @@ describe('htmlToMarkdown', () => {
     expect(typeof out).toBe('string');
     expect(out.length).toBeGreaterThan(0);
   });
+
+  it('strips javascript: links but keeps the visible text', () => {
+    const out = htmlToMarkdown('<p><a href="javascript:alert(1)">x</a></p>', META);
+    expect(out).toContain('x');
+    expect(out).not.toContain('javascript:');
+    expect(out).not.toContain('](');
+  });
+
+  it('keeps https links untouched', () => {
+    const out = htmlToMarkdown('<a href="https://x.test">x</a>', META);
+    expect(out).toContain('[x](https://x.test)');
+  });
+
+  it('allows mailto and relative link schemes', () => {
+    const out = htmlToMarkdown(
+      '<a href="mailto:a@b.test">mail</a><a href="/foo">rel</a><a href="#anchor">anc</a>',
+      META,
+    );
+    expect(out).toContain('[mail](mailto:a@b.test)');
+    expect(out).toContain('[rel](/foo)');
+    expect(out).toContain('[anc](#anchor)');
+  });
+
+  it('keeps inline data:image/* sources', () => {
+    const src = 'data:image/png;base64,iVBORw0KGgo=';
+    const out = htmlToMarkdown(`<img src="${src}" alt="px" />`, META);
+    expect(out).toContain(`![px](${src})`);
+  });
+
+  it('strips non-image data: URLs from images', () => {
+    const out = htmlToMarkdown('<img src="data:text/html,<script>x</script>" alt="bad" />', META);
+    expect(out).not.toContain('data:text/html');
+    expect(out).not.toContain('![bad]');
+  });
+
+  it('strips other dangerous schemes (vbscript:, file:)', () => {
+    const out = htmlToMarkdown(
+      '<a href="vbscript:msgbox">v</a><a href="file:///etc/passwd">f</a>',
+      META,
+    );
+    expect(out).not.toContain('vbscript:');
+    expect(out).not.toContain('file:');
+    expect(out).toContain('v');
+    expect(out).toContain('f');
+  });
 });

--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -175,4 +175,15 @@ describe('sanitizeUrl encoded-scheme bypass guard', () => {
     expect(out).not.toContain('javascript:');
     expect(out).not.toContain('](');
   });
+
+  it('keeps URLs containing percent-encoded path/query characters as-is', () => {
+    expect(sanitizeUrl('https://example.com/path?q=%2F', 'link')).toBe(
+      'https://example.com/path?q=%2F',
+    );
+    expect(sanitizeUrl('https://example.com/p%C3%A9', 'link')).toBe('https://example.com/p%C3%A9');
+  });
+
+  it('keeps URLs with stray literal % that would break decodeURIComponent', () => {
+    expect(sanitizeUrl('https://x.test/?q=100%', 'link')).toBe('https://x.test/?q=100%');
+  });
 });

--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { htmlToMarkdown } from './markdown';
+import { htmlToMarkdown, sanitizeUrl } from './markdown';
 
 const META = { title: 'Demo', schemaVersion: 1 as const };
 
@@ -122,5 +122,57 @@ describe('htmlToMarkdown', () => {
     expect(out).not.toContain('file:');
     expect(out).toContain('v');
     expect(out).toContain('f');
+  });
+});
+
+describe('sanitizeUrl encoded-scheme bypass guard', () => {
+  it('rejects HTML hex-entity encoded javascript scheme', () => {
+    expect(sanitizeUrl('&#x6A;avascript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects HTML decimal-entity encoded javascript scheme', () => {
+    expect(sanitizeUrl('&#106;avascript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects entity-encoded colon javascript scheme', () => {
+    expect(sanitizeUrl('javascript&#58;alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects URL percent-encoded javascript scheme', () => {
+    expect(sanitizeUrl('%6Aavascript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects javascript scheme with leading whitespace', () => {
+    expect(sanitizeUrl(' javascript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects javascript scheme with leading tab', () => {
+    expect(sanitizeUrl('\tjavascript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects javascript scheme with embedded tab/newline before colon', () => {
+    expect(sanitizeUrl('java\tscript:alert(1)', 'link')).toBeNull();
+    expect(sanitizeUrl('java\nscript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('rejects mixed-case javascript scheme', () => {
+    expect(sanitizeUrl('JavaScript:alert(1)', 'link')).toBeNull();
+  });
+
+  it('still permits safe http/mailto/relative URLs after decoding', () => {
+    expect(sanitizeUrl('https://x.test', 'link')).toBe('https://x.test');
+    expect(sanitizeUrl('mailto:a@b.test', 'link')).toBe('mailto:a@b.test');
+    expect(sanitizeUrl('/foo/bar', 'link')).toBe('/foo/bar');
+    expect(sanitizeUrl('#anchor', 'link')).toBe('#anchor');
+  });
+
+  it('strips entity-encoded javascript when used inside markdown link conversion', () => {
+    const out = htmlToMarkdown('<p><a href="&#x6A;avascript:alert(1)">x</a></p>', {
+      title: 'Demo',
+      schemaVersion: 1,
+    });
+    expect(out).toContain('x');
+    expect(out).not.toContain('javascript:');
+    expect(out).not.toContain('](');
   });
 });

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -151,7 +151,18 @@ function stripTags(input: string): string {
  * drop the link wrapper. Inline `data:image/*` is permitted for images only.
  */
 export function sanitizeUrl(raw: string, kind: 'link' | 'image'): string | null {
-  const value = raw.trim();
+  let value = raw;
+  for (let i = 0; i < 3; i += 1) {
+    const next = decodeEntities(value);
+    if (next === value) break;
+    value = next;
+  }
+  try {
+    value = decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+  value = stripControlChars(value).trim();
   if (!value) return null;
   if (/^(https?:|mailto:)/i.test(value)) return value;
   if (kind === 'image' && /^data:image\/(png|jpe?g|gif|webp|svg\+xml|avif|bmp);/i.test(value)) {
@@ -163,10 +174,31 @@ export function sanitizeUrl(raw: string, kind: 'link' | 'image'): string | null 
 
 function decodeEntities(input: string): string {
   return input
+    .replace(/&#x([0-9a-f]+);/gi, (_m, hex: string) => safeFromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_m, dec: string) => safeFromCodePoint(Number.parseInt(dec, 10)))
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'");
+}
+
+function safeFromCodePoint(code: number): string {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return '';
+  try {
+    return String.fromCodePoint(code);
+  } catch {
+    return '';
+  }
+}
+
+function stripControlChars(input: string): string {
+  let out = '';
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) continue;
+    out += input[i];
+  }
+  return out;
 }

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -88,15 +88,18 @@ function convertBody(html: string): string {
   out = out.replace(
     /<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
     (_m, href: string, inner: string) => {
-      const text = decodeEntities(stripTags(inner)).trim() || href;
-      return `[${text}](${href})`;
+      const safeHref = sanitizeUrl(href, 'link');
+      const text = decodeEntities(stripTags(inner)).trim();
+      if (!safeHref) return text;
+      return `[${text || safeHref}](${safeHref})`;
     },
   );
 
   out = out.replace(/<img\b[^>]*>/gi, (tag) => {
     const src = /src=["']([^"']+)["']/i.exec(tag)?.[1] ?? '';
     const alt = /alt=["']([^"']*)["']/i.exec(tag)?.[1] ?? '';
-    return src ? `![${alt}](${src})` : '';
+    const safeSrc = sanitizeUrl(src, 'image');
+    return safeSrc ? `![${alt}](${safeSrc})` : '';
   });
 
   out = out.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, level: string, inner: string) => {
@@ -140,6 +143,22 @@ function renderList(inner: string, ordered: boolean): string {
 
 function stripTags(input: string): string {
   return input.replace(/<[^>]+>/g, '');
+}
+
+/**
+ * Allowlist URL schemes for exported Markdown. Anything outside the safe set
+ * (http/https/mailto, relative URLs, fragments) returns null so the caller can
+ * drop the link wrapper. Inline `data:image/*` is permitted for images only.
+ */
+export function sanitizeUrl(raw: string, kind: 'link' | 'image'): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  if (/^(https?:|mailto:)/i.test(value)) return value;
+  if (kind === 'image' && /^data:image\/(png|jpe?g|gif|webp|svg\+xml|avif|bmp);/i.test(value)) {
+    return value;
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return null;
+  return value;
 }
 
 function decodeEntities(input: string): string {

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -151,25 +151,34 @@ function stripTags(input: string): string {
  * drop the link wrapper. Inline `data:image/*` is permitted for images only.
  */
 export function sanitizeUrl(raw: string, kind: 'link' | 'image'): string | null {
-  let value = raw;
+  const output = stripControlChars(raw).trim();
+  if (!output) return null;
+
+  let probe = output;
   for (let i = 0; i < 3; i += 1) {
-    const next = decodeEntities(value);
-    if (next === value) break;
-    value = next;
+    const next = decodeEntities(probe);
+    if (next === probe) break;
+    probe = next;
   }
-  try {
-    value = decodeURIComponent(value);
-  } catch {
-    return null;
+  const colonIdx = probe.indexOf(':');
+  if (colonIdx > 0) {
+    const schemePart = probe.slice(0, colonIdx);
+    if (/%[0-9a-fA-F]{2}/.test(schemePart)) {
+      try {
+        probe = decodeURIComponent(schemePart) + probe.slice(colonIdx);
+      } catch {
+        // Leave probe untouched — the regex below will catch obviously unsafe forms.
+      }
+    }
   }
-  value = stripControlChars(value).trim();
-  if (!value) return null;
-  if (/^(https?:|mailto:)/i.test(value)) return value;
-  if (kind === 'image' && /^data:image\/(png|jpe?g|gif|webp|svg\+xml|avif|bmp);/i.test(value)) {
-    return value;
+  probe = stripControlChars(probe).trim();
+
+  if (/^(https?:|mailto:)/i.test(probe)) return output;
+  if (kind === 'image' && /^data:image\/(png|jpe?g|gif|webp|svg\+xml|avif|bmp);/i.test(probe)) {
+    return output;
   }
-  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return null;
-  return value;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(probe)) return null;
+  return output;
 }
 
 function decodeEntities(input: string): string {

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -1,0 +1,153 @@
+import type { ExportResult } from './index';
+
+export interface MarkdownMeta {
+  title?: string;
+  schemaVersion: 1;
+}
+
+export interface ExportMarkdownOptions {
+  meta?: Partial<MarkdownMeta>;
+}
+
+export async function exportMarkdown(
+  htmlContent: string,
+  destinationPath: string,
+  opts: ExportMarkdownOptions = {},
+): Promise<ExportResult> {
+  const fs = await import('node:fs/promises');
+  const md = htmlToMarkdown(htmlContent, {
+    title: opts.meta?.title ?? deriveTitle(htmlContent),
+    schemaVersion: 1,
+  });
+  await fs.writeFile(destinationPath, md, 'utf8');
+  const stat = await fs.stat(destinationPath);
+  return { bytes: stat.size, path: destinationPath };
+}
+
+/**
+ * Convert a small subset of HTML to Markdown using regex passes. We never aim
+ * for perfect parity — anything we cannot map cleanly is dropped. The output
+ * always begins with a YAML frontmatter block carrying the schemaVersion so
+ * older readers can refuse to parse a future bump.
+ */
+export function htmlToMarkdown(html: string, meta: MarkdownMeta): string {
+  const frontmatter = renderFrontmatter(meta);
+  const body = convertBody(html ?? '');
+  return `${frontmatter}\n${body}`
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()
+    .concat('\n');
+}
+
+function renderFrontmatter(meta: MarkdownMeta): string {
+  const lines = ['---'];
+  if (meta.title) lines.push(`title: ${escapeYaml(meta.title)}`);
+  lines.push(`schemaVersion: ${meta.schemaVersion}`);
+  lines.push('---');
+  return `${lines.join('\n')}\n`;
+}
+
+function escapeYaml(value: string): string {
+  if (/[:#"'\n]/.test(value)) return JSON.stringify(value);
+  return value;
+}
+
+function deriveTitle(html: string): string {
+  const t = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html ?? '');
+  if (t?.[1]) return decodeEntities(stripTags(t[1])).trim();
+  const h1 = /<h1[^>]*>([\s\S]*?)<\/h1>/i.exec(html ?? '');
+  if (h1?.[1]) return decodeEntities(stripTags(h1[1])).trim();
+  return 'open-codesign export';
+}
+
+function convertBody(html: string): string {
+  let out = html;
+  const headRe = /<head[\s>][\s\S]*?<\/head>/gi;
+  out = out.replace(headRe, '');
+  out = out.replace(/<script[\s\S]*?<\/script>/gi, '');
+  out = out.replace(/<style[\s\S]*?<\/style>/gi, '');
+  out = out.replace(/<!--[\s\S]*?-->/g, '');
+
+  out = out.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, (_m, inner: string) => {
+    const text = decodeEntities(stripTags(inner));
+    return `\n\n\`\`\`\n${text.trim()}\n\`\`\`\n\n`;
+  });
+  out = out.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, (_m, inner: string) => {
+    return `\`${decodeEntities(stripTags(inner)).trim()}\``;
+  });
+
+  out = out.replace(
+    /<(strong|b)[^>]*>([\s\S]*?)<\/\1>/gi,
+    (_m, _t, inner: string) => `**${decodeEntities(stripTags(inner)).trim()}**`,
+  );
+  out = out.replace(
+    /<(em|i)[^>]*>([\s\S]*?)<\/\1>/gi,
+    (_m, _t, inner: string) => `*${decodeEntities(stripTags(inner)).trim()}*`,
+  );
+
+  out = out.replace(
+    /<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, href: string, inner: string) => {
+      const text = decodeEntities(stripTags(inner)).trim() || href;
+      return `[${text}](${href})`;
+    },
+  );
+
+  out = out.replace(/<img\b[^>]*>/gi, (tag) => {
+    const src = /src=["']([^"']+)["']/i.exec(tag)?.[1] ?? '';
+    const alt = /alt=["']([^"']*)["']/i.exec(tag)?.[1] ?? '';
+    return src ? `![${alt}](${src})` : '';
+  });
+
+  out = out.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, level: string, inner: string) => {
+    const hashes = '#'.repeat(Number(level));
+    return `\n\n${hashes} ${decodeEntities(stripTags(inner)).trim()}\n\n`;
+  });
+
+  out = out.replace(/<ul[^>]*>([\s\S]*?)<\/ul>/gi, (_m, inner: string) => renderList(inner, false));
+  out = out.replace(/<ol[^>]*>([\s\S]*?)<\/ol>/gi, (_m, inner: string) => renderList(inner, true));
+
+  out = out.replace(/<br\s*\/?>(\s*)/gi, '  \n');
+  out = out.replace(
+    /<p[^>]*>([\s\S]*?)<\/p>/gi,
+    (_m, inner: string) => `\n\n${decodeEntities(stripTags(inner)).trim()}\n\n`,
+  );
+
+  out = stripTags(out);
+  out = decodeEntities(out);
+  return out
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function renderList(inner: string, ordered: boolean): string {
+  const items: string[] = [];
+  const re = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let m: RegExpExecArray | null = re.exec(inner);
+  let i = 1;
+  while (m !== null) {
+    const text = decodeEntities(stripTags(m[1] ?? ''))
+      .trim()
+      .replace(/\s+/g, ' ');
+    const prefix = ordered ? `${i}.` : '-';
+    items.push(`${prefix} ${text}`);
+    i += 1;
+    m = re.exec(inner);
+  }
+  return `\n\n${items.join('\n')}\n\n`;
+}
+
+function stripTags(input: string): string {
+  return input.replace(/<[^>]+>/g, '');
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -341,6 +341,10 @@
       "zip": {
         "label": "ZIP bundle",
         "hint": "index.html + assets + README.md"
+      },
+      "markdown": {
+        "label": "Markdown",
+        "hint": "Plain .md with YAML frontmatter"
       }
     }
   },

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -340,6 +340,10 @@
       "zip": {
         "label": "ZIP 包",
         "hint": "index.html + 资源文件 + README.md"
+      },
+      "markdown": {
+        "label": "Markdown",
+        "hint": "纯文本 .md（含 YAML frontmatter）"
       }
     }
   },


### PR DESCRIPTION
## Summary
- New `packages/exporters/src/markdown.ts` — pure-regex HTML→Markdown converter (~120 lines, zero new deps).
- Output ships with `---\ntitle: …\nschemaVersion: 1\n---` frontmatter so future schema bumps stay back-compatible.
- Wired through the existing exporter IPC + `PreviewToolbar` Export menu, with en + zh-CN i18n strings (`export.items.markdown.{label,hint}`).

## What's covered
- Headings `<h1>..<h6>` → `#..######`
- `<p>` → blank-line wrapped paragraphs
- `<a href>` → `[text](url)`, `<img src alt>` → `![alt](src)`
- `<ul>` / `<ol>` → `-` / `1.` lists
- `<strong>`/`<b>` → `**`, `<em>`/`<i>` → `*`
- `<code>` → backticks, `<pre>` → fenced block
- `<head>`, `<script>`, `<style>` and HTML comments stripped
- Common entities decoded

## Test plan
- [x] `pnpm --filter @open-codesign/exporters test` (10 new tests covering frontmatter, headings, paragraphs, links/images, lists, inline marks, stripping, entities, empty + malformed input)
- [x] `pnpm typecheck` (10/10 packages)
- [x] `pnpm lint` (no errors)
- [ ] Manual: open Export menu in dev build → "Markdown" → save .md → verify frontmatter + body

## PRINCIPLES §5b
- Compatibility ✅ (additive format, schemaVersion: 1)
- Upgradeability ✅ (frontmatter version field)
- No bloat ✅ (zero new deps, ~120 LOC)
- Elegance ✅ (small regex pipeline, mirrors `html.ts` style)