### PR TITLE
fix(desktop): PreviewPane hint pill + iframe dark-mode tokens

### DIFF
--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -88,7 +88,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     body = (
       <div className="h-full p-6">
         <div className="relative h-full">
-          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[rgba(255,255,255,0.88)] px-3 py-1 text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
+          <div className="absolute left-5 top-5 z-10 rounded-full border border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_88%,transparent)] px-3 py-1 text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur">
             {t('preview.clickToComment')}
           </div>
           <iframe
@@ -97,7 +97,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
             title="design-preview"
             sandbox="allow-scripts"
             srcDoc={buildSrcdoc(previewHtml)}
-            className="w-full h-full bg-white rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
+            className="w-full h-full bg-[var(--color-surface)] rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]"
           />
           <InlineCommentComposer />
         </div>


### PR DESCRIPTION
## Summary
- Replace opaque `rgba(255,255,255,0.88)` on the click-to-comment hint pill with a token-aware `color-mix(...var(--color-surface)...)` so it respects dark mode.
- Replace iframe `bg-white` with `bg-[var(--color-surface)]` so the visible frame chrome between rounded corners and content edges follows the active theme.

## Test plan
- [x] `pnpm -w typecheck`
- [x] `pnpm -w lint` (no new findings)
- [x] `pnpm -w test` (149 desktop tests pass, ran via pre-commit hook)
- [ ] Manual: toggle dark mode, confirm hint pill and iframe chrome no longer flash white

## PRINCIPLES §5b
- ✅ Compatibility — pure className change, no API/schema impact
- ✅ Upgradeability — uses existing CSS variables; no new tokens required
- ✅ No bloat — zero new deps, 2-line diff
- ✅ Elegance — switches from hard-coded color to token, matches surrounding token usage