### PR TITLE
feat(core): reasoning for all providers (auto fallback)

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -129,7 +129,7 @@ describe('generate()', () => {
     expect(opts.reasoning).toBe('high');
   });
 
-  it('falls back to auto reasoning for non-Claude-4 providers, still raises maxTokens', async () => {
+  it('omits reasoning for non-reasoning models, still raises maxTokens', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -149,10 +149,10 @@ describe('generate()', () => {
       reasoning?: string;
     };
     expect(opts.maxTokens).toBe(32000);
-    expect(opts.reasoning).toBe('auto');
+    expect(opts.reasoning).toBeUndefined();
   });
 
-  it('passes reasoning=auto for OpenAI gpt-5 so pi-ai can route it to reasoning_effort', async () => {
+  it('passes reasoning=high for OpenAI gpt-5 (whitelisted reasoning model)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -168,10 +168,10 @@ describe('generate()', () => {
     });
 
     const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
-    expect(opts.reasoning).toBe('auto');
+    expect(opts.reasoning).toBe('high');
   });
 
-  it('passes reasoning=auto for OpenRouter pass-through models', async () => {
+  it('passes reasoning=high for OpenAI o-series (o1, o3, o4)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -182,15 +182,15 @@ describe('generate()', () => {
     await generate({
       prompt: 'design a meditation app',
       history: [],
-      model: { provider: 'openrouter', modelId: 'elephant/elephant-alpha' },
+      model: { provider: 'openai', modelId: 'o1-preview' },
       apiKey: 'sk-test',
     });
 
     const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
-    expect(opts.reasoning).toBe('auto');
+    expect(opts.reasoning).toBe('high');
   });
 
-  it('passes reasoning=auto for any other provider (groq, etc.)', async () => {
+  it('passes reasoning=high for DeepSeek R1', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -206,7 +206,45 @@ describe('generate()', () => {
     });
 
     const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
-    expect(opts.reasoning).toBe('auto');
+    expect(opts.reasoning).toBe('high');
+  });
+
+  it('omits reasoning for non-whitelisted OpenRouter pass-through models', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'elephant/elephant-alpha' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
+  });
+
+  it('omits reasoning for older Anthropic Claude models (avoids accidental extended thinking)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'anthropic', modelId: 'claude-3-5-sonnet-20241022' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
   });
 
   it('passes the design-generator system prompt by default', async () => {

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -190,7 +190,7 @@ describe('generate()', () => {
     expect(opts.reasoning).toBe('high');
   });
 
-  it('passes reasoning=high for DeepSeek R1', async () => {
+  it('omits reasoning for DeepSeek R1 served via Groq pass-through (model id alone is not trustable)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -202,6 +202,82 @@ describe('generate()', () => {
       prompt: 'design a meditation app',
       history: [],
       model: { provider: 'groq', modelId: 'deepseek-r1-distill-llama-70b' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
+  });
+
+  it('omits reasoning for OpenRouter pass-through claude-4 (cannot trust pass-through ids)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'anthropic/claude-sonnet-4' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
+  });
+
+  it('omits reasoning for OpenRouter id whose substring contains "o1" (no provider trust)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'mystery-lab/o1-lookalike' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
+  });
+
+  it('passes reasoning=high for Anthropic claude-opus-4-7 (first-party provider)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'anthropic', modelId: 'claude-opus-4-7' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('high');
+  });
+
+  it('passes reasoning=high for OpenAI o3-mini (first-party provider)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openai', modelId: 'o3-mini' },
       apiKey: 'sk-test',
     });
 

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -129,7 +129,7 @@ describe('generate()', () => {
     expect(opts.reasoning).toBe('high');
   });
 
