### PR TITLE
feat(core): Skills PR-B — wire loader into generation

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -1,23 +1,38 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { ChatMessage, ModelRef, StoredDesignSystem } from '@open-codesign/shared';
+import type { ChatMessage, LoadedSkill, ModelRef, StoredDesignSystem } from '@open-codesign/shared';
 import { CodesignError, STORED_DESIGN_SYSTEM_SCHEMA_VERSION } from '@open-codesign/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PROMPT_SECTIONS, PROMPT_SECTION_FILES, composeSystemPrompt } from './prompts/index.js';
 
 const completeMock = vi.fn();
+const loadBuiltinSkillsMock = vi.fn(async (): Promise<LoadedSkill[]> => []);
 
-vi.mock('@open-codesign/providers', () => ({
-  complete: (...args: unknown[]) => completeMock(...args),
-  completeWithRetry: (
-    _model: unknown,
-    _messages: unknown,
-    _opts: unknown,
-    _retryOpts: unknown,
-    impl: (...args: unknown[]) => unknown,
-  ) => impl(_model, _messages, _opts),
-}));
+vi.mock('@open-codesign/providers', async () => {
+  const actual = await vi.importActual<typeof import('@open-codesign/providers')>(
+    '@open-codesign/providers',
+  );
+  return {
+    ...actual,
+    complete: (...args: unknown[]) => completeMock(...args),
+    completeWithRetry: (
+      _model: unknown,
+      _messages: unknown,
+      _opts: unknown,
+      _retryOpts: unknown,
+      impl: (...args: unknown[]) => unknown,
+    ) => impl(_model, _messages, _opts),
+  };
+});
+
+vi.mock('./skills/loader.js', async () => {
+  const actual = await vi.importActual<typeof import('./skills/loader.js')>('./skills/loader.js');
+  return {
+    ...actual,
+    loadBuiltinSkills: () => loadBuiltinSkillsMock(),
+  };
+});
 
 import { applyComment, generate } from './index';
 
