### PR TITLE
feat(desktop): preview zoom dropdown

### DIFF
--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isTrustedPreviewMessageSource } from './PreviewPane';
+import { isTrustedPreviewMessageSource, scaleRectForZoom } from './PreviewPane';
 
 describe('isTrustedPreviewMessageSource', () => {
   it('accepts only messages from the active preview iframe window', () => {
@@ -9,5 +9,30 @@ describe('isTrustedPreviewMessageSource', () => {
     expect(isTrustedPreviewMessageSource(previewWindow, previewWindow)).toBe(true);
     expect(isTrustedPreviewMessageSource(otherWindow, previewWindow)).toBe(false);
     expect(isTrustedPreviewMessageSource(null, previewWindow)).toBe(false);
+  });
+});
+
+describe('scaleRectForZoom', () => {
+  const rect = { top: 100, left: 200, width: 300, height: 50 };
+
+  it('returns identical coords at 100% zoom', () => {
+    expect(scaleRectForZoom(rect, 100)).toEqual(rect);
+  });
+
+  it('halves coords and dimensions at 50% zoom', () => {
+    expect(scaleRectForZoom(rect, 50)).toEqual({ top: 50, left: 100, width: 150, height: 25 });
+  });
+
+  it('doubles coords and dimensions at 200% zoom', () => {
+    expect(scaleRectForZoom(rect, 200)).toEqual({ top: 200, left: 400, width: 600, height: 100 });
+  });
+
+  it('handles 75% zoom (the regression case)', () => {
+    expect(scaleRectForZoom({ top: 80, left: 40, width: 100, height: 100 }, 75)).toEqual({
+      top: 60,
+      left: 30,
+      width: 75,
+      height: 75,
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -44,6 +44,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const pushIframeError = useCodesignStore((s) => s.pushIframeError);
   const selectCanvasElement = useCodesignStore((s) => s.selectCanvasElement);
   const previewViewport = useCodesignStore((s) => s.previewViewport);
+  const previewZoom = useCodesignStore((s) => s.previewZoom);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
@@ -91,7 +92,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     body = <LoadingState />;
   } else if (previewHtml) {
     const isMobile = previewViewport === 'mobile';
-    const iframe = (
+    const rawIframe = (
       <iframe
         ref={iframeRef}
         key={previewHtml.length}
@@ -105,13 +106,30 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         }
       />
     );
+    const scale = previewZoom / 100;
+    const inversePct = `${10000 / previewZoom}%`;
+    const iframe =
+      previewZoom === 100 ? (
+        rawIframe
+      ) : (
+        <div
+          className="origin-top-left"
+          style={{
+            transform: `scale(${scale})`,
+            width: inversePct,
+            height: inversePct,
+          }}
+        >
+          {rawIframe}
+        </div>
+      );
 
     if (isMobile) {
       body = (
         <div className="min-h-full p-6 flex flex-col items-center justify-center overflow-auto">
           <div className="relative inline-flex">
             <PhoneFrame>{iframe}</PhoneFrame>
-            <InlineCommentComposer />
+            {previewZoom === 100 && <InlineCommentComposer />}
           </div>
         </div>
       );
@@ -128,7 +146,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
-            <InlineCommentComposer />
+            {previewZoom === 100 && <InlineCommentComposer />}
           </div>
         </div>
       );
@@ -145,7 +163,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
-            <InlineCommentComposer />
+            {previewZoom === 100 && <InlineCommentComposer />}
           </div>
         </div>
       );

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -31,6 +31,23 @@ export function isTrustedPreviewMessageSource(
   return source !== null && source === previewWindow;
 }
 
+// Convert a rect reported from inside the sandbox iframe (iframe-internal
+// viewport coords) into the parent renderer's viewport coords. The wrapper
+// applies `transform: scale(zoom/100)` to a div sized at `100/scale %`, so a
+// child at iframe-internal position P appears in the parent at P * scale.
+export function scaleRectForZoom(
+  rect: { top: number; left: number; width: number; height: number },
+  zoomPercent: number,
+): { top: number; left: number; width: number; height: number } {
+  const scale = zoomPercent / 100;
+  return {
+    top: rect.top * scale,
+    left: rect.left * scale,
+    width: rect.width * scale,
+    height: rect.height * scale,
+  };
+}
+
 const COMMENT_HINT_CLASS =
   'absolute left-[var(--space-5)] top-[var(--space-5)] z-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-[var(--space-3)] py-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur';
 
@@ -56,7 +73,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           selector: event.data.selector,
           tag: event.data.tag,
           outerHTML: event.data.outerHTML,
-          rect: event.data.rect,
+          rect: scaleRectForZoom(event.data.rect, previewZoom),
         });
         return;
       }
@@ -75,7 +92,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [pushIframeError, selectCanvasElement]);
+  }, [pushIframeError, selectCanvasElement, previewZoom]);
 
   let body: React.ReactNode;
   if (errorMessage) {
@@ -129,7 +146,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         <div className="min-h-full p-6 flex flex-col items-center justify-center overflow-auto">
           <div className="relative inline-flex">
             <PhoneFrame>{iframe}</PhoneFrame>
-            {previewZoom === 100 && <InlineCommentComposer />}
+            <InlineCommentComposer />
           </div>
         </div>
       );
@@ -146,7 +163,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
-            {previewZoom === 100 && <InlineCommentComposer />}
+            <InlineCommentComposer />
           </div>
         </div>
       );
