### PR TITLE
fix(desktop): i18n ThemeToggle aria/tooltip strings

### DIFF
--- a/apps/desktop/src/renderer/src/components/ThemeToggle.tsx
+++ b/apps/desktop/src/renderer/src/components/ThemeToggle.tsx
@@ -1,14 +1,16 @@
+import { useT } from '@open-codesign/i18n';
 import { IconButton, Tooltip } from '@open-codesign/ui';
 import { Moon, Sun } from 'lucide-react';
 import { useCodesignStore } from '../store';
 
 export function ThemeToggle() {
+  const t = useT();
   const theme = useCodesignStore((s) => s.theme);
   const toggle = useCodesignStore((s) => s.toggleTheme);
   const isDark = theme === 'dark';
   return (
-    <Tooltip label={isDark ? 'Switch to light' : 'Switch to dark'}>
-      <IconButton label="Toggle theme" size="sm" onClick={toggle}>
+    <Tooltip label={isDark ? t('theme.switchToLight') : t('theme.switchToDark')}>
+      <IconButton label={t('theme.toggleAria')} size="sm" onClick={toggle}>
         {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
       </IconButton>
     </Tooltip>

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -293,6 +293,11 @@
     "byokTitle": "BYOK — bring-your-own-key. Full usage tracking coming soon.",
     "spendTooltip": "Spending this week (full tracking coming soon)"
   },
+  "theme": {
+    "toggleAria": "Toggle theme",
+    "switchToLight": "Switch to light",
+    "switchToDark": "Switch to dark"
+  },
   "commands": {
     "title": "Commands",
     "placeholder": "Type a command or search…",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -292,6 +292,11 @@
     "byokTitle": "BYOK — 自带密钥，完整用量统计即将上线。",
     "spendTooltip": "本周花费（完整统计即将上线）"
   },
+  "theme": {
+    "toggleAria": "切换主题",
+    "switchToLight": "切换到浅色",
+    "switchToDark": "切换到深色"
+  },
   "commands": {
     "title": "命令面板",
     "placeholder": "输入命令或搜索…",


### PR DESCRIPTION
## Summary
- Replace hardcoded English in `ThemeToggle.tsx` (`Switch to light` / `Switch to dark` / `Toggle theme`) with `t()` calls via `useT()`.
- Add `theme.toggleAria` / `theme.switchToLight` / `theme.switchToDark` keys to both `en.json` and `zh-CN.json`.

## Test plan
- [x] `pnpm -w typecheck` — clean
- [x] `pnpm -w lint` — clean (pre-existing warnings only)
- [x] `pnpm -w test` (via pre-commit hook) — 149 desktop + 11 i18n tests pass
- [ ] Manual: toggle theme button shows localized tooltip in both EN and zh-CN

## PRINCIPLES §5b checklist
- ✅ **Compatibility** — additive locale keys, no schema change, no behavior shift
- ✅ **Upgradeability** — JSON namespaced under `theme.*`, easy to extend
- ✅ **No bloat** — zero new deps; 3-file diff, +14/-2 LOC
- ✅ **Elegance** — uses existing `useT()` pattern shared by sibling components

🤖 Generated with [Claude Code](https://claude.com/claude-code)