### PR TITLE
fix(desktop): honor XDG_CONFIG_HOME in locale-ipc and preferences-ipc

### DIFF
--- a/apps/desktop/src/main/locale-ipc.test.ts
+++ b/apps/desktop/src/main/locale-ipc.test.ts
@@ -37,9 +37,9 @@ describe('locale-ipc XDG_CONFIG_HOME', () => {
       await setHandler({}, 'fr-FR');
       expect(writeFileMock).toHaveBeenCalled();
       const firstCall = writeFileMock.mock.calls[0];
-      expect(firstCall && firstCall[0]).toBe('/tmp/xdg-locale-test/open-codesign/locale.json');
+      expect(firstCall?.[0]).toBe('/tmp/xdg-locale-test/open-codesign/locale.json');
     } finally {
-      if (prev === undefined) delete process.env['XDG_CONFIG_HOME'];
+      if (prev === undefined) process.env['XDG_CONFIG_HOME'] = undefined;
       else process.env['XDG_CONFIG_HOME'] = prev;
     }
   });

--- a/apps/desktop/src/main/locale-ipc.test.ts
+++ b/apps/desktop/src/main/locale-ipc.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./electron-runtime', () => ({
+  app: { getLocale: () => 'en-US' },
+  ipcMain: { handle: vi.fn() },
+}));
+
+const writeFileMock = vi.fn<(path: string, data: string, encoding: string) => Promise<void>>(
+  async () => {},
+);
+const mkdirMock = vi.fn<(path: string, opts: { recursive?: boolean }) => Promise<void>>(
+  async () => {},
+);
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: (path: string, data: string, encoding: string) => writeFileMock(path, data, encoding),
+  mkdir: (path: string, opts: { recursive?: boolean }) => mkdirMock(path, opts),
+}));
+
+import { ipcMain } from './electron-runtime';
+import { registerLocaleIpc } from './locale-ipc';
+
+describe('locale-ipc XDG_CONFIG_HOME', () => {
+  it('writes locale.json under XDG_CONFIG_HOME when set', async () => {
+    const prev = process.env['XDG_CONFIG_HOME'];
+    process.env['XDG_CONFIG_HOME'] = '/tmp/xdg-locale-test';
+    try {
+      const handlers = new Map<string, (...args: unknown[]) => unknown>();
+      const handleMock = ipcMain.handle as unknown as ReturnType<typeof vi.fn>;
+      handleMock.mockImplementation((channel: unknown, fn: unknown) => {
+        handlers.set(channel as string, fn as (...args: unknown[]) => unknown);
+      });
+      registerLocaleIpc();
+      const setHandler = handlers.get('locale:set');
+      if (!setHandler) throw new Error('locale:set not registered');
+      await setHandler({}, 'fr-FR');
+      expect(writeFileMock).toHaveBeenCalled();
+      const firstCall = writeFileMock.mock.calls[0];
+      expect(firstCall && firstCall[0]).toBe('/tmp/xdg-locale-test/open-codesign/locale.json');
+    } finally {
+      if (prev === undefined) delete process.env['XDG_CONFIG_HOME'];
+      else process.env['XDG_CONFIG_HOME'] = prev;
+    }
+  });
+});

--- a/apps/desktop/src/main/locale-ipc.ts
+++ b/apps/desktop/src/main/locale-ipc.ts
@@ -12,13 +12,15 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { configDir } from './config';
 import { app, ipcMain } from './electron-runtime';
 
-const CONFIG_DIR = join(homedir(), '.config', 'open-codesign');
-const LOCALE_FILE = join(CONFIG_DIR, 'locale.json');
 const SCHEMA_VERSION = 1;
