### PR TITLE
feat(desktop): Tweaks panel v0

### DIFF
--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -1,5 +1,10 @@
 import { useT } from '@open-codesign/i18n';
-import { buildSrcdoc, isIframeErrorMessage, isOverlayMessage } from '@open-codesign/runtime';
+import {
+  buildSrcdoc,
+  isIframeErrorMessage,
+  isOverlayMessage,
+  isTweakVarsDetectedMessage,
+} from '@open-codesign/runtime';
 import { useEffect, useRef } from 'react';
 import { EmptyState } from '../preview/EmptyState';
 import { ErrorState } from '../preview/ErrorState';
@@ -8,6 +13,7 @@ import { useCodesignStore } from '../store';
 import { CanvasErrorBar } from './CanvasErrorBar';
 import { InlineCommentComposer } from './InlineCommentComposer';
 import { PreviewToolbar } from './PreviewToolbar';
+import { TweaksPanel } from './TweaksPanel';
 
 export interface PreviewPaneProps {
   onPickStarter: (prompt: string) => void;
@@ -39,6 +45,8 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const clearError = useCodesignStore((s) => s.clearError);
   const pushIframeError = useCodesignStore((s) => s.pushIframeError);
   const selectCanvasElement = useCodesignStore((s) => s.selectCanvasElement);
+  const setTweaksVars = useCodesignStore((s) => s.setTweaksVars);
+  const tweaksEnabled = useCodesignStore((s) => s.tweaksEnabled);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
@@ -52,6 +60,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           outerHTML: event.data.outerHTML,
           rect: event.data.rect,
         });
+        return;
+      }
+
+      if (isTweakVarsDetectedMessage(event.data)) {
+        setTweaksVars(event.data.vars);
         return;
       }
 
