### PR TITLE
feat(core): extended thinking + bigger output budget

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -106,6 +106,52 @@ describe('generate()', () => {
     expect(result.costUsd).toBeCloseTo(0.0001);
   });
 
+  it('requests 32k output tokens and high reasoning for Claude 4 models', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as {
+      maxTokens?: number;
+      reasoning?: string;
+    };
+    expect(opts.maxTokens).toBe(32000);
+    expect(opts.reasoning).toBe('high');
+  });
+
+  it('omits reasoning for non-Claude-4 providers but still raises maxTokens', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openai', modelId: 'gpt-4o' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as {
+      maxTokens?: number;
+      reasoning?: string;
+    };
+    expect(opts.maxTokens).toBe(32000);
+    expect(opts.reasoning).toBeUndefined();
+  });
+
   it('passes the design-generator system prompt by default', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
-import type { GenerateResult } from '@open-codesign/providers';
+import type { GenerateResult, ReasoningLevel } from '@open-codesign/providers';
 import {
   type RetryReason,
   complete,
@@ -279,6 +279,7 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
   log.info(`[${scope}] step=send_request`, ctx);
   const sendStart = Date.now();
   let result: GenerateResult;
+  const reasoning = reasoningForModel(input.model);
   try {
     result = await completeWithRetry(
       input.model,
@@ -287,6 +288,8 @@ async function runModel(input: ModelRunInput): Promise<GenerateOutput> {
         apiKey: input.apiKey,
         ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
         ...(input.signal !== undefined ? { signal: input.signal } : {}),
+        maxTokens: MAX_OUTPUT_TOKENS,
+        ...(reasoning !== undefined ? { reasoning } : {}),
       },
       {
         ...(input.onRetry !== undefined ? { onRetry: input.onRetry } : {}),
@@ -385,6 +388,22 @@ async function collectMatchedSkillBlobs(
   }
   const matched = matchSkillsToPrompt(skills, userPrompt);
   return { blobs: matched.map(formatSkillBlob), warnings: [] };
+}
+
+/**
+ * Output-token budget for every generation. Tripled from pi-ai's default
+ * (~1/3 of context window, ~10k for Opus 4) to give Claude room for both
+ * extended-thinking traces and a full HTML artifact.
+ */
+const MAX_OUTPUT_TOKENS = 32000;
+
+/** Match Anthropic's Claude 4.x family, which supports extended thinking. */
+const CLAUDE_4_MODEL_RE = /claude-(?:opus|sonnet)-4/i;
+
+function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
+  if (model.provider !== 'anthropic') return undefined;
+  if (!CLAUDE_4_MODEL_RE.test(model.modelId)) return undefined;
+  return 'high';
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -8,10 +8,22 @@
 
 import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
 
+/** Subset of pi-ai's `ThinkingLevel` we expose. Maps directly to its `reasoning`
+ * field, which Anthropic adapters translate to extended-thinking effort/budget
+ * (and OpenAI/Gemini adapters translate to their respective reasoning knobs). */
+export type ReasoningLevel = 'low' | 'medium' | 'high' | 'xhigh';
+
 export interface GenerateOptions {
   apiKey: string;
   baseUrl?: string;
   signal?: AbortSignal;
+  /** Hard cap on output tokens. When omitted, pi-ai falls back to ~1/3 of
+   *  the model's context window. */
+  maxTokens?: number;
+  /** When set, asks the provider to "think before answering". On Anthropic
+   *  Claude 4.x models this enables extended thinking; on OpenAI/Gemini it
+   *  maps to their reasoning effort. Older/non-reasoning models ignore it. */
+  reasoning?: ReasoningLevel;
 }
 
 export interface GenerateResult {
@@ -105,7 +117,13 @@ export async function complete(
     completeSimple: (
       model: PiModel,
       context: PiContext,
-      opts: { apiKey: string; baseUrl?: string; signal?: AbortSignal },
+      opts: {
+        apiKey: string;
+        baseUrl?: string;
+        signal?: AbortSignal;
+        maxTokens?: number;
+        reasoning?: ReasoningLevel;
+      },
     ) => Promise<PiAssistantMessage>;
   };
 
@@ -117,11 +135,19 @@ export async function complete(
     );
   }
 
-  const piOpts: { apiKey: string; baseUrl?: string; signal?: AbortSignal } = {
+  const piOpts: {
+    apiKey: string;
+    baseUrl?: string;
+    signal?: AbortSignal;
+    maxTokens?: number;
+    reasoning?: ReasoningLevel;
+  } = {
     apiKey: opts.apiKey,
   };
   if (opts.baseUrl !== undefined) piOpts.baseUrl = opts.baseUrl;
   if (opts.signal !== undefined) piOpts.signal = opts.signal;
+  if (opts.maxTokens !== undefined) piOpts.maxTokens = opts.maxTokens;
+  if (opts.reasoning !== undefined) piOpts.reasoning = opts.reasoning;
 
   const result = await pi.completeSimple(piModel, toPiContext(messages, piModel), piOpts);
 


### PR DESCRIPTION
让模型有 10k thinking budget + 32k 输出预算，单次生成质量大幅提升（代价：时间翻 2-3 倍）。仅 Claude 4 系列启用 thinking。