@@ -163,7 +180,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           >
             <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
             {iframe}
-            {previewZoom === 100 && <InlineCommentComposer />}
+            <InlineCommentComposer />
           </div>
         </div>
       );

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -179,7 +179,7 @@ export function PreviewToolbar(): ReactElement {
         {zoomOpen && (
           <div
             role="menu"
-            className="absolute right-0 top-full mt-2 min-w-[6rem] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)] py-1 z-10"
+            className="absolute right-0 top-full mt-2 min-w-[var(--size-menu-compact)] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)] py-1 z-10"
           >
             {ZOOM_OPTIONS.map((value) => (
               <button

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -19,6 +19,8 @@ interface ViewportItem {
   icon: ReactElement;
 }
 
+const ZOOM_OPTIONS = [50, 75, 90, 100, 110, 125, 150, 175, 200] as const;
+
 export function PreviewToolbar(): ReactElement {
   const t = useT();
   const previewHtml = useCodesignStore((s) => s.previewHtml);
@@ -27,8 +29,12 @@ export function PreviewToolbar(): ReactElement {
   const dismissToast = useCodesignStore((s) => s.dismissToast);
   const previewViewport = useCodesignStore((s) => s.previewViewport);
   const setPreviewViewport = useCodesignStore((s) => s.setPreviewViewport);
+  const previewZoom = useCodesignStore((s) => s.previewZoom);
+  const setPreviewZoom = useCodesignStore((s) => s.setPreviewZoom);
   const [open, setOpen] = useState(false);
+  const [zoomOpen, setZoomOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
+  const zoomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -38,6 +44,15 @@ export function PreviewToolbar(): ReactElement {
     document.addEventListener('mousedown', onClick);
     return () => document.removeEventListener('mousedown', onClick);
   }, [open]);
+
+  useEffect(() => {
+    if (!zoomOpen) return;
+    function onClick(e: MouseEvent): void {
+      if (zoomRef.current && !zoomRef.current.contains(e.target as Node)) setZoomOpen(false);
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [zoomOpen]);
 
   useEffect(() => {
     if (!toastMessage) return;
@@ -142,6 +157,48 @@ export function PreviewToolbar(): ReactElement {
           );
         })}
       </fieldset>
+
+      <div className="relative" ref={zoomRef}>
+        <Tooltip
+          label={disabled ? t('disabledReason.noDesignToExport') : t('preview.zoom')}
+          side="bottom"
+        >
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setZoomOpen((v) => !v)}
+            className="inline-flex items-center gap-1.5 h-[var(--size-control-xs)] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)] disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color] duration-[var(--duration-fast)] ease-[var(--ease-out)]"
+            aria-haspopup="menu"
+            aria-expanded={zoomOpen}
+            aria-label={t('preview.zoom')}
+          >
+            {previewZoom}%
+          </button>
+        </Tooltip>
+
+        {zoomOpen && (
+          <div
+            role="menu"
+            className="absolute right-0 top-full mt-2 min-w-[6rem] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-elevated)] py-1 z-10"
+          >
+            {ZOOM_OPTIONS.map((value) => (
+              <button
+                key={value}
+                type="button"
+                role="menuitemradio"
+                aria-checked={previewZoom === value}
+                onClick={() => {
+                  setPreviewZoom(value);
+                  setZoomOpen(false);
+                }}
+                className={`w-full px-3 py-2 text-[var(--text-sm)] text-left transition-colors duration-100 hover:bg-[var(--color-surface-hover)] ${previewZoom === value ? 'text-[var(--color-accent)] font-medium' : 'text-[var(--color-text-primary)]'}`}
+              >
+                {value}%
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
 
       <div className="relative" ref={ref}>
         <Tooltip label={disabled ? t('disabledReason.noDesignToExport') : undefined} side="bottom">

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -605,3 +605,14 @@ describe('useCodesignStore design management', () => {
     expect(useCodesignStore.getState().toasts.at(-1)?.variant).toBe('info');
   });
 });
+
+describe('useCodesignStore previewZoom', () => {
+  it('defaults previewZoom to 100', () => {
+    expect(useCodesignStore.getState().previewZoom).toBe(100);
+  });
+
+  it('updates previewZoom via setPreviewZoom', () => {
+    useCodesignStore.getState().setPreviewZoom(150);
+    expect(useCodesignStore.getState().previewZoom).toBe(150);
+  });
+});

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -96,6 +96,7 @@ interface CodesignState {
   referenceUrl: string;
   lastPromptInput: PromptRequest | null;
   selectedElement: SelectedElement | null;
+  previewZoom: number;
 
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
@@ -123,6 +124,7 @@ interface CodesignState {
 
   selectCanvasElement: (selection: SelectedElement) => void;
   clearCanvasElement: () => void;
+  setPreviewZoom: (zoom: number) => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -494,6 +496,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   referenceUrl: '',
   lastPromptInput: null,
   selectedElement: null,
+  previewZoom: 100,
 
   clearIframeErrors() {
     set({ iframeErrors: [] });
@@ -795,6 +798,10 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   clearCanvasElement() {
     set({ selectedElement: null });
+  },
+
+  setPreviewZoom(zoom) {
+    set({ previewZoom: zoom });
   },
 
   setTheme(theme) {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -52,6 +52,7 @@
     "clickToComment": "Click any element in the preview to leave an inline comment.",
     "runtimeError": "Preview runtime error",
     "dismissErrors": "Dismiss preview errors",
+    "zoom": "Zoom",
     "viewport": {
       "label": "Viewport",
       "desktop": "Desktop",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -51,6 +51,7 @@
     "clickToComment": "点击预览中的任意元素即可留下局部评论。",
     "runtimeError": "预览运行时错误",
     "dismissErrors": "关闭预览错误",
+    "zoom": "缩放",
     "viewport": {
       "label": "视口",
       "desktop": "桌面",

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -132,6 +132,9 @@
   /* Minimum width for menus, popovers, and stage panels */
   --size-stage-min: 200px;
 
+  /* Compact menu width (zoom dropdown, narrow option pickers) */
+  --size-menu-compact: 6rem;
+
   /* Hub sidebar (Designs hub left rail) */
   --size-hub-sidebar: 360px;
 


### PR DESCRIPTION
## Summary

- Adds a zoom dropdown to the preview toolbar with steps **50/75/90/100/110/125/150/175/200%**, default 100%.
- Wires `previewZoom` + `setPreviewZoom` into the Zustand store; `PreviewPane` applies the zoom via `transform: scale()` on the iframe wrapper (with inverse width/height so the layout box still fills the viewport).
- The artifact's own layout is untouched — pure visual scaling.
- Inline-comment composer is hidden when zoom != 100% to avoid stale rect math; tracked as a follow-up to make rect-based positioning zoom-aware.

i18n: added `preview.zoom` (en + zh-CN). Option labels are simple `\${n}%` strings.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (added unit tests: default 100, set to 150 updates store)
- [x] `pnpm lint` (no new errors; pre-existing warnings unchanged)
- [ ] Manual: open preview, click zoom, switch between 50% / 100% / 200% — iframe scales, artifact internals unchanged

## PRINCIPLES §5b

- Compatibility: green — additive store field, default 100% preserves current behavior
- Upgradeability: green — store field is plain number, easy to persist later
- No bloat: green — no new deps, ~80 LOC, plain Tailwind + existing Tooltip
- Elegance: green — mirrors the existing export dropdown pattern