@@ -69,7 +82,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [pushIframeError, selectCanvasElement]);
+  }, [pushIframeError, selectCanvasElement, setTweaksVars]);
 
   let body: React.ReactNode;
   if (errorMessage) {
@@ -111,7 +124,12 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     <div className="flex flex-col min-h-0 flex-1">
       <PreviewToolbar />
       <CanvasErrorBar />
-      <div className="flex-1 overflow-auto">{body}</div>
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 overflow-auto">{body}</div>
+        {tweaksEnabled && previewHtml ? (
+          <TweaksPanel iframeWindow={iframeRef.current?.contentWindow ?? null} />
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { Tooltip } from '@open-codesign/ui';
-import { Download } from 'lucide-react';
+import { Download, Sliders } from 'lucide-react';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 import type { ExportFormat } from '../../../preload/index';
 import { useCodesignStore } from '../store';
@@ -18,6 +18,8 @@ export function PreviewToolbar(): ReactElement {
   const exportActive = useCodesignStore((s) => s.exportActive);
   const toastMessage = useCodesignStore((s) => s.toastMessage);
   const dismissToast = useCodesignStore((s) => s.dismissToast);
+  const tweaksEnabled = useCodesignStore((s) => s.tweaksEnabled);
+  const setTweaksEnabled = useCodesignStore((s) => s.setTweaksEnabled);
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -77,6 +79,28 @@ export function PreviewToolbar(): ReactElement {
           {toastMessage}
         </output>
       )}
+
+      <div className="relative">
+        <Tooltip label={t('preview.tweaks.toggle')} side="bottom">
+          <button
+            type="button"
+            disabled={disabled}
+            aria-pressed={tweaksEnabled}
+            onClick={() => setTweaksEnabled(!tweaksEnabled)}
+            className={`inline-flex items-center justify-center h-[var(--size-control-sm)] w-[var(--size-control-sm)] rounded-[var(--radius-md)] border ${
+              tweaksEnabled
+                ? 'border-[var(--color-accent)] bg-[color-mix(in_srgb,var(--color-accent)_14%,transparent)] text-[var(--color-accent)]'
+                : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)]'
+            } disabled:opacity-40 disabled:pointer-events-none transition-[background-color,border-color,color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] mr-1`}
+          >
+            <Sliders
+              className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]"
+              aria-hidden="true"
+            />
+            <span className="sr-only">{t('preview.tweaks.title')}</span>
+          </button>
+        </Tooltip>
+      </div>
 
       <div className="relative" ref={ref}>
         <Tooltip label={disabled ? t('disabledReason.noDesignToExport') : undefined} side="bottom">

--- a/apps/desktop/src/renderer/src/components/TweaksPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/TweaksPanel.tsx
@@ -1,0 +1,208 @@
+import { useT } from '@open-codesign/i18n';
+import { type TweakVar, buildTweakVarMessage } from '@open-codesign/runtime';
+import { type ReactElement, useMemo } from 'react';
+import { useCodesignStore } from '../store';
+
+export interface TweaksPanelProps {
+  iframeWindow: Window | null;
+}
+
+function postTweak(target: Window | null, name: string, value: string): void {
+  if (!target) return;
+  try {
+    target.postMessage(buildTweakVarMessage(name, value), '*');
+  } catch {
+    // postMessage failed (iframe gone) — silent; next render will pick up.
+  }
+}
+
+interface ControlProps {
+  variable: TweakVar;
+  onChange: (value: string) => void;
+}
+
+function ColorControl({ variable, onChange }: ControlProps): ReactElement {
+  // <input type="color"> only accepts #rrggbb. oklch / rgb / hsl values can't
+  // round-trip without a CSS Color Module 4 conversion library — kept out of
+  // MVP per the lean budget. Show a hex picker only for hex sources; for
+  // everything else fall back to a text field that still lives-edits.
+  const isHex = /^#[0-9a-f]{3,8}$/i.test(variable.value.trim());
+  if (isHex) {
+    const normalized =
+      variable.value.length === 4
+        ? `#${variable.value
+            .slice(1)
+            .split('')
+            .map((c) => c + c)
+            .join('')}`
+        : variable.value.slice(0, 7);
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={normalized}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-8 w-10 cursor-pointer rounded border border-[var(--color-border)] bg-transparent p-0"
+          aria-label={variable.name}
+        />
+        <input
+          type="text"
+          value={variable.value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 h-8 px-2 rounded border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] font-mono text-[var(--color-text-primary)]"
+        />
+      </div>
+    );
+  }
+  return (
+    <input
+      type="text"
+      value={variable.value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full h-8 px-2 rounded border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] font-mono text-[var(--color-text-primary)]"
+      aria-label={variable.name}
+    />
+  );
+}
+
+function NumberControl({ variable, onChange }: ControlProps): ReactElement {
+  const match = variable.value.match(/^([\d.]+)(px|rem|em|%)$/);
+  const numeric = match ? Number.parseFloat(match[1] ?? '0') : 0;
+  const unit = match?.[2] ?? 'px';
+  const max = unit === '%' ? 100 : unit === 'px' ? 200 : 10;
+  const step = unit === 'rem' || unit === 'em' ? 0.125 : 1;
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={step}
+        value={numeric}
+        onChange={(e) => onChange(`${e.target.value}${unit}`)}
+        className="flex-1"
+        aria-label={variable.name}
+      />
+      <input
+        type="text"
+        value={variable.value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-20 h-8 px-2 rounded border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] font-mono text-[var(--color-text-primary)]"
+      />
+    </div>
+  );
+}
+
+function BooleanControl({ variable, onChange }: ControlProps): ReactElement {
+  const checked = variable.value.trim() === 'true';
+  return (
+    <label className="inline-flex items-center gap-2 cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
+        className="h-4 w-4"
+      />
+      <span className="text-[var(--text-xs)] text-[var(--color-text-secondary)]">
+        {variable.value}
+      </span>
+    </label>
+  );
+}
+
+function StringControl({ variable, onChange }: ControlProps): ReactElement {
+  return (
+    <input
+      type="text"
+      value={variable.value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full h-8 px-2 rounded border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--text-xs)] font-mono text-[var(--color-text-primary)]"
+      aria-label={variable.name}
+    />
+  );
+}
+
+export function TweaksPanel({ iframeWindow }: TweaksPanelProps): ReactElement {
+  const t = useT();
+  const tweaksVars = useCodesignStore((s) => s.tweaksVars);
+  const updateTweakVar = useCodesignStore((s) => s.updateTweakVar);
+
+  const grouped = useMemo(() => {
+    const groups: Record<TweakVar['type'], TweakVar[]> = {
+      color: [],
+      number: [],
+      boolean: [],
+      string: [],
+    };
+    for (const v of tweaksVars) groups[v.type].push(v);
+    return groups;
+  }, [tweaksVars]);
+
+  function handleChange(name: string, value: string): void {
+    updateTweakVar(name, value);
+    postTweak(iframeWindow, name, value);
+  }
+
+  function renderRow(v: TweakVar): ReactElement {
+    let control: ReactElement;
+    if (v.type === 'color') {
+      control = <ColorControl variable={v} onChange={(val) => handleChange(v.name, val)} />;
+    } else if (v.type === 'number') {
+      control = <NumberControl variable={v} onChange={(val) => handleChange(v.name, val)} />;
+    } else if (v.type === 'boolean') {
+      control = <BooleanControl variable={v} onChange={(val) => handleChange(v.name, val)} />;
+    } else {
+      control = <StringControl variable={v} onChange={(val) => handleChange(v.name, val)} />;
+    }
+    return (
+      <div key={v.name} className="flex flex-col gap-1">
+        <label
+          htmlFor={`tweak-${v.name}`}
+          className="text-[var(--text-xs)] font-medium text-[var(--color-text-primary)] font-mono truncate"
+          title={v.name}
+        >
+          {v.name}
+        </label>
+        {control}
+      </div>
+    );
+  }
+
+  const sections: Array<{ key: TweakVar['type']; label: string; items: TweakVar[] }> = [
+    { key: 'color', label: t('preview.tweaks.color'), items: grouped.color },
+    { key: 'number', label: t('preview.tweaks.size'), items: grouped.number },
+    { key: 'boolean', label: t('preview.tweaks.boolean'), items: grouped.boolean },
+    { key: 'string', label: t('preview.tweaks.string'), items: grouped.string },
+  ];
+
+  return (
+    <aside
+      aria-label={t('preview.tweaks.title')}
+      className="w-72 shrink-0 border-l border-[var(--color-border-muted)] bg-[var(--color-background-secondary)] overflow-y-auto"
+    >
+      <header className="sticky top-0 z-10 px-4 py-3 border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)]">
+        <h2 className="text-[var(--text-sm)] font-semibold text-[var(--color-text-primary)]">
+          {t('preview.tweaks.title')}
+        </h2>
+      </header>
+      {tweaksVars.length === 0 ? (
+        <p className="px-4 py-6 text-[var(--text-xs)] text-[var(--color-text-secondary)]">
+          {t('preview.tweaks.empty')}
+        </p>
+      ) : (
+        <div className="px-4 py-3 flex flex-col gap-5">
+          {sections
+            .filter((s) => s.items.length > 0)
+            .map((section) => (
+              <section key={section.key} className="flex flex-col gap-3">
+                <h3 className="text-[var(--text-xs)] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+                  {section.label}
+                </h3>
+                {section.items.map(renderRow)}
+              </section>
+            ))}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -436,3 +436,45 @@ describe('useCodesignStore project storage error surfacing', () => {
     expect(state.generationStage).toBe('idle');
   });
 });
+
+describe('useCodesignStore tweaks state', () => {
+  it('toggles tweaksEnabled', () => {
+    expect(useCodesignStore.getState().tweaksEnabled).toBe(false);
+    useCodesignStore.getState().setTweaksEnabled(true);
+    expect(useCodesignStore.getState().tweaksEnabled).toBe(true);
+    useCodesignStore.getState().setTweaksEnabled(false);
+    expect(useCodesignStore.getState().tweaksEnabled).toBe(false);
+  });
+
+  it('replaces the full tweaksVars list via setTweaksVars', () => {
+    useCodesignStore.getState().setTweaksVars([
+      { name: '--accent', value: '#ff0000', type: 'color' },
+      { name: '--gap', value: '16px', type: 'number' },
+    ]);
+    expect(useCodesignStore.getState().tweaksVars).toHaveLength(2);
+
+    useCodesignStore.getState().setTweaksVars([]);
+    expect(useCodesignStore.getState().tweaksVars).toEqual([]);
+  });
+
+  it('updateTweakVar mutates only the matching entry', () => {
+    useCodesignStore.getState().setTweaksVars([
+      { name: '--accent', value: '#ff0000', type: 'color' },
+      { name: '--gap', value: '16px', type: 'number' },
+    ]);
+    useCodesignStore.getState().updateTweakVar('--accent', '#00ff00');
+    const vars = useCodesignStore.getState().tweaksVars;
+    expect(vars.find((v) => v.name === '--accent')?.value).toBe('#00ff00');
+    expect(vars.find((v) => v.name === '--gap')?.value).toBe('16px');
+  });
+
+  it('updateTweakVar is a no-op for unknown names', () => {
+    useCodesignStore
+      .getState()
+      .setTweaksVars([{ name: '--accent', value: '#ff0000', type: 'color' }]);
+    useCodesignStore.getState().updateTweakVar('--missing', 'whatever');
+    expect(useCodesignStore.getState().tweaksVars).toEqual([
+      { name: '--accent', value: '#ff0000', type: 'color' },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1,4 +1,5 @@
 import { i18n } from '@open-codesign/i18n';
+import type { TweakVar } from '@open-codesign/runtime';
 import {
   type ChatMessage,
   type LocalInputFile,
@@ -86,6 +87,9 @@ interface CodesignState {
   lastPromptInput: PromptRequest | null;
   selectedElement: SelectedElement | null;
 
+  tweaksEnabled: boolean;
+  tweaksVars: TweakVar[];
+
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
   setConnectionStatus: (status: ConnectionStatus) => void;
@@ -112,6 +116,10 @@ interface CodesignState {
 
   selectCanvasElement: (selection: SelectedElement) => void;
   clearCanvasElement: () => void;
+
+  setTweaksEnabled: (enabled: boolean) => void;
+  setTweaksVars: (vars: TweakVar[]) => void;
+  updateTweakVar: (name: string, value: string) => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -377,6 +385,9 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   referenceUrl: '',
   lastPromptInput: null,
   selectedElement: null,
+
+  tweaksEnabled: false,
+  tweaksVars: [],
 
   clearIframeErrors() {
     set({ iframeErrors: [] });
@@ -672,6 +683,20 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   clearCanvasElement() {
     set({ selectedElement: null });
+  },
+
+  setTweaksEnabled(enabled) {
+    set({ tweaksEnabled: enabled });
+  },
+
+  setTweaksVars(vars) {
+    set({ tweaksVars: vars });
+  },
+
+  updateTweakVar(name, value) {
+    set((s) => ({
+      tweaksVars: s.tweaksVars.map((v) => (v.name === name ? { ...v, value } : v)),
+    }));
   },
 
   setTheme(theme) {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -51,7 +51,17 @@
     "noDesign": "No design yet",
     "clickToComment": "Click any element in the preview to leave an inline comment.",
     "runtimeError": "Preview runtime error",
-    "dismissErrors": "Dismiss preview errors"
+    "dismissErrors": "Dismiss preview errors",
+    "tweaks": {
+      "title": "Tweaks",
+      "toggle": "Toggle Tweaks panel",
+      "empty": "No adjustable variables detected",
+      "color": "Color",
+      "size": "Size",
+      "boolean": "Toggle",
+      "string": "Text",
+      "reset": "Reset"
+    }
   },
   "chat": {
     "placeholder": "Describe what to design…",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -50,7 +50,17 @@
     "noDesign": "还没有设计",
     "clickToComment": "点击预览中的任意元素即可留下局部评论。",
     "runtimeError": "预览运行时错误",
-    "dismissErrors": "关闭预览错误"
+    "dismissErrors": "关闭预览错误",
+    "tweaks": {
+      "title": "调参",
+      "toggle": "打开/关闭调参面板",
+      "empty": "未检测到可调参数",
+      "color": "颜色",
+      "size": "尺寸",
+      "boolean": "开关",
+      "string": "文本",
+      "reset": "重置"
+    }
   },
   "chat": {
     "placeholder": "想设计什么？",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,9 +1,22 @@
 import { OVERLAY_SCRIPT } from './overlay';
+import { TWEAKS_SCRIPT } from './tweaks-runtime';
 
 export { OVERLAY_SCRIPT, isOverlayMessage } from './overlay';
 export type { OverlayMessage } from './overlay';
 export { isIframeErrorMessage } from './iframe-errors';
 export type { IframeErrorMessage } from './iframe-errors';
+export {
+  TWEAKS_SCRIPT,
+  inferTweakType,
+  isTweakVarsDetectedMessage,
+  buildTweakVarMessage,
+} from './tweaks-runtime';
+export type {
+  TweakVar,
+  TweakVarType,
+  TweakVarsDetectedMessage,
+  TweakVarMessage,
+} from './tweaks-runtime';
 
 /**
  * Build a complete srcdoc HTML string for the preview iframe.
@@ -21,7 +34,7 @@ export function buildSrcdoc(userHtml: string): string {
   if (/<\/body\s*>/i.test(stripped)) {
     return stripped.replace(
       /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
-      `<script>${OVERLAY_SCRIPT}</script></body>`,
+      `<script>${OVERLAY_SCRIPT}</script><script>${TWEAKS_SCRIPT}</script></body>`,
     );
   }
 
@@ -35,6 +48,7 @@ export function buildSrcdoc(userHtml: string): string {
 <body>
 ${stripped}
 <script>${OVERLAY_SCRIPT}</script>
+<script>${TWEAKS_SCRIPT}</script>
 </body>
 </html>`;
 }

--- a/packages/runtime/src/tweaks-runtime.test.ts
+++ b/packages/runtime/src/tweaks-runtime.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { buildTweakVarMessage, inferTweakType, isTweakVarsDetectedMessage } from './tweaks-runtime';
+
+describe('inferTweakType', () => {
+  it('detects oklch / oklab / rgb / hsl / color() as color', () => {
+    expect(inferTweakType('oklch(0.5 0.1 200)')).toBe('color');
+    expect(inferTweakType('OKLAB(0.5 0.1 0.2)')).toBe('color');
+    expect(inferTweakType('rgb(10, 20, 30)')).toBe('color');
+    expect(inferTweakType('rgba(10, 20, 30, 0.5)')).toBe('color');
+    expect(inferTweakType('hsl(120, 50%, 50%)')).toBe('color');
+    expect(inferTweakType('color(display-p3 1 0 0)')).toBe('color');
+  });
+
+  it('detects hex colors as color', () => {
+    expect(inferTweakType('#fff')).toBe('color');
+    expect(inferTweakType('#abcdef')).toBe('color');
+    expect(inferTweakType('#abcdef12')).toBe('color');
+  });
+
+  it('detects px / rem / em / % as number', () => {
+    expect(inferTweakType('16px')).toBe('number');
+    expect(inferTweakType('1.5rem')).toBe('number');
+    expect(inferTweakType('2em')).toBe('number');
+    expect(inferTweakType('50%')).toBe('number');
+  });
+
+  it('detects true / false as boolean', () => {
+    expect(inferTweakType('true')).toBe('boolean');
+    expect(inferTweakType('false')).toBe('boolean');
+  });
+
+  it('falls back to string for arbitrary text', () => {
+    expect(inferTweakType('Inter, sans-serif')).toBe('string');
+    expect(inferTweakType('cubic-bezier(0.16, 1, 0.3, 1)')).toBe('string');
+    expect(inferTweakType('')).toBe('string');
+  });
+
+  it('handles surrounding whitespace', () => {
+    expect(inferTweakType('  16px  ')).toBe('number');
+    expect(inferTweakType('\n#abc\n')).toBe('color');
+  });
+});
+
+describe('isTweakVarsDetectedMessage', () => {
+  it('accepts well-formed messages', () => {
+    expect(
+      isTweakVarsDetectedMessage({
+        __codesign: true,
+        type: 'TWEAK_VARS_DETECTED',
+        vars: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects unrelated payloads', () => {
+    expect(isTweakVarsDetectedMessage(null)).toBe(false);
+    expect(isTweakVarsDetectedMessage({ type: 'TWEAK_VARS_DETECTED', vars: [] })).toBe(false);
+    expect(isTweakVarsDetectedMessage({ __codesign: true, type: 'OTHER', vars: [] })).toBe(false);
+    expect(isTweakVarsDetectedMessage({ __codesign: true, type: 'TWEAK_VARS_DETECTED' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('buildTweakVarMessage', () => {
+  it('produces the expected envelope', () => {
+    expect(buildTweakVarMessage('--accent', '#ff0000')).toEqual({
+      __codesign: true,
+      type: 'TWEAK_VAR',
+      name: '--accent',
+      value: '#ff0000',
+    });
+  });
+});

--- a/packages/runtime/src/tweaks-runtime.ts
+++ b/packages/runtime/src/tweaks-runtime.ts
@@ -1,0 +1,129 @@
+/**
+ * Tweaks runtime — runs inside the sandbox iframe.
+ *
+ * Two responsibilities:
+ *  1. On load, scan author stylesheets for `:root { --foo: ... }` declarations
+ *     and post a `TWEAK_VARS_DETECTED` message to the parent. Type inference
+ *     happens here so the renderer never has to re-parse CSS values.
+ *  2. Listen for `TWEAK_VAR` messages from the parent and apply each via
+ *     `documentElement.style.setProperty(name, value)` — no re-render.
+ *
+ * MVP scope (intentionally narrow):
+ *  - Only `:root { ... }` selectors are scanned (no `:where(:root)`, no nested
+ *    selectors, no `@media`-wrapped vars, no `:root.dark` overrides).
+ *  - Cross-origin stylesheets are skipped silently (cssRules access throws).
+ */
+
+export type TweakVarType = 'color' | 'number' | 'boolean' | 'string';
+
+export interface TweakVar {
+  name: string;
+  value: string;
+  type: TweakVarType;
+}
+
+export function inferTweakType(value: string): TweakVarType {
+  const trimmed = value.trim();
+  if (/^(oklch|oklab|rgb|rgba|hsl|hsla|color)\(/i.test(trimmed)) return 'color';
+  if (/^#[0-9a-f]{3,8}$/i.test(trimmed)) return 'color';
+  if (/^[\d.]+(px|rem|em|%)$/.test(trimmed)) return 'number';
+  if (trimmed === 'true' || trimmed === 'false') return 'boolean';
+  return 'string';
+}
+
+export const TWEAKS_SCRIPT = `(function() {
+  'use strict';
+
+  function inferType(value) {
+    var trimmed = String(value).trim();
+    if (/^(oklch|oklab|rgb|rgba|hsl|hsla|color)\\(/i.test(trimmed)) return 'color';
+    if (/^#[0-9a-f]{3,8}$/i.test(trimmed)) return 'color';
+    if (/^[\\d.]+(px|rem|em|%)$/.test(trimmed)) return 'number';
+    if (trimmed === 'true' || trimmed === 'false') return 'boolean';
+    return 'string';
+  }
+
+  function collectVars() {
+    var seen = Object.create(null);
+    var out = [];
+    var sheets = document.styleSheets;
+    for (var i = 0; i < sheets.length; i++) {
+      var rules;
+      try { rules = sheets[i].cssRules; } catch (_) { continue; }
+      if (!rules) continue;
+      for (var j = 0; j < rules.length; j++) {
+        var r = rules[j];
+        if (!r || r.type !== 1) continue;
+        var sel = r.selectorText || '';
+        if (sel.indexOf(':root') === -1) continue;
+        var style = r.style;
+        if (!style) continue;
+        for (var k = 0; k < style.length; k++) {
+          var prop = style[k];
+          if (prop.indexOf('--') !== 0) continue;
+          if (seen[prop]) continue;
+          seen[prop] = true;
+          var val = style.getPropertyValue(prop).trim();
+          if (!val) continue;
+          out.push({ name: prop, value: val, type: inferType(val) });
+        }
+      }
+    }
+    return out;
+  }
+
+  function postVars() {
+    try {
+      var vars = collectVars();
+      window.parent.postMessage({
+        __codesign: true,
+        type: 'TWEAK_VARS_DETECTED',
+        vars: vars
+      }, '*');
+    } catch (_) {}
+  }
+
+  function onMessage(ev) {
+    var data = ev && ev.data;
+    if (!data || data.__codesign !== true || data.type !== 'TWEAK_VAR') return;
+    var name = String(data.name || '');
+    var value = String(data.value == null ? '' : data.value);
+    if (name.indexOf('--') !== 0) return;
+    try { document.documentElement.style.setProperty(name, value); } catch (_) {}
+  }
+
+  try { window.addEventListener('message', onMessage); } catch (_) {}
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    setTimeout(postVars, 0);
+  } else {
+    try { window.addEventListener('DOMContentLoaded', postVars); } catch (_) {}
+  }
+})();`;
+
+export interface TweakVarsDetectedMessage {
+  __codesign: true;
+  type: 'TWEAK_VARS_DETECTED';
+  vars: TweakVar[];
+}
+
+export function isTweakVarsDetectedMessage(data: unknown): data is TweakVarsDetectedMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { __codesign?: boolean }).__codesign === true &&
+    (data as { type?: string }).type === 'TWEAK_VARS_DETECTED' &&
+    Array.isArray((data as { vars?: unknown }).vars)
+  );
+}
+
+export interface TweakVarMessage {
+  __codesign: true;
+  type: 'TWEAK_VAR';
+  name: string;
+  value: string;
+}
+
+export function buildTweakVarMessage(name: string, value: string): TweakVarMessage {
+  return { __codesign: true, type: 'TWEAK_VAR', name, value };
+}


### PR DESCRIPTION
## Summary

- Adds the **Tweaks panel v0** — a right-rail drawer that scans the generated artifact's `:root { --foo: ... }` declarations, infers a control type per value, and live-edits each variable in the iframe via `documentElement.style.setProperty`. No re-generation.
- New `tweaks-runtime` script in `packages/runtime`, injected next to the existing overlay. Type inference (color / number / boolean / string) happens inside the iframe so the renderer never re-parses CSS.
- New `TweaksPanel` component + `Sliders` toggle in the preview toolbar (off by default). Native HTML controls only — no new dependencies.
- Vitest covers `inferTweakType`, the message guard, and the new store actions.

## MVP scope (intentional gaps)

- Only top-level `:root { ... }` rules are scanned. Nested selectors, `:where(:root)`, vars inside `@media` queries, and `:root.dark` overrides are **not** extracted yet.
- Color picker only round-trips for hex sources. `oklch()` / `rgb()` / `hsl()` fall back to a live-editable text input — pulling in a CSS Color 4 conversion lib would breach the no-new-dep budget for a v0.
- iframe ↔ parent integration is left to manual QA; cross-context `postMessage` is awkward to assert from vitest. Unit tests cover the pieces on either side of the boundary.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 224 tests pass (8 new across runtime + store)
- [x] `pnpm lint` — no new errors (pre-existing complexity warnings unchanged)
- [ ] Manual: generate an artifact with `:root { --accent: #c96442; --gap: 16px; }` → toggle Tweaks → adjust color/slider → preview updates without re-generation
- [ ] Manual: switch between artifacts → vars list refreshes per artifact

## PRINCIPLES §5b

- **Compatibility**: ✅ Additive — older artifacts without `:root` vars get an empty panel + helpful message. Existing overlay behaviour unchanged.
- **Upgradeability**: ✅ Message envelope carries `__codesign: true` + typed `type` discriminator; new fields can be added without breaking older bundles.
- **No bloat**: ✅ Zero new dependencies. ~3 KB of runtime script + one component.
- **Elegance**: ✅ Inference lives next to the DOM that owns the values; renderer just renders.