### PR TITLE
fix(providers): treat empty Retry-After header as no hint

### DIFF
--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -32,6 +32,23 @@ describe('classifyError', () => {
     expect(d.retry).toBe(true);
     expect(d.retryAfterMs).toBe(7000);
   });
+  it('treats empty retry-after as no hint (not 0ms)', () => {
+    const d = classifyError(new HttpError('slow', 429, { 'retry-after': '' }));
+    expect(d.retry).toBe(true);
+    expect(d.retryAfterMs).toBeUndefined();
+  });
+  it('treats whitespace-only retry-after as no hint', () => {
+    const d = classifyError(new HttpError('slow', 429, { 'retry-after': '   ' }));
+    expect(d.retry).toBe(true);
+    expect(d.retryAfterMs).toBeUndefined();
+  });
+  it('parses HTTP-date retry-after to a delay relative to now', () => {
+    const future = new Date(Date.now() + 2_000).toUTCString();
+    const d = classifyError(new HttpError('slow', 429, { 'retry-after': future }));
+    expect(d.retry).toBe(true);
+    expect(d.retryAfterMs).toBeGreaterThanOrEqual(0);
+    expect(d.retryAfterMs).toBeLessThanOrEqual(2_500);
+  });
   it('marks AbortError as not retryable', () => {
     const err = new DOMException('Aborted', 'AbortError');
     expect(classifyError(err)).toMatchObject({ retry: false, reason: 'aborted' });

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -119,9 +119,17 @@ function extractRetryAfterMs(err: unknown): number | undefined {
     pickHeader(headers, 'retry-after') ??
     (typeof direct === 'string' || typeof direct === 'number' ? String(direct) : undefined);
   if (raw === undefined) return undefined;
-  const seconds = Number(raw);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
-  const dateMs = Date.parse(raw);
+  const trimmed = raw.trim();
+  // Empty / whitespace-only headers must not coerce to 0 via Number(''),
+  // which would otherwise emit a zero-delay retry hint and defeat backoff.
+  if (trimmed.length === 0) return undefined;
+  // Numeric path first — explicit shape so '7' / '1.5' parse but a
+  // Date-formatted header ('Wed, 21 Oct 2015 …') falls through to Date.parse.
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  }
+  const dateMs = Date.parse(trimmed);
   if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
   return undefined;
 }


### PR DESCRIPTION
## Summary
- `extractRetryAfterMs` was passing the raw header to `Number(...)`, so an empty/whitespace-only `Retry-After` coerced to `0` and emitted a misleading `retryAfterMs=0` hint to `onRetry` callbacks (downstream `buildRetryInfo` clamps to backoff so behavior wasn't catastrophic, but the signal was wrong).
- Reject empty / whitespace strings, gate the seconds path on a numeric-only regex, and fall through to `Date.parse` for HTTP-date `Retry-After` values.

## Changes
- `packages/providers/src/retry.ts` — guard empty/whitespace input, numeric regex before `Number(...)`.
- `packages/providers/src/retry.test.ts` — three new tests: empty header, whitespace-only header, HTTP-date header.

## PRINCIPLES check
- Compatibility: no API/contract change.
- Upgradeability: pure function, no schema impact.
- No bloat: same module, +0 deps.
- Elegance: removes a silent footgun.

## Test plan
- [x] `pnpm --filter @open-codesign/providers test` — 39 passed (was 36).
- [x] `pnpm --filter @open-codesign/providers typecheck`.
- [x] `pnpm exec biome check packages/providers/src/retry.ts packages/providers/src/retry.test.ts`.