### PR TITLE
fix(exporters): prevent zip-slip via asset path traversal

### DIFF
--- a/packages/exporters/src/zip.test.ts
+++ b/packages/exporters/src/zip.test.ts
@@ -69,5 +69,17 @@ describe('exportZip', () => {
         assets: [{ path: 'assets/../../escape.txt', content: 'pwn' }],
       }),
     ).rejects.toMatchObject({ code: 'EXPORTER_ZIP_UNSAFE_PATH' });
+    // Windows-style backslash traversal — must be rejected on POSIX too,
+    // since ZIP entries authored on Windows can carry `\` separators.
+    await expect(
+      exportZip('<p>x</p>', dest, {
+        assets: [{ path: '..\\..\\etc\\passwd', content: 'pwn' }],
+      }),
+    ).rejects.toMatchObject({ code: 'EXPORTER_ZIP_UNSAFE_PATH' });
+    await expect(
+      exportZip('<p>x</p>', dest, {
+        assets: [{ path: 'assets\\..\\..\\escape.txt', content: 'pwn' }],
+      }),
+    ).rejects.toMatchObject({ code: 'EXPORTER_ZIP_UNSAFE_PATH' });
   });
 });

--- a/packages/exporters/src/zip.test.ts
+++ b/packages/exporters/src/zip.test.ts
@@ -56,4 +56,18 @@ describe('exportZip', () => {
       code: 'EXPORTER_ZIP_FAILED',
     });
   });
+
+  it('rejects asset paths that escape the staging directory (zip-slip)', async () => {
+    const dest = join(tempDir, 'unsafe.zip');
+    await expect(
+      exportZip('<p>x</p>', dest, {
+        assets: [{ path: '../escape.txt', content: 'pwn' }],
+      }),
+    ).rejects.toMatchObject({ code: 'EXPORTER_ZIP_UNSAFE_PATH' });
+    await expect(
+      exportZip('<p>x</p>', dest, {
+        assets: [{ path: 'assets/../../escape.txt', content: 'pwn' }],
+      }),
+    ).rejects.toMatchObject({ code: 'EXPORTER_ZIP_UNSAFE_PATH' });
+  });
 });

--- a/packages/exporters/src/zip.ts
+++ b/packages/exporters/src/zip.ts
@@ -70,14 +70,19 @@ export async function exportZip(
     zip.addFile(readmePath, 'README.md');
 
     if (opts.assets) {
+      const stagingResolved = path.resolve(stagingDir);
       for (const asset of opts.assets) {
         const safeRel = asset.path.replace(/^\/+/, '');
-        const localPath = path.join(stagingDir, safeRel);
+        const localPath = path.resolve(stagingDir, safeRel);
+        const rel = path.relative(stagingResolved, localPath);
+        if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
+          throw new CodesignError(
+            `ZIP export rejected unsafe asset path: ${asset.path}`,
+            'EXPORTER_ZIP_UNSAFE_PATH',
+          );
+        }
         await fs.mkdir(path.dirname(localPath), { recursive: true });
-        await fs.writeFile(
-          localPath,
-          typeof asset.content === 'string' ? asset.content : asset.content,
-        );
+        await fs.writeFile(localPath, asset.content);
         zip.addFile(localPath, safeRel);
       }
     }
@@ -86,6 +91,7 @@ export async function exportZip(
     const stat = await fs.stat(destinationPath);
     return { bytes: stat.size, path: destinationPath };
   } catch (err) {
+    if (err instanceof CodesignError) throw err;
     throw new CodesignError(
       `ZIP export failed: ${err instanceof Error ? err.message : String(err)}`,
       'EXPORTER_ZIP_FAILED',

--- a/packages/exporters/src/zip.ts
+++ b/packages/exporters/src/zip.ts
@@ -72,8 +72,11 @@ export async function exportZip(
     if (opts.assets) {
       const stagingResolved = path.resolve(stagingDir);
       for (const asset of opts.assets) {
-        const safeRel = asset.path.replace(/^\/+/, '');
-        const localPath = path.resolve(stagingDir, safeRel);
+        // Normalize backslashes first: on POSIX `path.resolve` treats `\` as a
+        // literal char, so a Windows-style ZIP entry like `..\..\etc\passwd`
+        // would slip past the containment check unless rewritten to `/`.
+        const normalized = asset.path.replace(/\\/g, '/').replace(/^\/+/, '');
+        const localPath = path.resolve(stagingDir, normalized);
         const rel = path.relative(stagingResolved, localPath);
         if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
           throw new CodesignError(
@@ -83,7 +86,7 @@ export async function exportZip(
         }
         await fs.mkdir(path.dirname(localPath), { recursive: true });
         await fs.writeFile(localPath, asset.content);
-        zip.addFile(localPath, safeRel);
+        zip.addFile(localPath, normalized);
       }
     }
 


### PR DESCRIPTION
## Summary
- `exportZip` joined caller-supplied `asset.path` directly onto the staging dir, so paths like `../escape.txt` or `assets/../../x` would write outside the staging directory and end up at escaping locations inside the archive (zip-slip).
- Resolve the target path and verify it stays inside the staging dir; throw `EXPORTER_ZIP_UNSAFE_PATH` otherwise. Re-throw `CodesignError` from outer catch so the wrapper does not mask the explicit code.
- Drop a dead `typeof asset.content === 'string' ? a : a` ternary while here.

## Test plan
- [x] `pnpm --filter @open-codesign/exporters test -- --run zip.test` (4/4 pass, includes new traversal cases)

## PRINCIPLES checks
- Compatibility: green (additive validation, error code is new)
- Upgradeability: green
- No bloat: green (no deps)
- Elegance: green