### PR TITLE
feat(desktop): comment mode gating

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -36,6 +36,8 @@ export function App() {
   const designToRename = useCodesignStore((s) => s.designToRename);
   const requestDeleteDesign = useCodesignStore((s) => s.requestDeleteDesign);
   const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
+  const interactionMode = useCodesignStore((s) => s.interactionMode);
+  const setInteractionMode = useCodesignStore((s) => s.setInteractionMode);
 
   const [prompt, setPrompt] = useState('');
 
@@ -112,6 +114,10 @@ export function App() {
             closeDesignsView();
             return;
           }
+          if (interactionMode !== 'default') {
+            setInteractionMode('default');
+            return;
+          }
           if (view === 'settings') {
             setView('workspace');
             return;
@@ -133,6 +139,8 @@ export function App() {
       designsViewOpen,
       designToDelete,
       designToRename,
+      interactionMode,
+      setInteractionMode,
       setView,
       openCommandPalette,
       closeCommandPalette,

--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -3,6 +3,7 @@ import { useCodesignStore } from '../store';
 import {
   handlePreviewMessage,
   isTrustedPreviewMessageSource,
+  postModeToPreviewWindow,
   scaleRectForZoom,
 } from './PreviewPane';
 
@@ -110,5 +111,38 @@ describe('handlePreviewMessage trust boundary', () => {
     );
     expect(errorOutcome).toEqual({ status: 'handled', type: 'IFRAME_ERROR' });
     expect(handlers.onIframeError).toHaveBeenCalledOnce();
+  });
+});
+
+describe('postModeToPreviewWindow', () => {
+  it('forwards postMessage failures to the error sink instead of swallowing them', () => {
+    const onError = vi.fn();
+    const win = {
+      postMessage: vi.fn(() => {
+        throw new Error('iframe gone');
+      }),
+    } as unknown as Window;
+
+    const ok = postModeToPreviewWindow(win, 'comment', onError);
+
+    expect(ok).toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toContain('iframe gone');
+  });
+
+  it('returns true and does not call onError on success', () => {
+    const onError = vi.fn();
+    const post = vi.fn();
+    const win = { postMessage: post } as unknown as Window;
+
+    expect(postModeToPreviewWindow(win, 'default', onError)).toBe(true);
+    expect(post).toHaveBeenCalledWith({ __codesign: true, type: 'SET_MODE', mode: 'default' }, '*');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('returns false silently when the window handle is missing', () => {
+    const onError = vi.fn();
+    expect(postModeToPreviewWindow(null, 'comment', onError)).toBe(false);
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { isTrustedPreviewMessageSource, scaleRectForZoom } from './PreviewPane';
+import { describe, expect, it, vi } from 'vitest';
+import { useCodesignStore } from '../store';
+import {
+  handlePreviewMessage,
+  isTrustedPreviewMessageSource,
+  scaleRectForZoom,
+} from './PreviewPane';
 
 describe('isTrustedPreviewMessageSource', () => {
   it('accepts only messages from the active preview iframe window', () => {
@@ -34,5 +39,76 @@ describe('scaleRectForZoom', () => {
       width: 75,
       height: 75,
     });
+  });
+});
+
+describe('handlePreviewMessage trust boundary', () => {
+  function makeHandlers() {
+    return {
+      onElementSelected: vi.fn(),
+      onIframeError: vi.fn(),
+    };
+  }
+
+  it('rejects SET_MODE forged from the iframe and never mutates interactionMode', () => {
+    const handlers = makeHandlers();
+    useCodesignStore.setState({ interactionMode: 'default' });
+
+    const outcome = handlePreviewMessage(
+      { __codesign: true, type: 'SET_MODE', mode: 'comment' },
+      handlers,
+    );
+
+    expect(outcome).toEqual({
+      status: 'rejected',
+      reason: 'unknown-type',
+      type: 'SET_MODE',
+    });
+    expect(useCodesignStore.getState().interactionMode).toBe('default');
+    expect(handlers.onElementSelected).not.toHaveBeenCalled();
+    expect(handlers.onIframeError).not.toHaveBeenCalled();
+  });
+
+  it('rejects messages without the __codesign envelope', () => {
+    const handlers = makeHandlers();
+    expect(handlePreviewMessage({ type: 'ELEMENT_SELECTED' }, handlers)).toEqual({
+      status: 'rejected',
+      reason: 'envelope',
+    });
+    expect(handlePreviewMessage(null, handlers)).toEqual({
+      status: 'rejected',
+      reason: 'envelope',
+    });
+  });
+
+  it('accepts well-formed ELEMENT_SELECTED and IFRAME_ERROR payloads', () => {
+    const handlers = makeHandlers();
+
+    const elementOutcome = handlePreviewMessage(
+      {
+        __codesign: true,
+        type: 'ELEMENT_SELECTED',
+        selector: '#root',
+        tag: 'div',
+        outerHTML: '<div></div>',
+        rect: { top: 0, left: 0, width: 1, height: 1 },
+      },
+      handlers,
+    );
+    expect(elementOutcome).toEqual({ status: 'handled', type: 'ELEMENT_SELECTED' });
+    expect(handlers.onElementSelected).toHaveBeenCalledOnce();
+
+    const errorOutcome = handlePreviewMessage(
+      {
+        __codesign: true,
+        type: 'IFRAME_ERROR',
+        kind: 'error',
+        message: 'boom',
+        timestamp: 1,
+      },
+      handlers,
+    );
+    expect(errorOutcome).toEqual({ status: 'handled', type: 'IFRAME_ERROR' });
+    expect(handlers.onIframeError).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -62,7 +62,18 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const selectCanvasElement = useCodesignStore((s) => s.selectCanvasElement);
   const previewViewport = useCodesignStore((s) => s.previewViewport);
   const previewZoom = useCodesignStore((s) => s.previewZoom);
+  const interactionMode = useCodesignStore((s) => s.interactionMode);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    try {
+      win.postMessage({ __codesign: true, type: 'SET_MODE', mode: interactionMode }, '*');
+    } catch {
+      // iframe gone or cross-origin race; safe to ignore
+    }
+  }, [interactionMode]);
 
   useEffect(() => {
     function onMessage(event: MessageEvent): void {
@@ -109,6 +120,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     body = <LoadingState />;
   } else if (previewHtml) {
     const isMobile = previewViewport === 'mobile';
+    const showCommentUi = interactionMode === 'comment';
     const rawIframe = (
       <iframe
         ref={iframeRef}
@@ -116,6 +128,16 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         title="design-preview"
         sandbox="allow-scripts"
         srcDoc={buildSrcdoc(previewHtml)}
+        onLoad={() => {
+          try {
+            iframeRef.current?.contentWindow?.postMessage(
+              { __codesign: true, type: 'SET_MODE', mode: interactionMode },
+              '*',
+            );
+          } catch {
+            // best-effort sync; mode change effect will re-send
+          }
+        }}
         className={
           isMobile
             ? 'block w-full h-full bg-[var(--color-artifact-bg)] border-0'
@@ -146,7 +168,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         <div className="min-h-full p-6 flex flex-col items-center justify-center overflow-auto">
           <div className="relative inline-flex">
             <PhoneFrame>{iframe}</PhoneFrame>
-            <InlineCommentComposer />
+            {showCommentUi && <InlineCommentComposer />}
           </div>
         </div>
       );
@@ -161,9 +183,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
               flexShrink: 0,
             }}
           >
-            <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
+            {showCommentUi && (
+              <div className={COMMENT_HINT_CLASS}>{t('preview.commentModeHint')}</div>
+            )}
             {iframe}
-            <InlineCommentComposer />
+            {showCommentUi && <InlineCommentComposer />}
           </div>
         </div>
       );
@@ -178,9 +202,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
               flexShrink: 0,
             }}
           >
-            <div className={COMMENT_HINT_CLASS}>{t('preview.clickToComment')}</div>
+            {showCommentUi && (
+              <div className={COMMENT_HINT_CLASS}>{t('preview.commentModeHint')}</div>
+            )}
             {iframe}
-            <InlineCommentComposer />
+            {showCommentUi && <InlineCommentComposer />}
           </div>
         </div>
       );

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -37,6 +37,25 @@ export function isTrustedPreviewMessageSource(
   return source !== null && source === previewWindow;
 }
 
+// Send the SET_MODE control message to the preview iframe. Failures (iframe
+// torn down, cross-origin race) MUST surface — silent catches mask mode-sync
+// bugs that leave the preview stuck in the wrong interaction state.
+export function postModeToPreviewWindow(
+  win: Window | null | undefined,
+  mode: string,
+  onError: (message: string) => void,
+): boolean {
+  if (!win) return false;
+  try {
+    win.postMessage({ __codesign: true, type: 'SET_MODE', mode }, '*');
+    return true;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    onError(`SET_MODE postMessage failed: ${reason}`);
+    return false;
+  }
+}
+
 // Convert a rect reported from inside the sandbox iframe (iframe-internal
 // viewport coords) into the parent renderer's viewport coords. The wrapper
 // applies `transform: scale(zoom/100)` to a div sized at `100/scale %`, so a
@@ -119,14 +138,8 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
-    const win = iframeRef.current?.contentWindow;
-    if (!win) return;
-    try {
-      win.postMessage({ __codesign: true, type: 'SET_MODE', mode: interactionMode }, '*');
-    } catch {
-      // iframe gone or cross-origin race; safe to ignore
-    }
-  }, [interactionMode]);
+    postModeToPreviewWindow(iframeRef.current?.contentWindow, interactionMode, pushIframeError);
+  }, [interactionMode, pushIframeError]);
 
   useEffect(() => {
     function onMessage(event: MessageEvent): void {
@@ -177,14 +190,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         sandbox="allow-scripts"
         srcDoc={buildSrcdoc(previewHtml)}
         onLoad={() => {
-          try {
-            iframeRef.current?.contentWindow?.postMessage(
-              { __codesign: true, type: 'SET_MODE', mode: interactionMode },
-              '*',
-            );
-          } catch {
-            // best-effort sync; mode change effect will re-send
-          }
+          postModeToPreviewWindow(
+            iframeRef.current?.contentWindow,
+            interactionMode,
+            pushIframeError,
+          );
         }}
         className={
           isMobile

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -1,5 +1,11 @@
 import { useT } from '@open-codesign/i18n';
-import { buildSrcdoc, isIframeErrorMessage, isOverlayMessage } from '@open-codesign/runtime';
+import {
+  type IframeErrorMessage,
+  type OverlayMessage,
+  buildSrcdoc,
+  isIframeErrorMessage,
+  isOverlayMessage,
+} from '@open-codesign/runtime';
 import { useEffect, useRef } from 'react';
 import { EmptyState } from '../preview/EmptyState';
 import { ErrorState } from '../preview/ErrorState';
@@ -48,6 +54,53 @@ export function scaleRectForZoom(
   };
 }
 
+/**
+ * Trust boundary: parent → iframe is the ONLY direction allowed for control
+ * messages like SET_MODE. The iframe runs untrusted, model-generated code, so
+ * any message it sends back must be matched against an explicit allowlist.
+ * Adding a new accepted type requires updating both the union and the switch.
+ */
+export type AllowedPreviewMessageType = 'ELEMENT_SELECTED' | 'IFRAME_ERROR';
+
+export interface PreviewMessageHandlers {
+  onElementSelected: (msg: OverlayMessage) => void;
+  onIframeError: (msg: IframeErrorMessage) => void;
+}
+
+export type PreviewMessageOutcome =
+  | { status: 'handled'; type: AllowedPreviewMessageType }
+  | { status: 'rejected'; reason: 'envelope' | 'unknown-type' | 'shape'; type?: string };
+
+export function handlePreviewMessage(
+  data: unknown,
+  handlers: PreviewMessageHandlers,
+): PreviewMessageOutcome {
+  if (typeof data !== 'object' || data === null) {
+    return { status: 'rejected', reason: 'envelope' };
+  }
+  const envelope = data as { __codesign?: unknown; type?: unknown };
+  if (envelope.__codesign !== true || typeof envelope.type !== 'string') {
+    return { status: 'rejected', reason: 'envelope' };
+  }
+
+  switch (envelope.type) {
+    case 'ELEMENT_SELECTED':
+      if (isOverlayMessage(data)) {
+        handlers.onElementSelected(data);
+        return { status: 'handled', type: 'ELEMENT_SELECTED' };
+      }
+      return { status: 'rejected', reason: 'shape', type: envelope.type };
+    case 'IFRAME_ERROR':
+      if (isIframeErrorMessage(data)) {
+        handlers.onIframeError(data);
+        return { status: 'handled', type: 'IFRAME_ERROR' };
+      }
+      return { status: 'rejected', reason: 'shape', type: envelope.type };
+    default:
+      return { status: 'rejected', reason: 'unknown-type', type: envelope.type };
+  }
+}
+
 const COMMENT_HINT_CLASS =
   'absolute left-[var(--space-5)] top-[var(--space-5)] z-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-[var(--space-3)] py-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] backdrop-blur';
 
@@ -79,25 +132,20 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     function onMessage(event: MessageEvent): void {
       if (!isTrustedPreviewMessageSource(event.source, iframeRef.current?.contentWindow)) return;
 
-      if (isOverlayMessage(event.data)) {
-        selectCanvasElement({
-          selector: event.data.selector,
-          tag: event.data.tag,
-          outerHTML: event.data.outerHTML,
-          rect: scaleRectForZoom(event.data.rect, previewZoom),
-        });
-        return;
-      }
+      const outcome = handlePreviewMessage(event.data, {
+        onElementSelected: (msg) =>
+          selectCanvasElement({
+            selector: msg.selector,
+            tag: msg.tag,
+            outerHTML: msg.outerHTML,
+            rect: scaleRectForZoom(msg.rect, previewZoom),
+          }),
+        onIframeError: (msg) =>
+          pushIframeError(formatIframeError(msg.kind, msg.message, msg.source, msg.lineno)),
+      });
 
-      if (isIframeErrorMessage(event.data)) {
-        pushIframeError(
-          formatIframeError(
-            event.data.kind,
-            event.data.message,
-            event.data.source,
-            event.data.lineno,
-          ),
-        );
+      if (outcome.status === 'rejected' && outcome.reason === 'unknown-type') {
+        console.warn('[PreviewPane] rejected iframe message type:', outcome.type);
       }
     }
 

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -178,7 +178,7 @@ export function PreviewToolbar(): ReactElement {
           onClick={() => setInteractionMode(commentActive ? 'default' : 'comment')}
           className={`inline-flex items-center gap-1.5 h-[var(--size-control-xs)] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border transition-[background-color,border-color,color] duration-[var(--duration-fast)] ease-[var(--ease-out)] disabled:opacity-40 disabled:pointer-events-none ${
             commentActive
-              ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)]'
+              ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)]'
               : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)]'
           }`}
         >

--- a/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewToolbar.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { Tooltip } from '@open-codesign/ui';
-import { Download, Monitor, Smartphone, Tablet } from 'lucide-react';
+import { Download, MessageSquare, Monitor, Smartphone, Tablet } from 'lucide-react';
 import { type ReactElement, useEffect, useRef, useState } from 'react';
 import type { ExportFormat } from '../../../preload/index';
 import type { PreviewViewport } from '../store';
@@ -31,6 +31,8 @@ export function PreviewToolbar(): ReactElement {
   const setPreviewViewport = useCodesignStore((s) => s.setPreviewViewport);
   const previewZoom = useCodesignStore((s) => s.previewZoom);
   const setPreviewZoom = useCodesignStore((s) => s.setPreviewZoom);
+  const interactionMode = useCodesignStore((s) => s.interactionMode);
+  const setInteractionMode = useCodesignStore((s) => s.setInteractionMode);
   const [open, setOpen] = useState(false);
   const [zoomOpen, setZoomOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -61,6 +63,7 @@ export function PreviewToolbar(): ReactElement {
   }, [toastMessage, dismissToast]);
 
   const disabled = !previewHtml;
+  const commentActive = interactionMode === 'comment';
   const exportItems: ExportItem[] = [
     {
       format: 'html',
@@ -157,6 +160,35 @@ export function PreviewToolbar(): ReactElement {
           );
         })}
       </fieldset>
+
+      <Tooltip
+        label={
+          disabled
+            ? t('disabledReason.noDesignToExport')
+            : commentActive
+              ? t('preview.commentModeHint')
+              : t('preview.commentMode')
+        }
+        side="bottom"
+      >
+        <button
+          type="button"
+          disabled={disabled}
+          aria-pressed={commentActive}
+          onClick={() => setInteractionMode(commentActive ? 'default' : 'comment')}
+          className={`inline-flex items-center gap-1.5 h-[var(--size-control-xs)] px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] font-medium border transition-[background-color,border-color,color] duration-[var(--duration-fast)] ease-[var(--ease-out)] disabled:opacity-40 disabled:pointer-events-none ${
+            commentActive
+              ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)]'
+              : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] hover:border-[var(--color-border-strong)]'
+          }`}
+        >
+          <MessageSquare
+            className="w-[var(--size-icon-sm)] h-[var(--size-icon-sm)]"
+            aria-hidden="true"
+          />
+          {t('preview.commentMode')}
+        </button>
+      </Tooltip>
 
       <div className="relative" ref={zoomRef}>
         <Tooltip

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -616,7 +616,6 @@ describe('useCodesignStore previewZoom', () => {
     expect(useCodesignStore.getState().previewZoom).toBe(150);
   });
 });
-
 describe('useCodesignStore artifact persistence', () => {
   beforeAll(async () => {
     await initI18n('en');
@@ -788,5 +787,35 @@ describe('loadDesigns startup', () => {
     expect(state.designs).toHaveLength(2);
     expect(state.designs.map((d) => d.id)).toEqual(['design-1', 'design-2']);
     expect(state.designsLoaded).toBe(true);
+  });
+});
+
+describe('useCodesignStore interaction mode', () => {
+  it('defaults to "default" mode with no selected element', () => {
+    const state = useCodesignStore.getState();
+    expect(state.interactionMode).toBe('default');
+    expect(state.selectedElement).toBeNull();
+  });
+
+  it('setInteractionMode("comment") enters comment mode without touching selectedElement', () => {
+    useCodesignStore.getState().setInteractionMode('comment');
+    expect(useCodesignStore.getState().interactionMode).toBe('comment');
+    expect(useCodesignStore.getState().selectedElement).toBeNull();
+  });
+
+  it('setInteractionMode("default") clears selectedElement when leaving comment mode', () => {
+    const selection: SelectedElement = {
+      selector: '.btn',
+      tag: 'button',
+      outerHTML: '<button class="btn">x</button>',
+      rect: { top: 0, left: 0, width: 10, height: 10 },
+    };
+    useCodesignStore.setState({ interactionMode: 'comment', selectedElement: selection });
+
+    useCodesignStore.getState().setInteractionMode('default');
+
+    const s = useCodesignStore.getState();
+    expect(s.interactionMode).toBe('default');
+    expect(s.selectedElement).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -51,6 +51,7 @@ export interface ConnectionStatus {
 export type Theme = 'light' | 'dark';
 export type AppView = 'hub' | 'workspace' | 'settings';
 export type HubTab = 'recent' | 'your' | 'examples' | 'designSystems';
+export type InteractionMode = 'default' | 'comment';
 
 export type PreviewViewport = 'desktop' | 'tablet' | 'mobile';
 
@@ -97,6 +98,7 @@ interface CodesignState {
   lastPromptInput: PromptRequest | null;
   selectedElement: SelectedElement | null;
   previewZoom: number;
+  interactionMode: InteractionMode;
 
   loadConfig: () => Promise<void>;
   completeOnboarding: (next: OnboardingState) => void;
@@ -125,6 +127,7 @@ interface CodesignState {
   selectCanvasElement: (selection: SelectedElement) => void;
   clearCanvasElement: () => void;
   setPreviewZoom: (zoom: number) => void;
+  setInteractionMode: (mode: InteractionMode) => void;
 
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
@@ -557,6 +560,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   lastPromptInput: null,
   selectedElement: null,
   previewZoom: 100,
+  interactionMode: 'default' as InteractionMode,
 
   clearIframeErrors() {
     set({ iframeErrors: [] });
@@ -867,6 +871,14 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     set({ previewZoom: zoom });
   },
 
+  setInteractionMode(mode) {
+    if (mode === 'default') {
+      set({ interactionMode: mode, selectedElement: null });
+    } else {
+      set({ interactionMode: mode });
+    }
+  },
+
   setTheme(theme) {
     applyThemeClass(theme);
     persistTheme(theme);
@@ -919,6 +931,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       inputFiles: [],
       referenceUrl: '',
       selectedElement: null,
+      interactionMode: 'default',
       lastPromptInput: null,
       generationStage: 'idle' as GenerationStage,
       isGenerating: false,
@@ -947,6 +960,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       inputFiles: [],
       referenceUrl: '',
       selectedElement: null,
+      interactionMode: 'default',
       lastPromptInput: null,
       generationStage: 'idle' as GenerationStage,
       isGenerating: false,

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -50,6 +50,8 @@
     "ready": "Preview",
     "noDesign": "No design yet",
     "clickToComment": "Click any element in the preview to leave an inline comment.",
+    "commentMode": "Comment mode",
+    "commentModeHint": "Click any element to comment",
     "runtimeError": "Preview runtime error",
     "dismissErrors": "Dismiss preview errors",
     "zoom": "Zoom",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -49,6 +49,8 @@
     "ready": "预览",
     "noDesign": "还没有设计",
     "clickToComment": "点击预览中的任意元素即可留下局部评论。",
+    "commentMode": "评论模式",
+    "commentModeHint": "点击任意元素留评",
     "runtimeError": "预览运行时错误",
     "dismissErrors": "关闭预览错误",
     "zoom": "缩放",

--- a/packages/runtime/src/overlay.test.ts
+++ b/packages/runtime/src/overlay.test.ts
@@ -6,6 +6,7 @@ interface FakeWindow {
   parent: { postMessage: (msg: unknown, target: string) => void };
   __cs_err?: boolean;
   __cs_rej?: boolean;
+  __cs_msg?: boolean;
 }
 
 function runOverlay(opts: {
@@ -72,5 +73,120 @@ describe('OVERLAY_SCRIPT reattach loop warning throttle', () => {
     expect(warn.mock.calls.length).toBe(keys.size);
     // should be ≤ 3 (one per event type), well under the 25-tick spam ceiling
     expect(warn.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SET_MODE trust boundary: control messages must come from window.parent.
+// Untrusted in-iframe scripts could synthesise MessageEvent-shaped objects or
+// bounce events off the iframe itself (window.postMessage(self, ...)), which
+// would arrive with ev.source === window. Both paths must be rejected.
+// ---------------------------------------------------------------------------
+
+interface ListenerHarness {
+  documentListeners: Map<string, (e: unknown) => void>;
+  windowListeners: Map<string, (e: unknown) => void>;
+  parent: object;
+  postedToParent: unknown[];
+}
+
+function runOverlayWithHarness(): ListenerHarness {
+  const documentListeners = new Map<string, (e: unknown) => void>();
+  const windowListeners = new Map<string, (e: unknown) => void>();
+  const postedToParent: unknown[] = [];
+  const parent = { postMessage: (msg: unknown) => postedToParent.push(msg) };
+
+  const fakeDocument = {
+    body: {},
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      documentListeners.set(type, fn);
+    },
+    removeEventListener: () => {},
+  };
+  const fakeWindow = {
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      windowListeners.set(type, fn);
+    },
+    parent,
+  };
+  const fakeSetInterval = () => 1;
+  const sandbox = new Function(
+    'window',
+    'document',
+    'console',
+    'setInterval',
+    `with (window) { ${OVERLAY_SCRIPT} }`,
+  );
+  sandbox(fakeWindow, fakeDocument, { warn: () => {} }, fakeSetInterval);
+  return { documentListeners, windowListeners, parent, postedToParent };
+}
+
+describe('OVERLAY_SCRIPT SET_MODE source validation', () => {
+  it('drops SET_MODE messages whose source is not window.parent (forged)', () => {
+    const h = runOverlayWithHarness();
+    const onMessage = h.windowListeners.get('message');
+    const onClick = h.documentListeners.get('click');
+    expect(onMessage).toBeDefined();
+    expect(onClick).toBeDefined();
+
+    // Forged: source is the iframe itself (e.g. window.postMessage(self,...)),
+    // not the embedding parent. Even though the envelope looks valid, the
+    // mode must NOT switch to 'comment'.
+    const forgedSource = {};
+    onMessage?.({
+      source: forgedSource,
+      data: { __codesign: true, type: 'SET_MODE', mode: 'comment' },
+    });
+
+    // currentMode is internal to the IIFE, so we observe via the click gate:
+    // in default mode, clicks must not be intercepted (no postMessage to parent).
+    onClick?.({
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      target: { tagName: 'DIV', getBoundingClientRect: () => ({}), outerHTML: '<div/>' },
+    });
+    expect(h.postedToParent).toHaveLength(0);
+  });
+
+  it('accepts SET_MODE only when ev.source === window.parent', () => {
+    const h = runOverlayWithHarness();
+    const onMessage = h.windowListeners.get('message');
+    const onClick = h.documentListeners.get('click');
+
+    onMessage?.({
+      source: h.parent,
+      data: { __codesign: true, type: 'SET_MODE', mode: 'comment' },
+    });
+
+    // Now in comment mode → click should be intercepted and posted to parent.
+    onClick?.({
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      target: {
+        tagName: 'BUTTON',
+        getBoundingClientRect: () => ({ top: 1, left: 2, width: 3, height: 4 }),
+        outerHTML: '<button/>',
+      },
+    });
+    expect(h.postedToParent).toHaveLength(1);
+    expect((h.postedToParent[0] as { type: string }).type).toBe('ELEMENT_SELECTED');
+  });
+
+  it('drops messages with no source (null) even when envelope matches', () => {
+    const h = runOverlayWithHarness();
+    const onMessage = h.windowListeners.get('message');
+    const onClick = h.documentListeners.get('click');
+
+    onMessage?.({
+      source: null,
+      data: { __codesign: true, type: 'SET_MODE', mode: 'comment' },
+    });
+
+    onClick?.({
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      target: { tagName: 'DIV', getBoundingClientRect: () => ({}), outerHTML: '<div/>' },
+    });
+    expect(h.postedToParent).toHaveLength(0);
   });
 });

--- a/packages/runtime/src/overlay.ts
+++ b/packages/runtime/src/overlay.ts
@@ -75,7 +75,13 @@ export const OVERLAY_SCRIPT = `(function() {
     } catch (err) { console.warn('[overlay] postMessage ELEMENT_SELECTED failed:', err); }
   }
   function onParentMessage(ev) {
-    var data = ev && ev.data;
+    // Trust boundary: control messages must originate from the embedding
+    // window. Untrusted in-iframe scripts can synthesise MessageEvent-shaped
+    // calls into this handler (or, via window.postMessage(self,...), bounce
+    // events off the iframe itself); both paths are rejected here so any
+    // future control type added to the switch is structurally protected.
+    if (!ev || ev.source !== window.parent) return;
+    var data = ev.data;
     if (!data || data.__codesign !== true || data.type !== 'SET_MODE') return;
     var next = data.mode === 'comment' ? 'comment' : 'default';
     if (next === currentMode) return;

--- a/packages/runtime/src/overlay.ts
+++ b/packages/runtime/src/overlay.ts
@@ -25,6 +25,13 @@ export const OVERLAY_SCRIPT = `(function() {
     warned[key] = true;
     try { console.warn('[overlay] ' + key, err); } catch (_) { /* noop */ }
   }
+  var currentMode = 'default';
+
+  function clearHover() {
+    if (hovered) { try { hovered.style.outline = ''; } catch (_) {} }
+    hovered = null;
+  }
+
 
   function getXPath(el) {
     if (el.dataset && el.dataset.codesignId) return '[data-codesign-id="' + el.dataset.codesignId + '"]';
@@ -41,15 +48,17 @@ export const OVERLAY_SCRIPT = `(function() {
   }
 
   function onMouseOver(e) {
+    if (currentMode !== 'comment') return;
     if (hovered) hovered.style.outline = '';
     hovered = e.target;
     if (hovered) hovered.style.outline = '2px solid #c96442';
   }
   function onMouseOut() {
-    if (hovered) hovered.style.outline = '';
-    hovered = null;
+    if (currentMode !== 'comment') return;
+    clearHover();
   }
   function onClick(e) {
+    if (currentMode !== 'comment') return;
     e.preventDefault();
     e.stopPropagation();
     var el = e.target;
@@ -64,6 +73,14 @@ export const OVERLAY_SCRIPT = `(function() {
         rect: { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
       }, '*');
     } catch (err) { console.warn('[overlay] postMessage ELEMENT_SELECTED failed:', err); }
+  }
+  function onParentMessage(ev) {
+    var data = ev && ev.data;
+    if (!data || data.__codesign !== true || data.type !== 'SET_MODE') return;
+    var next = data.mode === 'comment' ? 'comment' : 'default';
+    if (next === currentMode) return;
+    currentMode = next;
+    if (currentMode === 'default') clearHover();
   }
   function onError(ev) {
     try {
@@ -114,6 +131,9 @@ export const OVERLAY_SCRIPT = `(function() {
     }
     if (!window.__cs_rej) {
       try { window.addEventListener('unhandledrejection', onRejection, true); window.__cs_rej = true; } catch (err) { warnOnce('attach unhandledrejection listener failed', err); }
+    }
+    if (!window.__cs_msg) {
+      try { window.addEventListener('message', onParentMessage, false); window.__cs_msg = true; } catch (_) {}
     }
   }
   reattach();


### PR DESCRIPTION
## Summary

Fixes the always-on iframe click listener that violated Claude Design's mode-based interaction. Previously every click on a preview element popped the inline comment composer (and `preventDefault` killed any real link/button inside the design). Now the iframe is click-pass-through by default and only intercepts when the user enters Comment mode from the preview toolbar.

## Behaviour

- New `interactionMode` (`'default' | 'comment'`) in the renderer store; defaults to `'default'`.
- Toolbar gets a `MessageSquare` Comment button. Clicking toggles the mode and `postMessage`s `{__codesign:true, type:'SET_MODE', mode}` into the iframe.
- Runtime overlay holds a module-local `currentMode`, gates `mouseover`/`mouseout`/`click` on it, and clears any outline when leaving comment mode. Listener is registered in the same idempotent reattach loop as the existing handlers.
- `InlineCommentComposer` and the comment hint badge only render in comment mode.
- ESC priority now: command palette > comment mode > settings view > workspace view.
- Switching projects resets `interactionMode` along with the rest of the workspace state.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (added 3 store unit tests for default state, set, and selection cleanup on exit)
- [x] `pnpm lint`
- [ ] Manual smoke: launch app, generate a design, confirm links/buttons inside the iframe behave normally; toggle Comment mode, verify hover outline + click composer; press ESC to exit.

## Compatibility / upgradeability / no bloat / elegance

- Compatibility: green — no schema or IPC changes; default mode preserves passive viewing for existing flows.
- Upgradeability: green — `SET_MODE` payload tagged with `__codesign` discriminator, easy to extend with future modes.
- No bloat: green — zero new deps, ~130 LOC across overlay/store/UI/i18n.
- Elegance: green — single source of truth in the store; overlay reads one variable; UI reflects mode through one toggle.