+
+function localeFile(): string {
+  return join(configDir(), 'locale.json');
+}
 
 interface LocaleFile {
   schemaVersion: number;
@@ -26,8 +28,9 @@ interface LocaleFile {
 }
 
 async function readPersisted(): Promise<string | null> {
+  const file = localeFile();
   try {
-    const raw = await readFile(LOCALE_FILE, 'utf8');
+    const raw = await readFile(file, 'utf8');
     const parsed = JSON.parse(raw) as Partial<LocaleFile>;
     if (typeof parsed.locale === 'string' && parsed.locale.length > 0) {
       return parsed.locale;
@@ -36,15 +39,16 @@ async function readPersisted(): Promise<string | null> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') return null;
-    console.warn(`[locale-ipc] failed to read ${LOCALE_FILE}:`, err);
+    console.warn(`[locale-ipc] failed to read ${file}:`, err);
     return null;
   }
 }
 
 async function writePersisted(locale: string): Promise<void> {
-  await mkdir(dirname(LOCALE_FILE), { recursive: true });
+  const file = localeFile();
+  await mkdir(dirname(file), { recursive: true });
   const payload: LocaleFile = { schemaVersion: SCHEMA_VERSION, locale };
-  await writeFile(LOCALE_FILE, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
 export function registerLocaleIpc(): void {

--- a/apps/desktop/src/main/preferences-ipc.test.ts
+++ b/apps/desktop/src/main/preferences-ipc.test.ts
@@ -42,6 +42,23 @@ describe('readPersisted()', () => {
     expect(result).toEqual({ updateChannel: 'stable', generationTimeoutSec: 120 });
   });
 
+  it('honors XDG_CONFIG_HOME when computing the persisted file path', async () => {
+    const prev = process.env['XDG_CONFIG_HOME'];
+    process.env['XDG_CONFIG_HOME'] = '/tmp/xdg-test-home';
+    const notFound = Object.assign(new Error('no such file'), { code: 'ENOENT' });
+    readFileMock.mockRejectedValueOnce(notFound);
+    try {
+      await readPersisted();
+      expect(readFileMock).toHaveBeenLastCalledWith(
+        '/tmp/xdg-test-home/open-codesign/preferences.json',
+        'utf8',
+      );
+    } finally {
+      if (prev === undefined) delete process.env['XDG_CONFIG_HOME'];
+      else process.env['XDG_CONFIG_HOME'] = prev;
+    }
+  });
+
   it('throws CodesignError with PREFERENCES_READ_FAILED on a non-ENOENT error (e.g. EACCES)', async () => {
     const permissionDenied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
     readFileMock.mockRejectedValueOnce(permissionDenied);

--- a/apps/desktop/src/main/preferences-ipc.test.ts
+++ b/apps/desktop/src/main/preferences-ipc.test.ts
@@ -54,7 +54,7 @@ describe('readPersisted()', () => {
         'utf8',
       );
     } finally {
-      if (prev === undefined) delete process.env['XDG_CONFIG_HOME'];
+      if (prev === undefined) process.env['XDG_CONFIG_HOME'] = undefined;
       else process.env['XDG_CONFIG_HOME'] = prev;
     }
   });

--- a/apps/desktop/src/main/preferences-ipc.ts
+++ b/apps/desktop/src/main/preferences-ipc.ts
@@ -9,17 +9,19 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { CodesignError } from '@open-codesign/shared';
 import { ipcMain } from 'electron';
+import { configDir } from './config';
 import { getLogger } from './logger';
 
 const logger = getLogger('preferences-ipc');
 
-const CONFIG_DIR = join(homedir(), '.config', 'open-codesign');
-const PREFS_FILE = join(CONFIG_DIR, 'preferences.json');
 const SCHEMA_VERSION = 1;
+
+function prefsFile(): string {
+  return join(configDir(), 'preferences.json');
+}
 
 export type UpdateChannel = 'stable' | 'beta';
 
@@ -38,8 +40,9 @@ const DEFAULTS: Preferences = {
 };
 
 export async function readPersisted(): Promise<Preferences> {
+  const file = prefsFile();
   try {
-    const raw = await readFile(PREFS_FILE, 'utf8');
+    const raw = await readFile(file, 'utf8');
     const parsed = JSON.parse(raw) as Partial<PreferencesFile>;
     return {
       updateChannel:
@@ -54,16 +57,17 @@ export async function readPersisted(): Promise<Preferences> {
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { ...DEFAULTS };
     throw new CodesignError(
-      `Failed to read preferences at ${PREFS_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to read preferences at ${file}: ${err instanceof Error ? err.message : String(err)}`,
       'PREFERENCES_READ_FAILED',
     );
   }
 }
 
 async function writePersisted(prefs: Preferences): Promise<void> {
-  await mkdir(dirname(PREFS_FILE), { recursive: true });
+  const file = prefsFile();
+  await mkdir(dirname(file), { recursive: true });
   const payload: PreferencesFile = { schemaVersion: SCHEMA_VERSION, ...prefs };
-  await writeFile(PREFS_FILE, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
 function parsePreferences(raw: unknown): Partial<Preferences> {


### PR DESCRIPTION
## Bug

`apps/desktop/src/main/config.ts` honors `XDG_CONFIG_HOME` via `configDir()`, but `locale-ipc.ts` and `preferences-ipc.ts` hardcoded `join(homedir(), '.config', 'open-codesign')`. With `XDG_CONFIG_HOME=/custom/path`, `config.toml` lands under `/custom/path/open-codesign/` while `locale.json` and `preferences.json` stay under `~/.config/open-codesign/` — split state. Violates CLAUDE.md hard constraint: "respect XDG base dirs / Electron `app.getPath()`".

## Fix

Both modules now call `configDir()` lazily inside the read/write functions (env var read at call time, matching `config.ts`). Dropped the no-longer-needed `homedir` import and the `CONFIG_DIR` wrapper constants.

## Tests

- `preferences-ipc.test.ts`: added a case asserting `XDG_CONFIG_HOME` redirects the `readFile` path.
- `locale-ipc.test.ts` (new): single test asserting `writeFile` uses the XDG path when `locale:set` runs.
- All 214 desktop tests pass; typecheck and lint green.

## PRINCIPLES §5b

- **Compatibility** ✅ — default behavior unchanged when `XDG_CONFIG_HOME` is unset; existing `~/.config/open-codesign/` files keep working.
- **Upgradeability** ✅ — `schemaVersion` fields preserved; no on-disk format changes.
- **No bloat** ✅ — net-negative on imports; no new dependencies.
- **Elegance** ✅ — single source of truth (`configDir()`) for all on-disk config paths.