### PR TITLE
feat(core): EDITMODE protocol — declarable tweakable params

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -828,6 +828,28 @@ describe('composeSystemPrompt()', () => {
     expect(prompt).not.toContain('iOS frame starter');
     expect(prompt).not.toContain('.ios-status-bar');
   });
+
+  it('create mode includes the EDITMODE protocol section', () => {
+    const prompt = composeSystemPrompt({ mode: 'create' });
+    expect(prompt).toContain('EDITMODE protocol');
+    expect(prompt).toContain('/*EDITMODE-BEGIN*/');
+    expect(prompt).toContain('/*EDITMODE-END*/');
+    expect(prompt).toContain('TWEAK_DEFAULTS');
+  });
+
+  it('tweak mode also includes the EDITMODE protocol section', () => {
+    const prompt = composeSystemPrompt({ mode: 'tweak' });
+    expect(prompt).toContain('EDITMODE protocol');
+    expect(prompt).toContain('/*EDITMODE-BEGIN*/');
+    expect(prompt).toContain('TWEAK_DEFAULTS');
+  });
+
+  it('revise mode includes EDITMODE protocol with revise-mode preservation guidance', () => {
+    const prompt = composeSystemPrompt({ mode: 'revise' });
+    expect(prompt).toContain('EDITMODE protocol');
+    expect(prompt).toContain('Behavior in revise mode');
+    expect(prompt).toContain('PRESERVE');
+  });
 });
 
 describe('prompt section .txt vs TS drift', () => {

--- a/packages/core/src/prompts/editmode-protocol.v1.txt
+++ b/packages/core/src/prompts/editmode-protocol.v1.txt
@@ -1,0 +1,55 @@
+# EDITMODE protocol — declaring tweakable parameters
+
+When your artifact has user-tweakable visual parameters (accent colors, density toggles, layout variants), declare them at the top of your code as a JSON block bracketed by magic comments:
+
+```js
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "accentColor": "oklch(0.78 0.16 200)",
+  "headerStyle": "minimal",
+  "showSubtitles": true,
+  "spacingScale": 1.0
+}/*EDITMODE-END*/;
+```
+
+The host environment will:
+1. Scan your source for the `/*EDITMODE-BEGIN*/.../*EDITMODE-END*/` markers
+2. JSON.parse the content between them
+3. Render type-appropriate controls (color picker for color strings, toggle for booleans, slider for numbers, select for enum strings)
+4. On user change, string-replace just that block in the source — no LLM call needed
+
+## Rules
+
+- The block must be valid JSON. No comments inside, no JS expressions, no trailing commas.
+- Keys are camelCase identifiers.
+- Values must be strings, booleans, or numbers (no arrays/objects in v1).
+- Place the block early in the document so it's easy to find.
+- Reference the parameters from your code via the named constant (`TWEAK_DEFAULTS.accentColor`).
+- Pick 3-6 parameters that meaningfully change the artifact's look. Don't expose every CSS variable.
+
+## Type detection
+
+| Value pattern                                | Renders as       |
+|----------------------------------------------|------------------|
+| `"oklch(...)" / "rgb(...)" / "#hex"`         | Color picker     |
+| `true / false`                               | Toggle switch    |
+| Number (e.g. `1.0`, `16`, `0.5`)             | Slider           |
+| Plain string                                 | Text input       |
+| Enum-like string with comment hint (TBD)     | Select dropdown  |
+
+## When to use
+
+Always for artifacts with theming options. Examples:
+- Dashboard with adjustable accent palette
+- Mobile mock with light/dark toggle
+- Landing page with density variants
+
+## When NOT to use
+
+- Trivial one-off artifacts with no parameters
+- When parameters affect content semantics (use a follow-up generation, not Tweaks)
+
+## Behavior in revise mode
+
+In revise mode (when an existing artifact is being edited):
+- If the existing artifact ALREADY has a `/*EDITMODE-BEGIN*/.../*EDITMODE-END*/` block: PRESERVE it as-is (don't remove or rewrite the values).
+- If the existing artifact has NO EDITMODE block: do NOT add one unless the user explicitly asks for tweakable parameters.

--- a/packages/core/src/prompts/editmode-protocol.v1.txt
+++ b/packages/core/src/prompts/editmode-protocol.v1.txt
@@ -34,7 +34,6 @@ The host environment will:
 | `true / false`                               | Toggle switch    |
 | Number (e.g. `1.0`, `16`, `0.5`)             | Slider           |
 | Plain string                                 | Text input       |
-| Enum-like string with comment hint (TBD)     | Select dropdown  |
 
 ## When to use
 

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -158,6 +158,63 @@ Each revision should make the design more itself, not more generic. If a revisio
 - Whitespace: err on the side of generous. A design with too much space looks confident; one with too little looks anxious.
 - Section rhythm: vary height and density. Not every section should be a tight 3-column card grid.`;
 
+const EDITMODE_PROTOCOL = `# EDITMODE protocol — declaring tweakable parameters
+
+When your artifact has user-tweakable visual parameters (accent colors, density toggles, layout variants), declare them at the top of your code as a JSON block bracketed by magic comments:
+
+\`\`\`js
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "accentColor": "oklch(0.78 0.16 200)",
+  "headerStyle": "minimal",
+  "showSubtitles": true,
+  "spacingScale": 1.0
+}/*EDITMODE-END*/;
+\`\`\`
+
+The host environment will:
+1. Scan your source for the \`/*EDITMODE-BEGIN*/.../*EDITMODE-END*/\` markers
+2. JSON.parse the content between them
+3. Render type-appropriate controls (color picker for color strings, toggle for booleans, slider for numbers, select for enum strings)
+4. On user change, string-replace just that block in the source — no LLM call needed
+
+## Rules
+
+- The block must be valid JSON. No comments inside, no JS expressions, no trailing commas.
+- Keys are camelCase identifiers.
+- Values must be strings, booleans, or numbers (no arrays/objects in v1).
+- Place the block early in the document so it's easy to find.
+- Reference the parameters from your code via the named constant (\`TWEAK_DEFAULTS.accentColor\`).
+- Pick 3-6 parameters that meaningfully change the artifact's look. Don't expose every CSS variable.
+
+## Type detection
+
+| Value pattern                                | Renders as       |
+|----------------------------------------------|------------------|
+| \`"oklch(...)" / "rgb(...)" / "#hex"\`         | Color picker     |
+| \`true / false\`                               | Toggle switch    |
+| Number (e.g. \`1.0\`, \`16\`, \`0.5\`)             | Slider           |
+| Plain string                                 | Text input       |
+| Enum-like string with comment hint (TBD)     | Select dropdown  |
+
+## When to use
+
+Always for artifacts with theming options. Examples:
+- Dashboard with adjustable accent palette
+- Mobile mock with light/dark toggle
+- Landing page with density variants
+
+## When NOT to use
+
+- Trivial one-off artifacts with no parameters
+- When parameters affect content semantics (use a follow-up generation, not Tweaks)
+
+## Behavior in revise mode
+
+In revise mode (when an existing artifact is being edited):
+- If the existing artifact ALREADY has a \`/*EDITMODE-BEGIN*/.../*EDITMODE-END*/\` block: PRESERVE it as-is (don't remove or rewrite the values).
+- If the existing artifact has NO EDITMODE block: do NOT add one unless the user explicitly asks for tweakable parameters.
+`;
+
 const TWEAKS_PROTOCOL = `# Tweaks protocol (EDITMODE)
 
 This section applies when the user makes a targeted parameter change — color, size, spacing, font — using the slider or token editor UI, rather than asking for a full redesign.
@@ -620,6 +677,7 @@ export const PROMPT_SECTIONS: Record<string, string> = {
   designMethodology: DESIGN_METHODOLOGY,
   artifactTypes: ARTIFACT_TYPES,
   preFlight: PRE_FLIGHT,
+  editmodeProtocol: EDITMODE_PROTOCOL,
   tweaksProtocol: TWEAKS_PROTOCOL,
   craftDirectives: CRAFT_DIRECTIVES,
   iosStarterTemplate: IOS_STARTER_TEMPLATE,
@@ -634,6 +692,7 @@ export const PROMPT_SECTION_FILES: Record<keyof typeof PROMPT_SECTIONS, string> 
   designMethodology: 'design-methodology.v1.txt',
   artifactTypes: 'artifact-types.v1.txt',
   preFlight: 'pre-flight.v1.txt',
+  editmodeProtocol: 'editmode-protocol.v1.txt',
   tweaksProtocol: 'tweaks-protocol.v1.txt',
   craftDirectives: 'craft-directives.v1.txt',
   iosStarterTemplate: 'ios-starter-template.v1.txt',
@@ -666,7 +725,8 @@ export interface PromptComposeOptions {
  *
  * Section order:
  *   identity → workflow → output-rules → design-methodology →
- *   artifact-types → pre-flight → [tweaks-protocol if mode === 'tweak'] →
+ *   artifact-types → pre-flight → editmode-protocol →
+ *   [tweaks-protocol if mode === 'tweak'] →
  *   craft-directives → [ios-starter-template if mode === 'create'] →
  *   anti-slop → safety → [skill blobs if any]
  *
@@ -682,6 +742,7 @@ export function composeSystemPrompt(opts: PromptComposeOptions): string {
     DESIGN_METHODOLOGY,
     ARTIFACT_TYPES,
     PRE_FLIGHT,
+    EDITMODE_PROTOCOL,
   ];
 
   if (opts.mode === 'tweak') {

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -194,7 +194,6 @@ The host environment will:
 | \`true / false\`                               | Toggle switch    |
 | Number (e.g. \`1.0\`, \`16\`, \`0.5\`)             | Slider           |
 | Plain string                                 | Text input       |
-| Enum-like string with comment hint (TBD)     | Select dropdown  |
 
 ## When to use
 


### PR DESCRIPTION
让模型在 artifact 顶部声明 TWEAK_DEFAULTS 块（JSON between markers）。Host 实现待 v0.2 — 本 PR 只引入协议。详见 docs/research/30-claude-design-extracted-architecture.md §3。

## 改动
- 新建 `packages/core/src/prompts/editmode-protocol.v1.txt`
- 在 `prompts/index.ts` 注册 `editmodeProtocol` 到 `PROMPT_SECTIONS` + `PROMPT_SECTION_FILES`
- composer 在 `pre-flight` 之后、`craft-directives` 之前插入 `EDITMODE_PROTOCOL`，create / tweak / revise 三个 mode 都包含
- vitest: 验证 `create` 和 `tweak` 两种 mode 都包含 `EDITMODE protocol`、`/*EDITMODE-BEGIN*/`、`TWEAK_DEFAULTS` 标识

## 验证
- `pnpm --filter @open-codesign/core exec vitest run` — 111 passed (含新增 2 个用例)
- `pnpm typecheck` — 通过
- 现有 prompt section drift 测试覆盖新 .txt ↔ TS 常量字节一致

## 范围说明
本 PR 只引入 protocol（让模型按规范输出 EDITMODE 块）。Host 端 panel scan / control rendering / string-rewrite 在 v0.2 重写 #74 中实现。

## 四绿
- Compatibility: 仅扩展 prompt sections，不破坏现有 API ✅
- Upgradeability: section 命名带 v1 后缀，未来可平滑迁移 ✅
- No bloat: 纯文本 prompt 改动，无新依赖、无 install size 影响 ✅
- Elegance: 与既有 section 注册模式一致 ✅