### PR TITLE
fix(exporters): quote YAML frontmatter titles starting with reserved indicators

### DIFF
--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -79,6 +79,19 @@ describe('htmlToMarkdown', () => {
     expect(out.length).toBeGreaterThan(0);
   });
 
+  it('quotes titles starting with YAML indicator chars so frontmatter stays valid', () => {
+    const cases = ['- TODO List', '? maybe', '[bracket', '{brace', '> quote', '| pipe', '! bang'];
+    for (const title of cases) {
+      const out = htmlToMarkdown('<p>x</p>', { title, schemaVersion: 1 });
+      expect(out).toContain(`title: ${JSON.stringify(title)}\n`);
+    }
+  });
+
+  it('quotes titles with leading or trailing whitespace', () => {
+    const out = htmlToMarkdown('<p>x</p>', { title: '  padded  ', schemaVersion: 1 });
+    expect(out).toContain('title: "  padded  "\n');
+  });
+
   it('strips javascript: links but keeps the visible text', () => {
     const out = htmlToMarkdown('<p><a href="javascript:alert(1)">x</a></p>', META);
     expect(out).toContain('x');

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -47,8 +47,20 @@ function renderFrontmatter(meta: MarkdownMeta): string {
   return `${lines.join('\n')}\n`;
 }
 
+// YAML 1.2 reserved indicator chars that, at the start of a plain scalar,
+// change parsing (sequence/flow/anchor/alias/directive/etc). Strings with
+// leading/trailing whitespace also need quoting to round-trip correctly.
+const YAML_LEADING_INDICATOR = /^[-?:,[\]{}#&*!|>'"%@`]/;
+const YAML_NEEDS_QUOTING = /[:#"'\n]/;
+
 function escapeYaml(value: string): string {
-  if (/[:#"'\n]/.test(value)) return JSON.stringify(value);
+  if (
+    YAML_NEEDS_QUOTING.test(value) ||
+    YAML_LEADING_INDICATOR.test(value) ||
+    value !== value.trim()
+  ) {
+    return JSON.stringify(value);
+  }
   return value;
 }
 


### PR DESCRIPTION
## Summary
- `escapeYaml` in `packages/exporters/src/markdown.ts` only quoted values containing `:`, `#`, `\"`, `'`, or `\n`. Titles beginning with YAML 1.2 reserved indicator chars (`-`, `?`, `[`, `{`, `>`, `|`, `!`, `&`, `*`, `%`, `@`, `\`` etc.) produced unquoted scalars that strict YAML parsers re-interpret as sequences / flow nodes — corrupting the markdown export's frontmatter whenever the artifact `<title>` or `<h1>` happened to start with one.
- Now: quote when the value contains the existing trigger set, starts with a YAML reserved indicator, or has leading/trailing whitespace (also unsafe in plain scalars).

## Compatibility / upgradeability / no bloat / elegance
- Compatibility: green — existing safe titles still emit unquoted; quoted values use `JSON.stringify` (already in this file).
- Upgradeability: green — no schema change; same `schemaVersion: 1` frontmatter.
- No bloat: green — pure regex tweak, no deps.
- Elegance: green — two named constants document intent.

## Test plan
- [x] `pnpm --filter @open-codesign/exporters test` (30 passing, including 2 new cases for indicator-prefixed and whitespace-padded titles).
- [x] `pnpm --filter @open-codesign/exporters typecheck`.
- [x] `pnpm lint`.