### PR TITLE
feat(core): chart rendering contract

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -1184,6 +1184,22 @@ describe('composeSystemPrompt()', () => {
     expect(prompt).toContain('Behavior in revise mode');
     expect(prompt).toContain('PRESERVE');
   });
+
+  it('create mode includes the chart rendering contract', () => {
+    const prompt = composeSystemPrompt({ mode: 'create' });
+    expect(prompt).toContain('Chart rendering contract');
+    expect(prompt).toContain('Inline SVG');
+    // Defers to the cdnjs whitelist in output rules — no host duplicated here.
+    expect(prompt).toContain("project's approved cdnjs whitelist");
+    // The deprecated open hosts must NOT appear as a recommended chart loader.
+    expect(prompt).not.toContain('esm.sh/recharts');
+    expect(prompt).not.toContain('cdn.jsdelivr.net/npm/chart.js');
+  });
+
+  it('tweak mode does NOT include the chart rendering contract', () => {
+    const prompt = composeSystemPrompt({ mode: 'tweak' });
+    expect(prompt).not.toContain('Chart rendering contract');
+  });
 });
 
 describe('prompt section .txt vs TS drift', () => {

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -1200,6 +1200,12 @@ describe('composeSystemPrompt()', () => {
     const prompt = composeSystemPrompt({ mode: 'tweak' });
     expect(prompt).not.toContain('Chart rendering contract');
   });
+
+  it('revise mode includes the chart rendering contract', () => {
+    const prompt = composeSystemPrompt({ mode: 'revise' });
+    expect(prompt).toContain('Chart rendering contract');
+    expect(prompt).toContain("project's approved cdnjs whitelist");
+  });
 });
 
 describe('prompt section .txt vs TS drift', () => {

--- a/packages/core/src/prompts/chart-rendering.v1.txt
+++ b/packages/core/src/prompts/chart-rendering.v1.txt
@@ -1,0 +1,41 @@
+# Chart rendering contract
+
+When the artifact is a dashboard, analytics view, report, case study with metrics, or any artifact requesting "chart", "graph", "plot", "visualization", or "数据看板" / "图表":
+
+## Render real markup, not labels
+Every chart-shaped section MUST emit `<svg>`, `<canvas>`, or a mounted React chart with actual numeric data. Outputting only the section header, a list of category names ("A B C D E F"), or placeholder text ("Chart goes here", "[chart]") is a hard failure.
+
+## Rendering choice (pick ONE per artifact)
+- **Inline SVG** — preferred for static charts up to ~30 data points. Hand-code paths, axes, gridlines, labels. No external script needed.
+- **Chart.js** — preferred for interactive charts with hover/animation. Load it from the project's approved cdnjs whitelist (see "Permitted external resources" in output rules) and pin an exact version. Use one `<canvas>` per chart.
+- **Recharts (React only)** — preferred when the artifact is React. Load it from the same cdnjs whitelist with a pinned version. For Recharts-specific styling, defer to the `data-viz-recharts` skill — do not duplicate its guidance here.
+
+Do not invent new CDN hosts. The output-rules whitelist is the single source of truth; if a library is not on it, hand-code an inline SVG instead.
+
+## Pick the right chart type
+- **Trend over time** — line chart (single series) or area chart with `fillOpacity ≈ 0.15` (multi-series). Never a bar chart for > 8 time buckets.
+- **Comparison across categories** — vertical bar chart for ≤ 8 categories, horizontal bar chart when labels are long or count > 8.
+- **Part-to-whole** — donut for 2–4 segments with a centered total. Never a pie chart with > 4 slices; switch to horizontal bars.
+- **Correlation** — scatter plot with domain-appropriate dot size, opacity ≈ 0.7 to show density.
+- **Single KPI trend** — sparkline (line, no axes) inside a stat card, paired with the absolute value and a delta pill.
+
+## Mandatory chart elements
+Every chart MUST include:
+- Real numeric data (≥ 6 data points for bars/lines, ≥ 3 slices for donut)
+- Axis labels — x-axis category names, y-axis scale with abbreviated large numbers (1.2M, 34K)
+- A title above the chart and a one-line subtitle stating the unit / time range
+- Encouraged: legend (only when ≥ 2 series), hover tooltip, subtle entry animation
+
+## Color palette
+- Pick a palette that matches the brief's tone (warm / cool / monochrome / accent-driven)
+- For dark themes use oklch with high chroma — `oklch(70% 0.18 200)`, `oklch(75% 0.16 30)` — avoid muted grays
+- Never use Chart.js or Recharts default palettes; they look like every tutorial chart
+- Color must not be the only differentiator. Pair it with shape, dasharray, or pattern fill so the chart stays legible in grayscale and for color-blind viewers
+
+## Hover and accessibility
+- Tooltip on hover shows the exact value plus the category and unit; avoid generic "Series 1: 42"
+- Add `aria-label` (or a `<title>` child for inline SVG) describing what the chart shows
+- Keyboard focus styles on interactive marks; never rely on hover-only affordances
+
+## Self-check
+Before finalizing the artifact, scan it: does every chart-shaped section contain rendered markup with data, axis labels, a title, and a deliberate palette? If not, fix it.

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -487,6 +487,48 @@ For dashboard / data / analytics artifacts, include these "live system" cues to 
 
 Slide decks substitute: cover → 3-7 content slides with strong hierarchy each → closing slide.`;
 
+const CHART_RENDERING = `# Chart rendering contract
+
+When the artifact is a dashboard, analytics view, report, case study with metrics, or any artifact requesting "chart", "graph", "plot", "visualization", or "数据看板" / "图表":
+
+## Render real markup, not labels
+Every chart-shaped section MUST emit \`<svg>\`, \`<canvas>\`, or a mounted React chart with actual numeric data. Outputting only the section header, a list of category names ("A B C D E F"), or placeholder text ("Chart goes here", "[chart]") is a hard failure.
+
+## Rendering choice (pick ONE per artifact)
+- **Inline SVG** — preferred for static charts up to ~30 data points. Hand-code paths, axes, gridlines, labels. No external script needed.
+- **Chart.js** — preferred for interactive charts with hover/animation. Load it from the project's approved cdnjs whitelist (see "Permitted external resources" in output rules) and pin an exact version. Use one \`<canvas>\` per chart.
+- **Recharts (React only)** — preferred when the artifact is React. Load it from the same cdnjs whitelist with a pinned version. For Recharts-specific styling, defer to the \`data-viz-recharts\` skill — do not duplicate its guidance here.
+
+Do not invent new CDN hosts. The output-rules whitelist is the single source of truth; if a library is not on it, hand-code an inline SVG instead.
+
+## Pick the right chart type
+- **Trend over time** — line chart (single series) or area chart with \`fillOpacity ≈ 0.15\` (multi-series). Never a bar chart for > 8 time buckets.
+- **Comparison across categories** — vertical bar chart for ≤ 8 categories, horizontal bar chart when labels are long or count > 8.
+- **Part-to-whole** — donut for 2–4 segments with a centered total. Never a pie chart with > 4 slices; switch to horizontal bars.
+- **Correlation** — scatter plot with domain-appropriate dot size, opacity ≈ 0.7 to show density.
+- **Single KPI trend** — sparkline (line, no axes) inside a stat card, paired with the absolute value and a delta pill.
+
+## Mandatory chart elements
+Every chart MUST include:
+- Real numeric data (≥ 6 data points for bars/lines, ≥ 3 slices for donut)
+- Axis labels — x-axis category names, y-axis scale with abbreviated large numbers (1.2M, 34K)
+- A title above the chart and a one-line subtitle stating the unit / time range
+- Encouraged: legend (only when ≥ 2 series), hover tooltip, subtle entry animation
+
+## Color palette
+- Pick a palette that matches the brief's tone (warm / cool / monochrome / accent-driven)
+- For dark themes use oklch with high chroma — \`oklch(70% 0.18 200)\`, \`oklch(75% 0.16 30)\` — avoid muted grays
+- Never use Chart.js or Recharts default palettes; they look like every tutorial chart
+- Color must not be the only differentiator. Pair it with shape, dasharray, or pattern fill so the chart stays legible in grayscale and for color-blind viewers
+
+## Hover and accessibility
+- Tooltip on hover shows the exact value plus the category and unit; avoid generic "Series 1: 42"
+- Add \`aria-label\` (or a \`<title>\` child for inline SVG) describing what the chart shows
+- Keyboard focus styles on interactive marks; never rely on hover-only affordances
+
+## Self-check
+Before finalizing the artifact, scan it: does every chart-shaped section contain rendered markup with data, axis labels, a title, and a deliberate palette? If not, fix it.`;
+
 const SAFETY = `# Safety and scope
 
 ## What you design
@@ -700,6 +742,7 @@ export const PROMPT_SECTIONS: Record<string, string> = {
   editmodeProtocol: EDITMODE_PROTOCOL,
   tweaksProtocol: TWEAKS_PROTOCOL,
   craftDirectives: CRAFT_DIRECTIVES,
+  chartRendering: CHART_RENDERING,
   iosStarterTemplate: IOS_STARTER_TEMPLATE,
   antiSlop: ANTI_SLOP,
   safety: SAFETY,
@@ -715,6 +758,7 @@ export const PROMPT_SECTION_FILES: Record<keyof typeof PROMPT_SECTIONS, string> 
   editmodeProtocol: 'editmode-protocol.v1.txt',
   tweaksProtocol: 'tweaks-protocol.v1.txt',
   craftDirectives: 'craft-directives.v1.txt',
+  chartRendering: 'chart-rendering.v1.txt',
   iosStarterTemplate: 'ios-starter-template.v1.txt',
   antiSlop: 'anti-slop.v1.txt',
   safety: 'safety.v1.txt',
@@ -747,7 +791,7 @@ export interface PromptComposeOptions {
  *   identity → workflow → output-rules → design-methodology →
  *   artifact-types → pre-flight → editmode-protocol →
  *   [tweaks-protocol if mode === 'tweak'] →
- *   craft-directives → [ios-starter-template if mode === 'create'] →
+ *   craft-directives → chart-rendering → [ios-starter-template if mode === 'create'] →
  *   anti-slop → safety → [skill blobs if any]
  *
  * Brand tokens and other user-filesystem data are intentionally excluded here.
@@ -771,6 +815,7 @@ export function composeSystemPrompt(opts: PromptComposeOptions): string {
 
   if (opts.mode !== 'tweak') {
     sections.push(CRAFT_DIRECTIVES);
+    sections.push(CHART_RENDERING);
   }
   if (opts.mode === 'create') {
     sections.push(IOS_STARTER_TEMPLATE);


### PR DESCRIPTION
## Summary

The system prompt now includes a dedicated **Chart rendering contract** section so the model emits real chart markup instead of label lists or empty section headers. Refactored to align with the cdnjs whitelist landed in #102.

## What changed

- New `packages/core/src/prompts/chart-rendering.v1.txt` (mirrored as `CHART_RENDERING` in `index.ts`).
- Section is appended in `create` and `revise` modes; excluded from `tweak` mode.
- Chart contract **defers** to the cdnjs whitelist in `output-rules.v1.txt` rather than re-listing libraries (DRY against #102 — single source of truth).
- Adds chart-recipe guidance: rendering choice (Inline SVG / Chart.js / Recharts), chart-type selection (line/bar/donut/scatter/sparkline), mandatory elements, accessible color palette, hover & a11y rules.
- Complements `data-viz-recharts.md` skill (Recharts-specific styling) without duplicating it.

## Addressing the original codex finding

The original PR was flagged because it used `esm.sh` and `cdn.jsdelivr.net`, which violated the then-current `no CDN` rule. After #102 we have a verified cdnjs slug whitelist (`recharts`, `Chart.js`, `d3`, `three.js`, `lodash.js`, `PapaParse`). This refactor:

- Removes every `esm.sh` / `jsdelivr` reference from the chart contract.
- Points to "the project's approved cdnjs whitelist" with pinned-version format.
- Tests assert the deprecated open hosts are no longer recommended (`esm.sh/recharts`, `cdn.jsdelivr.net/npm/chart.js`).

## Tests

- 2 new tests in `generate.test.ts`: `create` mode includes chart contract + cdnjs deferral; `tweak` mode excludes it.
- Drift test passes (`.txt` ↔ TS constant in sync).
- All 136 core tests + 334 desktop tests green.

## Four PRINCIPLES checks
- Compatibility: green — string-only prompt section, no API changes
- Upgradeability: green — new `chartRendering` key in `PROMPT_SECTIONS` map (additive)
- No bloat: green — text-only, ~50 lines added
- Elegance: green — defers to `output-rules` whitelist (DRY)