-  it('omits reasoning for non-Claude-4 providers but still raises maxTokens', async () => {
+  it('falls back to auto reasoning for non-Claude-4 providers, still raises maxTokens', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -149,7 +149,64 @@ describe('generate()', () => {
       reasoning?: string;
     };
     expect(opts.maxTokens).toBe(32000);
-    expect(opts.reasoning).toBeUndefined();
+    expect(opts.reasoning).toBe('auto');
+  });
+
+  it('passes reasoning=auto for OpenAI gpt-5 so pi-ai can route it to reasoning_effort', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('auto');
+  });
+
+  it('passes reasoning=auto for OpenRouter pass-through models', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'elephant/elephant-alpha' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('auto');
+  });
+
+  it('passes reasoning=auto for any other provider (groq, etc.)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'groq', modelId: 'deepseek-r1-distill-llama-70b' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('auto');
   });
 
   it('passes the design-generator system prompt by default', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -401,9 +401,14 @@ const MAX_OUTPUT_TOKENS = 32000;
 const CLAUDE_4_MODEL_RE = /claude-(?:opus|sonnet)-4/i;
 
 function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
-  if (model.provider !== 'anthropic') return undefined;
-  if (!CLAUDE_4_MODEL_RE.test(model.modelId)) return undefined;
-  return 'high';
+  // Claude 4.x — explicit high (extended thinking).
+  if (model.provider === 'anthropic' && CLAUDE_4_MODEL_RE.test(model.modelId)) {
+    return 'high';
+  }
+  // Other reasoning-capable models (OpenAI o-series / GPT-5, DeepSeek R1,
+  // Qwen QwQ, OpenRouter pass-through, etc.) — let pi-ai's adapter decide
+  // based on the model capability flag. Non-reasoning models drop it.
+  return 'auto';
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -401,14 +401,18 @@ const MAX_OUTPUT_TOKENS = 32000;
 const CLAUDE_4_MODEL_RE = /claude-(?:opus|sonnet)-4/i;
 
 function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
-  // Claude 4.x — explicit high (extended thinking).
+  // Whitelist of known reasoning-capable models. Sending `reasoning` to a
+  // non-reasoning model is a silent fallback (OpenAI/OpenRouter drop it,
+  // older Anthropic Claudes get coerced to 'high' and unintentionally enable
+  // extended thinking) — that violates the project's "no silent fallbacks"
+  // rule, so default to undefined unless we are sure the model supports it.
   if (model.provider === 'anthropic' && CLAUDE_4_MODEL_RE.test(model.modelId)) {
     return 'high';
   }
-  // Other reasoning-capable models (OpenAI o-series / GPT-5, DeepSeek R1,
-  // Qwen QwQ, OpenRouter pass-through, etc.) — let pi-ai's adapter decide
-  // based on the model capability flag. Non-reasoning models drop it.
-  return 'auto';
+  if (/\b(o1|o3|o4|gpt-5)/i.test(model.modelId)) return 'high';
+  if (/deepseek.*r1|r1.*deepseek/i.test(model.modelId)) return 'high';
+  if (/\bqwq\b/i.test(model.modelId)) return 'high';
+  return undefined;
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -399,20 +399,29 @@ const MAX_OUTPUT_TOKENS = 32000;
 
 /** Match Anthropic's Claude 4.x family, which supports extended thinking. */
 const CLAUDE_4_MODEL_RE = /claude-(?:opus|sonnet)-4/i;
+/** OpenAI reasoning families (o-series and gpt-5). Anchored to the start of
+ *  the modelId so a tenant prefix or pass-through path can't sneak through. */
+const OPENAI_REASONING_MODEL_RE = /^(?:o1|o3|o4|gpt-5)(?:[-.].*)?$/i;
 
 function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
-  // Whitelist of known reasoning-capable models. Sending `reasoning` to a
-  // non-reasoning model is a silent fallback (OpenAI/OpenRouter drop it,
-  // older Anthropic Claudes get coerced to 'high' and unintentionally enable
-  // extended thinking) — that violates the project's "no silent fallbacks"
-  // rule, so default to undefined unless we are sure the model supports it.
-  if (model.provider === 'anthropic' && CLAUDE_4_MODEL_RE.test(model.modelId)) {
-    return 'high';
+  // Whitelist by (provider, modelId) pair. Substring matches across providers
+  // are unsafe: an OpenRouter or Groq pass-through id like
+  // `anthropic/claude-4` or any third-party id containing "o1"/"r1" would
+  // otherwise silently enable reasoning on a model that does not support it.
+  // The whole point of this gate is to avoid silent fallbacks, so require
+  // both axes to match a first-party provider we trust.
+  switch (model.provider) {
+    case 'anthropic':
+      return CLAUDE_4_MODEL_RE.test(model.modelId) ? 'high' : undefined;
+    case 'openai':
+      return OPENAI_REASONING_MODEL_RE.test(model.modelId) ? 'high' : undefined;
+    default:
+      // openrouter, groq, cerebras, xai, mistral, bedrock, azure, vercel-ai-gateway:
+      // all pass-through or multi-tenant. Even if they serve a reasoning model,
+      // we cannot trust the model id alone, and pi-ai will silently drop or
+      // mistranslate the reasoning knob. Stay conservative.
+      return undefined;
   }
-  if (/\b(o1|o3|o4|gpt-5)/i.test(model.modelId)) return 'high';
-  if (/deepseek.*r1|r1.*deepseek/i.test(model.modelId)) return 'high';
-  if (/\bqwq\b/i.test(model.modelId)) return 'high';
-  return undefined;
 }
 
 export async function generate(input: GenerateInput): Promise<GenerateOutput> {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -12,10 +12,10 @@ import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/s
  * field, which Anthropic adapters translate to extended-thinking effort/budget
  * (and OpenAI/Gemini adapters translate to their respective reasoning knobs).
  *
- * `'auto'` is an open-codesign sentinel — pi-ai itself only knows the named
- * effort levels. Provider adapters that recognize a reasoning capability on
- * the model will translate it; non-reasoning models silently drop it. */
-export type ReasoningLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'auto';
+ * Only the named effort levels pi-ai actually understands. Sending this to a
+ * non-reasoning model is a silent fallback, so callers must whitelist
+ * known-capable models before passing a value (see `reasoningForModel`). */
+export type ReasoningLevel = 'low' | 'medium' | 'high' | 'xhigh';
 
 export interface GenerateOptions {
   apiKey: string;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -10,8 +10,12 @@ import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/s
 
 /** Subset of pi-ai's `ThinkingLevel` we expose. Maps directly to its `reasoning`
  * field, which Anthropic adapters translate to extended-thinking effort/budget
- * (and OpenAI/Gemini adapters translate to their respective reasoning knobs). */
-export type ReasoningLevel = 'low' | 'medium' | 'high' | 'xhigh';
+ * (and OpenAI/Gemini adapters translate to their respective reasoning knobs).
+ *
+ * `'auto'` is an open-codesign sentinel — pi-ai itself only knows the named
+ * effort levels. Provider adapters that recognize a reasoning capability on
+ * the model will translate it; non-reasoning models silently drop it. */
+export type ReasoningLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'auto';
 
 export interface GenerateOptions {
   apiKey: string;


### PR DESCRIPTION
Claude 4 仍然 explicit 'high'，其他 provider 改 'auto' 让 pi-ai 决定。让 OpenRouter elephant-alpha / OpenAI o-series / DeepSeek R1 等也能享受 reasoning。