### PR TITLE
fix(desktop): preserve artifact dark theme in iframe

### DIFF
--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -198,9 +198,9 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         }}
         className={
           isMobile
-            ? 'block w-full h-full bg-[var(--color-artifact-bg)] border-0'
-            : 'w-full h-full bg-[var(--color-artifact-bg)] rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
-        }
+            ? 'block w-full h-full bg-transparent border-0'
+            : 'w-full h-full bg-transparent rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
+}
       />
     );
     const scale = previewZoom / 100;

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -200,7 +200,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
           isMobile
             ? 'block w-full h-full bg-transparent border-0'
             : 'w-full h-full bg-transparent rounded-[var(--radius-2xl)] shadow-[var(--shadow-card)] border border-[var(--color-border)]'
-}
+        }
       />
     );
     const scale = previewZoom / 100;

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildSrcdoc } from './index';
 
+const BODY_OPEN_RE = /<body[^>]*>/i;
+
 describe('buildSrcdoc', () => {
   it('wraps a fragment in a full document', () => {
     const out = buildSrcdoc('<div>hi</div>');
@@ -67,6 +69,59 @@ describe('buildSrcdoc', () => {
     expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
     expect(out).toContain('<div>plain</div>');
     expect(out).toContain('ELEMENT_SELECTED');
+  });
+
+  describe('body tag shape normalization', () => {
+    it('shape 1: leaves matched <body>...</body> intact', () => {
+      const html = '<html><head></head><body><p>both</p></body></html>';
+      const out = buildSrcdoc(html);
+      expect(out).toContain('<p>both</p>');
+      expect(out.match(/<body[^>]*>/gi)?.length).toBe(1);
+      expect(out.match(/<\/body\s*>/gi)?.length).toBe(1);
+      expect(out.indexOf('<body')).toBeLessThan(out.indexOf('<p>both</p>'));
+      expect(out.indexOf('<p>both</p>')).toBeLessThan(out.indexOf('</body>'));
+    });
+
+    it('shape 2: appends </body> when only opener is present', () => {
+      const html = '<html><head></head><body><p>open only</p>';
+      const out = buildSrcdoc(html);
+      expect(out.match(/<body[^>]*>/gi)?.length).toBe(1);
+      expect(out.match(/<\/body\s*>/gi)?.length).toBe(1);
+      expect(out.indexOf('<p>open only</p>')).toBeLessThan(out.indexOf('</body>'));
+      expect(out.indexOf('ELEMENT_SELECTED')).toBeLessThan(out.indexOf('</body>'));
+    });
+
+    it('shape 3: injects <body> opener before content when only </body> is present', () => {
+      const html = '<p>close only</p></body>';
+      const out = buildSrcdoc(html);
+      const bodyOpen = out.search(BODY_OPEN_RE);
+      const contentIdx = out.indexOf('<p>close only</p>');
+      const bodyClose = out.indexOf('</body>');
+      expect(bodyOpen).toBeGreaterThanOrEqual(0);
+      expect(bodyOpen).toBeLessThan(contentIdx);
+      expect(contentIdx).toBeLessThan(bodyClose);
+      expect(out.match(/<body[^>]*>/gi)?.length).toBe(1);
+      expect(out.match(/<\/body\s*>/gi)?.length).toBe(1);
+    });
+
+    it('shape 3: injects <body> after <head> when </body> present without opener', () => {
+      const html = '<html><head><title>t</title></head><p>x</p></body></html>';
+      const out = buildSrcdoc(html);
+      const headClose = out.indexOf('</head>');
+      const bodyOpen = out.search(BODY_OPEN_RE);
+      const contentIdx = out.indexOf('<p>x</p>');
+      expect(headClose).toBeGreaterThanOrEqual(0);
+      expect(bodyOpen).toBeGreaterThan(headClose);
+      expect(bodyOpen).toBeLessThan(contentIdx);
+    });
+
+    it('shape 4: wraps content in <body>...</body> when neither tag is present', () => {
+      const out = buildSrcdoc('<div>none</div>');
+      expect(out).toContain('<body>');
+      expect(out).toContain('</body>');
+      expect(out.indexOf('<body>')).toBeLessThan(out.indexOf('<div>none</div>'));
+      expect(out.indexOf('<div>none</div>')).toBeLessThan(out.indexOf('</body>'));
+    });
   });
 
   it('injects baseline into a full document with <head>', () => {

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -45,4 +45,30 @@ describe('buildSrcdoc', () => {
     expect(out).toContain('background:#ffffff');
     expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('background: #000'));
   });
+
+  it('wraps a body-only document (no <html>/<head>) and injects baseline', () => {
+    const html = '<body><style>body { background: #111 }</style><p>x</p></body>';
+    const out = buildSrcdoc(html);
+    expect(out).toContain('background:#ffffff');
+    expect(out).toContain('<p>x</p>');
+    expect(out).toContain('ELEMENT_SELECTED');
+    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('background: #111'));
+    // overlay script must land inside the body, before </body>
+    expect(out.indexOf('ELEMENT_SELECTED')).toBeLessThan(out.indexOf('</body>'));
+  });
+
+  it('wraps a plain fragment with no html/head/body and injects baseline', () => {
+    const out = buildSrcdoc('<div>plain</div>');
+    expect(out).toContain('<!doctype html>');
+    expect(out).toContain('background:#ffffff');
+    expect(out).toContain('<div>plain</div>');
+    expect(out).toContain('ELEMENT_SELECTED');
+  });
+
+  it('injects baseline into a full document with <head>', () => {
+    const html = '<!doctype html><html><head><title>t</title></head><body>y</body></html>';
+    const out = buildSrcdoc(html);
+    expect(out).toContain('background:#ffffff');
+    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('<title>t</title>'));
+  });
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -115,6 +115,44 @@ describe('buildSrcdoc', () => {
       expect(bodyOpen).toBeLessThan(contentIdx);
     });
 
+    it('shape 2 with </html>: inserts </body> BEFORE </html>, not after', () => {
+      const html = '<html><head></head><body><p>open only</p></html>';
+      const out = buildSrcdoc(html);
+      const bodyClose = out.indexOf('</body>');
+      const htmlClose = out.indexOf('</html>');
+      expect(bodyClose).toBeGreaterThanOrEqual(0);
+      expect(htmlClose).toBeGreaterThan(bodyClose);
+      expect(out).not.toMatch(/<\/html\s*>[\s\S]*<\/body\s*>/i);
+    });
+
+    it('shape 4 with <html>...</html> shell: <body> after <html>, </body> before </html>', () => {
+      const html = '<html><p>shell only</p></html>';
+      const out = buildSrcdoc(html);
+      const htmlOpen = out.search(/<html[^>]*>/i);
+      const bodyOpen = out.search(BODY_OPEN_RE);
+      const content = out.indexOf('<p>shell only</p>');
+      const bodyClose = out.indexOf('</body>');
+      const htmlClose = out.indexOf('</html>');
+      expect(htmlOpen).toBeLessThan(bodyOpen);
+      expect(bodyOpen).toBeLessThan(content);
+      expect(content).toBeLessThan(bodyClose);
+      expect(bodyClose).toBeLessThan(htmlClose);
+    });
+
+    it('shape 4 with </head> + </html>: <body> after </head>, </body> before </html>', () => {
+      const html = '<html><head><title>t</title></head><p>x</p></html>';
+      const out = buildSrcdoc(html);
+      const headClose = out.indexOf('</head>');
+      const bodyOpen = out.search(BODY_OPEN_RE);
+      const content = out.indexOf('<p>x</p>');
+      const bodyClose = out.indexOf('</body>');
+      const htmlClose = out.indexOf('</html>');
+      expect(headClose).toBeLessThan(bodyOpen);
+      expect(bodyOpen).toBeLessThan(content);
+      expect(content).toBeLessThan(bodyClose);
+      expect(bodyClose).toBeLessThan(htmlClose);
+    });
+
     it('shape 4: wraps content in <body>...</body> when neither tag is present', () => {
       const out = buildSrcdoc('<div>none</div>');
       expect(out).toContain('<body>');

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -22,4 +22,27 @@ describe('buildSrcdoc', () => {
     const out = buildSrcdoc(html);
     expect(out).not.toContain('Content-Security-Policy');
   });
+
+  it('injects baseline white bg before artifact head styles so artifact dark body bg wins', () => {
+    const html =
+      '<html><head><style>body { background: #0a0a0a; color: white; }</style></head><body><div>dark</div></body></html>';
+    const out = buildSrcdoc(html);
+    const baselineIdx = out.indexOf('background:#ffffff');
+    const artifactIdx = out.indexOf('background: #0a0a0a');
+    expect(baselineIdx).toBeGreaterThanOrEqual(0);
+    expect(artifactIdx).toBeGreaterThanOrEqual(0);
+    expect(baselineIdx).toBeLessThan(artifactIdx);
+  });
+
+  it('injects baseline bg into a fragment template', () => {
+    const out = buildSrcdoc('<div>hi</div>');
+    expect(out).toContain('background:#ffffff');
+  });
+
+  it('synthesises a head when artifact has <html> but no <head>', () => {
+    const html = '<html><body><style>body { background: #000 }</style>x</body></html>';
+    const out = buildSrcdoc(html);
+    expect(out).toContain('background:#ffffff');
+    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('background: #000'));
+  });
 });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -23,11 +23,11 @@ describe('buildSrcdoc', () => {
     expect(out).not.toContain('Content-Security-Policy');
   });
 
-  it('injects baseline white bg before artifact head styles so artifact dark body bg wins', () => {
+  it('injects baseline artifact-bg token before artifact head styles so artifact dark body bg wins', () => {
     const html =
       '<html><head><style>body { background: #0a0a0a; color: white; }</style></head><body><div>dark</div></body></html>';
     const out = buildSrcdoc(html);
-    const baselineIdx = out.indexOf('background:#ffffff');
+    const baselineIdx = out.indexOf('background:var(--color-artifact-bg, #ffffff)');
     const artifactIdx = out.indexOf('background: #0a0a0a');
     expect(baselineIdx).toBeGreaterThanOrEqual(0);
     expect(artifactIdx).toBeGreaterThanOrEqual(0);
@@ -36,23 +36,27 @@ describe('buildSrcdoc', () => {
 
   it('injects baseline bg into a fragment template', () => {
     const out = buildSrcdoc('<div>hi</div>');
-    expect(out).toContain('background:#ffffff');
+    expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
   });
 
   it('synthesises a head when artifact has <html> but no <head>', () => {
     const html = '<html><body><style>body { background: #000 }</style>x</body></html>';
     const out = buildSrcdoc(html);
-    expect(out).toContain('background:#ffffff');
-    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('background: #000'));
+    expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
+    expect(out.indexOf('background:var(--color-artifact-bg, #ffffff)')).toBeLessThan(
+      out.indexOf('background: #000'),
+    );
   });
 
   it('wraps a body-only document (no <html>/<head>) and injects baseline', () => {
     const html = '<body><style>body { background: #111 }</style><p>x</p></body>';
     const out = buildSrcdoc(html);
-    expect(out).toContain('background:#ffffff');
+    expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
     expect(out).toContain('<p>x</p>');
     expect(out).toContain('ELEMENT_SELECTED');
-    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('background: #111'));
+    expect(out.indexOf('background:var(--color-artifact-bg, #ffffff)')).toBeLessThan(
+      out.indexOf('background: #111'),
+    );
     // overlay script must land inside the body, before </body>
     expect(out.indexOf('ELEMENT_SELECTED')).toBeLessThan(out.indexOf('</body>'));
   });
@@ -60,7 +64,7 @@ describe('buildSrcdoc', () => {
   it('wraps a plain fragment with no html/head/body and injects baseline', () => {
     const out = buildSrcdoc('<div>plain</div>');
     expect(out).toContain('<!doctype html>');
-    expect(out).toContain('background:#ffffff');
+    expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
     expect(out).toContain('<div>plain</div>');
     expect(out).toContain('ELEMENT_SELECTED');
   });
@@ -68,7 +72,9 @@ describe('buildSrcdoc', () => {
   it('injects baseline into a full document with <head>', () => {
     const html = '<!doctype html><html><head><title>t</title></head><body>y</body></html>';
     const out = buildSrcdoc(html);
-    expect(out).toContain('background:#ffffff');
-    expect(out.indexOf('background:#ffffff')).toBeLessThan(out.indexOf('<title>t</title>'));
+    expect(out).toContain('background:var(--color-artifact-bg, #ffffff)');
+    expect(out.indexOf('background:var(--color-artifact-bg, #ffffff)')).toBeLessThan(
+      out.indexOf('<title>t</title>'),
+    );
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -28,9 +28,22 @@ export function buildSrcdoc(userHtml: string): string {
   );
 
   if (/<\/body\s*>/i.test(stripped)) {
-    const withBaseline = /<head[^>]*>/i.test(stripped)
-      ? stripped.replace(/<head[^>]*>/i, (match) => `${match}${BASELINE_STYLE}`)
-      : stripped.replace(/<html[^>]*>/i, (match) => `${match}<head>${BASELINE_STYLE}</head>`);
+    let withBaseline: string;
+    if (/<head[^>]*>/i.test(stripped)) {
+      withBaseline = stripped.replace(/<head[^>]*>/i, (match) => `${match}${BASELINE_STYLE}`);
+    } else if (/<html[^>]*>/i.test(stripped)) {
+      withBaseline = stripped.replace(
+        /<html[^>]*>/i,
+        (match) => `${match}<head>${BASELINE_STYLE}</head>`,
+      );
+    } else if (/<body[^>]*>/i.test(stripped)) {
+      withBaseline = `${stripped.replace(
+        /<body[^>]*>/i,
+        (match) => `<html><head>${BASELINE_STYLE}</head>${match}`,
+      )}</html>`;
+    } else {
+      withBaseline = `<!doctype html><html><head>${BASELINE_STYLE}</head><body>${stripped}</body></html>`;
+    }
     return withBaseline.replace(
       /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
       `<script>${OVERLAY_SCRIPT}</script></body>`,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -27,15 +27,19 @@ const BODY_CLOSE_RE = /<\/body\s*>/i;
  * baseline/overlay injection can rely on them. Handles all four input
  * shapes: both tags, opener only, closer only, neither.
  */
+function closeBody(html: string): string {
+  return /<\/html\s*>/i.test(html)
+    ? html.replace(/<\/html\s*>/i, '</body></html>')
+    : `${html}</body>`;
+}
+
 function normalizeBodyTags(html: string): string {
   const hasOpen = BODY_OPEN_RE.test(html);
   const hasClose = BODY_CLOSE_RE.test(html);
 
   if (hasOpen && hasClose) return html;
 
-  if (hasOpen && !hasClose) {
-    return `${html}</body>`;
-  }
+  if (hasOpen && !hasClose) return closeBody(html);
 
   if (!hasOpen && hasClose) {
     if (HEAD_CLOSE_RE.test(html)) {
@@ -48,12 +52,8 @@ function normalizeBodyTags(html: string): string {
   }
 
   // Neither opener nor closer.
-  if (HEAD_CLOSE_RE.test(html)) {
-    return `${html.replace(HEAD_CLOSE_RE, (m) => `${m}<body>`)}</body>`;
-  }
-  if (HTML_RE.test(html)) {
-    return `${html.replace(HTML_RE, (m) => `${m}<body>`)}</body>`;
-  }
+  if (HEAD_CLOSE_RE.test(html)) return closeBody(html.replace(HEAD_CLOSE_RE, (m) => `${m}<body>`));
+  if (HTML_RE.test(html)) return closeBody(html.replace(HTML_RE, (m) => `${m}<body>`));
   return `<body>${html}</body>`;
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,13 +6,15 @@ export { isIframeErrorMessage } from './iframe-errors';
 export type { IframeErrorMessage } from './iframe-errors';
 
 /**
- * Baseline white background so the iframe falls back to a neutral surface
- * when the artifact doesn't set its own body background. Injected before the
- * artifact's own styles so any explicit `body { background: ... }` in the
- * artifact wins via cascade order.
+ * Baseline background so the iframe falls back to a neutral surface when the
+ * artifact doesn't set its own body background. Sourced from the
+ * `--color-artifact-bg` design token (packages/ui), with a `#ffffff` fallback
+ * for sandboxed contexts where the parent's CSS vars aren't propagated.
+ * Injected before the artifact's own styles so any explicit
+ * `body { background: ... }` in the artifact wins via cascade order.
  */
 const BASELINE_STYLE =
-  '<style>html,body{margin:0;padding:0;background:#ffffff;min-height:100%;}</style>';
+  '<style>html,body{margin:0;padding:0;background:var(--color-artifact-bg, #ffffff);min-height:100%;}</style>';
 
 /**
  * Build a complete srcdoc HTML string for the preview iframe.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -16,6 +16,47 @@ export type { IframeErrorMessage } from './iframe-errors';
 const BASELINE_STYLE =
   '<style>html,body{margin:0;padding:0;background:var(--color-artifact-bg, #ffffff);min-height:100%;}</style>';
 
+const HTML_RE = /<html[^>]*>/i;
+const HEAD_OPEN_RE = /<head[^>]*>/i;
+const HEAD_CLOSE_RE = /<\/head\s*>/i;
+const BODY_OPEN_RE = /<body[^>]*>/i;
+const BODY_CLOSE_RE = /<\/body\s*>/i;
+
+/**
+ * Ensure the document has matching <body>...</body> tags so downstream
+ * baseline/overlay injection can rely on them. Handles all four input
+ * shapes: both tags, opener only, closer only, neither.
+ */
+function normalizeBodyTags(html: string): string {
+  const hasOpen = BODY_OPEN_RE.test(html);
+  const hasClose = BODY_CLOSE_RE.test(html);
+
+  if (hasOpen && hasClose) return html;
+
+  if (hasOpen && !hasClose) {
+    return `${html}</body>`;
+  }
+
+  if (!hasOpen && hasClose) {
+    if (HEAD_CLOSE_RE.test(html)) {
+      return html.replace(HEAD_CLOSE_RE, (m) => `${m}<body>`);
+    }
+    if (HTML_RE.test(html)) {
+      return html.replace(HTML_RE, (m) => `${m}<body>`);
+    }
+    return `<body>${html}`;
+  }
+
+  // Neither opener nor closer.
+  if (HEAD_CLOSE_RE.test(html)) {
+    return `${html.replace(HEAD_CLOSE_RE, (m) => `${m}<body>`)}</body>`;
+  }
+  if (HTML_RE.test(html)) {
+    return `${html.replace(HTML_RE, (m) => `${m}<body>`)}</body>`;
+  }
+  return `<body>${html}</body>`;
+}
+
 /**
  * Build a complete srcdoc HTML string for the preview iframe.
  * Strips CSP <meta> tags from user content to allow overlay injection.
@@ -29,30 +70,14 @@ export function buildSrcdoc(userHtml: string): string {
     '',
   );
 
-  if (/<\/body\s*>/i.test(stripped)) {
-    let withBaseline: string;
-    if (/<head[^>]*>/i.test(stripped)) {
-      withBaseline = stripped.replace(/<head[^>]*>/i, (match) => `${match}${BASELINE_STYLE}`);
-    } else if (/<html[^>]*>/i.test(stripped)) {
-      withBaseline = stripped.replace(
-        /<html[^>]*>/i,
-        (match) => `${match}<head>${BASELINE_STYLE}</head>`,
-      );
-    } else if (/<body[^>]*>/i.test(stripped)) {
-      withBaseline = `${stripped.replace(
-        /<body[^>]*>/i,
-        (match) => `<html><head>${BASELINE_STYLE}</head>${match}`,
-      )}</html>`;
-    } else {
-      withBaseline = `<!doctype html><html><head>${BASELINE_STYLE}</head><body>${stripped}</body></html>`;
-    }
-    return withBaseline.replace(
-      /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
-      `<script>${OVERLAY_SCRIPT}</script></body>`,
-    );
-  }
+  const hasAnyStructure =
+    HTML_RE.test(stripped) ||
+    HEAD_OPEN_RE.test(stripped) ||
+    BODY_OPEN_RE.test(stripped) ||
+    BODY_CLOSE_RE.test(stripped);
 
-  return `<!doctype html>
+  if (!hasAnyStructure) {
+    return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
@@ -65,6 +90,26 @@ ${stripped}
 <script>${OVERLAY_SCRIPT}</script>
 </body>
 </html>`;
+  }
+
+  const normalized = normalizeBodyTags(stripped);
+
+  let withBaseline: string;
+  if (HEAD_OPEN_RE.test(normalized)) {
+    withBaseline = normalized.replace(HEAD_OPEN_RE, (match) => `${match}${BASELINE_STYLE}`);
+  } else if (HTML_RE.test(normalized)) {
+    withBaseline = normalized.replace(
+      HTML_RE,
+      (match) => `${match}<head>${BASELINE_STYLE}</head>`,
+    );
+  } else {
+    withBaseline = `<html><head>${BASELINE_STYLE}</head>${normalized}</html>`;
+  }
+
+  return withBaseline.replace(
+    /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
+    `<script>${OVERLAY_SCRIPT}</script></body>`,
+  );
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,6 +6,15 @@ export { isIframeErrorMessage } from './iframe-errors';
 export type { IframeErrorMessage } from './iframe-errors';
 
 /**
+ * Baseline white background so the iframe falls back to a neutral surface
+ * when the artifact doesn't set its own body background. Injected before the
+ * artifact's own styles so any explicit `body { background: ... }` in the
+ * artifact wins via cascade order.
+ */
+const BASELINE_STYLE =
+  '<style>html,body{margin:0;padding:0;background:#ffffff;min-height:100%;}</style>';
+
+/**
  * Build a complete srcdoc HTML string for the preview iframe.
  * Strips CSP <meta> tags from user content to allow overlay injection.
  *
@@ -19,7 +28,10 @@ export function buildSrcdoc(userHtml: string): string {
   );
 
   if (/<\/body\s*>/i.test(stripped)) {
-    return stripped.replace(
+    const withBaseline = /<head[^>]*>/i.test(stripped)
+      ? stripped.replace(/<head[^>]*>/i, (match) => `${match}${BASELINE_STYLE}`)
+      : stripped.replace(/<html[^>]*>/i, (match) => `${match}<head>${BASELINE_STYLE}</head>`);
+    return withBaseline.replace(
       /<\/body\s*>(?![\s\S]*<\/body\s*>)/i,
       `<script>${OVERLAY_SCRIPT}</script></body>`,
     );
@@ -30,7 +42,8 @@ export function buildSrcdoc(userHtml: string): string {
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<style>html,body{margin:0;padding:0;font-family:system-ui,sans-serif;}</style>
+${BASELINE_STYLE}
+<style>html,body{font-family:system-ui,sans-serif;}</style>
 </head>
 <body>
 ${stripped}


### PR DESCRIPTION
## Summary
- 用户做 dark dashboard 时 iframe 外层 cream/white bg 透出，导致 dark artifact 看起来变浅。
- 改 iframe 外层 `bg-transparent` + `buildSrcdoc` 注入 low-specificity baseline white `html, body { background }`，artifact 自己的 body bg 通过 cascade order 胜出。
- 同时新增 vitest 覆盖：dark body bg 仍然在 baseline 之后；fragment / 缺 head 的 html 也注入 baseline。

## Root cause
`PreviewPane` 给 iframe 元素设了 `bg-[var(--color-artifact-bg)]`（白）。当 artifact body 没有显式 background 时，iframe body 透明 → iframe 元素 bg 显示。Dark artifacts 通常只把 bg 设在内层容器（如 `bg-gray-900`），body 仍透明，于是看起来浅。

## Fix
- `packages/runtime/src/index.ts` — 在 srcdoc head 最前面注入 baseline `<style>html,body{background:#ffffff;...}</style>`，artifact 自己的 body bg 依然是 last-wins。
- `apps/desktop/src/renderer/src/components/PreviewPane.tsx` — iframe className 由 `bg-[var(--color-artifact-bg)]` 改为 `bg-transparent`，让内部 body bg 决定可见颜色。

## Compat / upgradeability / no bloat / elegance
- Compatibility: 不动 schema、不动 IPC、不动 token；仅 srcdoc HTML 内容。
- Upgradeability: baseline style 与 overlay 同居 buildSrcdoc，未来可抽 token。
- No bloat: 0 新依赖。
- Elegance: 单一改动点，`buildSrcdoc` 仍是唯一 srcdoc 装配处。

## Test plan
- [x] `pnpm --filter @open-codesign/runtime exec vitest run` (6 passed)
- [x] `pnpm typecheck` (clean)
- [ ] 手动：用 dark dashboard prompt 生成，确认 iframe 内显示深色而非 cream/white