@@ -52,6 +67,8 @@ const DESIGN_SYSTEM: StoredDesignSystem = {
 
 afterEach(() => {
   completeMock.mockReset();
+  loadBuiltinSkillsMock.mockReset();
+  loadBuiltinSkillsMock.mockResolvedValue([]);
 });
 
 describe('generate()', () => {
@@ -393,6 +410,93 @@ describe('generate()', () => {
     const userContent = userMessages.map((m) => m.content).join('\n');
     expect(userContent).toContain('untrusted_scanned_content');
     expect(userContent).toContain('Ignore previous instructions');
+  });
+});
+
+describe('generate() skills injection', () => {
+  const dataVizSkill: LoadedSkill = {
+    id: 'data-viz-recharts',
+    source: 'builtin',
+    frontmatter: {
+      schemaVersion: 1,
+      name: 'data-viz-recharts',
+      description:
+        'Guides data visualization. Use when building charts, dashboards, analytics views.',
+      trigger: { providers: ['*'], scope: 'system' },
+      disable_model_invocation: false,
+      user_invocable: true,
+    },
+    body: '## Data Viz\n\nNever use Recharts default colors.',
+  };
+
+  it('injects matched skill body into the system prompt when prompt contains a trigger keyword', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([dataVizSkill]);
+
+    await generate({
+      prompt: 'make a dashboard for sales metrics',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).toContain('### Skill: data-viz-recharts');
+    expect(system.content).toContain('Never use Recharts default colors.');
+  });
+
+  it('does NOT inject the dashboard skill when prompt has no matching keyword', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([dataVizSkill]);
+
+    await generate({
+      prompt: 'make a meditation app onboarding flow',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).not.toContain('### Skill: data-viz-recharts');
+    expect(system.content).not.toContain('Never use Recharts default colors.');
+  });
+
+  it('falls back gracefully when the skills loader throws', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockRejectedValue(new Error('disk read failed'));
+
+    await expect(
+      generate({
+        prompt: 'make a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).resolves.toBeDefined();
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).not.toContain('### Skill:');
   });
 });
 

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -484,19 +484,31 @@ describe('generate() skills injection', () => {
     });
     loadBuiltinSkillsMock.mockRejectedValue(new Error('disk read failed'));
 
-    await expect(
-      generate({
-        prompt: 'make a dashboard',
-        history: [],
-        model: MODEL,
-        apiKey: 'sk-test',
-      }),
-    ).resolves.toBeDefined();
+    const errorLogs: Array<{ msg: string; meta?: unknown }> = [];
+    const logger = {
+      info: () => {},
+      error: (msg: string, meta?: unknown) => {
+        errorLogs.push({ msg, meta });
+      },
+    };
+
+    const result = await generate({
+      prompt: 'make a dashboard',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+      logger,
+    });
 
     const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
     const system = messages[0];
     if (!system) throw new Error('expected system message');
     expect(system.content).not.toContain('### Skill:');
+
+    expect(result.warnings).toEqual([
+      expect.stringContaining('Builtin skills unavailable: disk read failed'),
+    ]);
+    expect(errorLogs.some((entry) => entry.msg.includes('step=load_skills.fail'))).toBe(true);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,12 @@ export interface GenerateOutput {
   inputTokens: number;
   outputTokens: number;
   costUsd: number;
+  /**
+   * Non-fatal issues surfaced during this generate call (e.g. builtin skill
+   * loader failed). Callers MUST forward these to the UI — this is the
+   * "no silent fallbacks" escape hatch for best-effort substeps.
+   */
+  warnings?: string[];
 }
 
 interface Collected {
@@ -357,21 +363,28 @@ function formatSkillBlob(skill: LoadedSkill): string {
 }
 
 // Skill loading is best-effort: a missing or unreadable builtin directory must
-// not block generation. We log the failure and fall through to a skill-less
-// prompt so the user always gets a response.
-async function collectMatchedSkillBlobs(userPrompt: string, log: CoreLogger): Promise<string[]> {
+// not block generation, but the failure must surface (logged at error level
+// AND returned as a warning so the UI can show it). This honours
+// PRINCIPLES "no silent fallbacks" without sacrificing the user's response.
+async function collectMatchedSkillBlobs(
+  userPrompt: string,
+  log: CoreLogger,
+): Promise<{ blobs: string[]; warnings: string[] }> {
   let skills: LoadedSkill[];
   try {
     skills = await loadBuiltinSkills();
   } catch (err) {
-    log.error('[generate] step=load_skills.fail', {
-      errorClass: err instanceof Error ? err.constructor.name : typeof err,
-      message: err instanceof Error ? err.message : String(err),
-    });
-    return [];
+    const message = err instanceof Error ? err.message : String(err);
+    const errorClass = err instanceof Error ? err.constructor.name : typeof err;
+    log.error('[generate] step=load_skills.fail', { errorClass, message });
+    console.warn(`[open-codesign] builtin skills failed to load (${errorClass}): ${message}`);
+    return {
+      blobs: [],
+      warnings: [`Builtin skills unavailable: ${message}`],
+    };
   }
   const matched = matchSkillsToPrompt(skills, userPrompt);
-  return matched.map(formatSkillBlob);
+  return { blobs: matched.map(formatSkillBlob), warnings: [] };
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {
@@ -405,7 +418,10 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
 
   log.info('[generate] step=build_request', ctx);
   const buildStart = Date.now();
-  const skillBlobs = input.systemPrompt ? [] : await collectMatchedSkillBlobs(input.prompt, log);
+  const skillResult = input.systemPrompt
+    ? { blobs: [], warnings: [] }
+    : await collectMatchedSkillBlobs(input.prompt, log);
+  const skillBlobs = skillResult.blobs;
   const messages: ChatMessage[] = [
     {
       role: 'system',
@@ -424,9 +440,10 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     ms: Date.now() - buildStart,
     messages: messages.length,
     skills: skillBlobs.length,
+    skillWarnings: skillResult.warnings.length,
   });
 
-  return runModel({
+  const output = await runModel({
     model: input.model,
     apiKey: input.apiKey,
     baseUrl: input.baseUrl,
@@ -435,6 +452,9 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     messages,
     logger: input.logger,
   });
+  return skillResult.warnings.length > 0
+    ? { ...output, warnings: [...(output.warnings ?? []), ...skillResult.warnings] }
+    : output;
 }
 
 export async function applyComment(input: ApplyCommentInput): Promise<GenerateOutput> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,15 @@
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
 import type { GenerateResult } from '@open-codesign/providers';
-import { type RetryReason, complete, completeWithRetry } from '@open-codesign/providers';
+import {
+  type RetryReason,
+  complete,
+  completeWithRetry,
+  matchSkillsToPrompt,
+} from '@open-codesign/providers';
 import type {
   Artifact,
   ChatMessage,
+  LoadedSkill,
   ModelRef,
   SelectedElement,
   StoredDesignSystem,
@@ -12,6 +18,7 @@ import { CodesignError } from '@open-codesign/shared';
 import { remapProviderError } from './errors.js';
 import { type CoreLogger, NOOP_LOGGER } from './logger.js';
 import { type PromptComposeOptions, composeSystemPrompt } from './prompts/index.js';
+import { loadBuiltinSkills } from './skills/loader.js';
 
 export type { PromptComposeOptions };
 export type { CoreLogger } from './logger.js';
@@ -345,6 +352,28 @@ function extractStatus(err: unknown): number | undefined {
   return undefined;
 }
 
+function formatSkillBlob(skill: LoadedSkill): string {
+  return `### Skill: ${skill.frontmatter.name}\n\n${skill.body.trim()}`;
+}
+
+// Skill loading is best-effort: a missing or unreadable builtin directory must
+// not block generation. We log the failure and fall through to a skill-less
+// prompt so the user always gets a response.
+async function collectMatchedSkillBlobs(userPrompt: string, log: CoreLogger): Promise<string[]> {
+  let skills: LoadedSkill[];
+  try {
+    skills = await loadBuiltinSkills();
+  } catch (err) {
+    log.error('[generate] step=load_skills.fail', {
+      errorClass: err instanceof Error ? err.constructor.name : typeof err,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+  const matched = matchSkillsToPrompt(skills, userPrompt);
+  return matched.map(formatSkillBlob);
+}
+
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {
   const log = input.logger ?? NOOP_LOGGER;
   const ctx = {
@@ -376,6 +405,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
 
   log.info('[generate] step=build_request', ctx);
   const buildStart = Date.now();
+  const skillBlobs = input.systemPrompt ? [] : await collectMatchedSkillBlobs(input.prompt, log);
   const messages: ChatMessage[] = [
     {
       role: 'system',
@@ -383,6 +413,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
         input.systemPrompt ??
         composeSystemPrompt({
           mode: 'create',
+          ...(skillBlobs.length > 0 ? { skills: skillBlobs } : {}),
         }),
     },
     ...input.history,
@@ -392,6 +423,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
     ...ctx,
     ms: Date.now() - buildStart,
     messages: messages.length,
+    skills: skillBlobs.length,
   });
 
   return runModel({

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,4 +1,4 @@
-export { loadAllSkills, loadSkillsFromDir } from './loader.js';
+export { loadAllSkills, loadBuiltinSkills, loadSkillsFromDir } from './loader.js';
 export type { LoadAllSkillsOptions } from './loader.js';
 export { SkillFrontmatterV1 } from './types.js';
 export type { LoadedSkill } from './types.js';

--- a/packages/core/src/skills/loader.ts
+++ b/packages/core/src/skills/loader.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { CodesignError } from '@open-codesign/shared';
 import { type LoadedSkill, SkillFrontmatterV1 } from './types.js';
 
@@ -283,4 +284,15 @@ export async function loadAllSkills(opts: LoadAllSkillsOptions): Promise<LoadedS
   }
 
   return [...map.values()];
+}
+
+/**
+ * Load the four builtin skills shipped inside this package
+ * (`packages/core/src/skills/builtin/*.md`). Resolved relative to this file via
+ * `import.meta.url` so it works in ESM, Vite, and Electron main without
+ * hard-coded paths.
+ */
+export async function loadBuiltinSkills(): Promise<LoadedSkill[]> {
+  const builtinDir = fileURLToPath(new URL('./builtin/', import.meta.url));
+  return loadSkillsFromDir(builtinDir, 'builtin');
 }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -202,7 +202,7 @@ export type { ValidateResult } from './validate';
 export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
 export type { CompleteWithRetryOptions, RetryReason } from './retry';
 
-export { injectSkillsIntoMessages } from './skill-injector';
+export { injectSkillsIntoMessages, matchSkillsToPrompt } from './skill-injector';
 
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>

--- a/packages/providers/src/skill-injector.ts
+++ b/packages/providers/src/skill-injector.ts
@@ -119,3 +119,71 @@ export function injectSkillsIntoMessages(
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Skill matching against a free-form user prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Trigger keywords harvested from the builtin skill descriptions. We match on
+ * surface-form vocabulary in the user's prompt rather than running a model
+ * call — Tier 1 keeps this purely lexical and zero-cost. Add new entries here
+ * when introducing a skill whose intent isn't covered by an existing keyword.
+ *
+ * Excluded on purpose: "design" — it appears in nearly every open-codesign
+ * prompt and would force-match every skill on every call.
+ */
+const SKILL_TRIGGER_KEYWORDS = [
+  'dashboard',
+  'chart',
+  'graph',
+  'analytics',
+  'kpi',
+  'metric',
+  'data viz',
+  'data-driven',
+  'recharts',
+  'landing',
+  'homepage',
+  'hero',
+  'mobile',
+  'phone',
+  'app screen',
+  'ios',
+  'android',
+  'deck',
+  'slide',
+  'slides',
+  'presentation',
+  'pitch',
+  'keynote',
+] as const;
+
+function extractKeywords(text: string): Set<string> {
+  const lower = text.toLowerCase();
+  const hits = new Set<string>();
+  for (const kw of SKILL_TRIGGER_KEYWORDS) {
+    if (lower.includes(kw)) hits.add(kw);
+  }
+  return hits;
+}
+
+/**
+ * Pick the subset of `skills` whose description shares at least one trigger
+ * keyword with `userPrompt`. Pure function, no provider call, no allocation
+ * per skill beyond the Set lookup. Returns an empty array when the prompt has
+ * no triggering vocabulary.
+ */
+export function matchSkillsToPrompt(skills: LoadedSkill[], userPrompt: string): LoadedSkill[] {
+  if (!userPrompt.trim()) return [];
+  const promptKeywords = extractKeywords(userPrompt);
+  if (promptKeywords.size === 0) return [];
+
+  return skills.filter((s) => {
+    const descKeywords = extractKeywords(s.frontmatter.description);
+    for (const kw of descKeywords) {
+      if (promptKeywords.has(kw)) return true;
+    }
+    return false;
+  });
+}


### PR DESCRIPTION
## Summary

#33 added the skills loader and four builtin skills (data-viz-recharts, frontend-design-anti-slop, mobile-mock, pitch-deck) but the generation pipeline never called the loader nor injected skill bodies into the system prompt — so a user asking for a dashboard never got the data-viz-recharts skill applied.

This PR wires the loader into `generate()`:

- `loadBuiltinSkills()` resolves the bundled `builtin/` dir via `import.meta.url`.
- `matchSkillsToPrompt(skills, userPrompt)` (new, in `packages/providers/src/skill-injector.ts`) does a lexical keyword match between the prompt and each skill's frontmatter description. Excludes the word "design" on purpose — it's in nearly every prompt.
- `generate()` calls the loader + matcher each request, then passes matched skill bodies through the existing `composeSystemPrompt({ skills })` slot. Loader failure is best-effort: log and continue with no skills.
- `apply_comment` and `systemPrompt` overrides remain skill-free (no behaviour change there).

No new dependencies. Does not touch the #43 craft-directives section.

## Compatibility / upgradeability / no bloat / elegance

- Compatibility: existing test surface unchanged; the only added log payload field is `skills: <count>` on `step=build_request.ok`.
- Upgradeability: the keyword list is a single `as const` array, easy to extend per future skill.
- No bloat: zero deps, ~70 LOC of production code.
- Elegance: matcher is pure, loader is best-effort, generate() picks them up via one helper.

## Test plan

- [x] `pnpm --filter @open-codesign/core test` — 41 generate tests pass, including 3 new skill-injection cases (matched, unmatched, loader failure)
- [x] `pnpm --filter @open-codesign/providers test` — 36 tests pass
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — no new errors (10 pre-existing complexity warnings unchanged)
- [ ] Manual: run `pnpm dev`, prompt "make a dashboard", confirm data-viz-recharts body appears in the request log