### PR TITLE
fix(desktop): add 10s timeout to connection-ipc fetches

### DIFF
--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -7,10 +7,12 @@ vi.mock('./electron-runtime', () => ({
 
 import { createHash } from 'node:crypto';
 import {
+  CONNECTION_FETCH_TIMEOUT_MS,
   _clearModelsCache,
   classifyHttpError,
   extractIds,
   extractModelIds,
+  fetchWithTimeout,
   getCacheKey,
   normalizeBaseUrl,
 } from './connection-ipc';
@@ -540,5 +542,44 @@ describe('normalizeBaseUrl', () => {
     expect(normalizeBaseUrl('https://generativelanguage.googleapis.com', 'google')).toBe(
       'https://generativelanguage.googleapis.com',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWithTimeout — aborts when the host hangs past the deadline
+// ---------------------------------------------------------------------------
+
+describe('fetchWithTimeout', () => {
+  it('exports a finite default timeout', () => {
+    expect(Number.isFinite(CONNECTION_FETCH_TIMEOUT_MS)).toBe(true);
+    expect(CONNECTION_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it('aborts the underlying fetch when the timer fires', async () => {
+    vi.useRealTimers();
+    const seenSignals: AbortSignal[] = [];
+    const fakeFetch = vi.fn(
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init.signal as AbortSignal;
+          seenSignals.push(signal);
+          signal.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+    const originalFetch = globalThis.fetch;
+    (globalThis as { fetch: typeof fetch }).fetch = fakeFetch as unknown as typeof fetch;
+
+    try {
+      await expect(fetchWithTimeout('https://example.test', {}, 5)).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      expect(seenSignals[0]?.aborted).toBe(true);
+    } finally {
+      (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    }
   });
 });

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -168,6 +168,12 @@ export function classifyHttpError(status: number): {
 
 function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']; hint: string } {
   const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof Error && err.name === 'AbortError') {
+    return {
+      code: 'NETWORK',
+      hint: `请求超时（>${CONNECTION_FETCH_TIMEOUT_MS / 1000}s），检查 baseUrl 与网络可达性`,
+    };
+  }
   if (message.includes('ECONNREFUSED') || message.includes('ENOTFOUND')) {
     return {
       code: 'ECONNREFUSED',
@@ -184,6 +190,25 @@ function classifyNetworkError(err: unknown): { code: ConnectionTestError['code']
     code: 'NETWORK',
     hint: `网络错误：${message}。查看日志：~/Library/Logs/open-codesign/main.log`,
   };
+}
+
+// Provider /models endpoints normally return in <1s. Anything past 10s means the
+// host is unreachable or stuck — better to surface a clear NETWORK error than to
+// pin the renderer's "Test connection" spinner forever.
+export const CONNECTION_FETCH_TIMEOUT_MS = 10_000;
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = CONNECTION_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function extractIds(items: unknown[]): string[] | null {
@@ -327,7 +352,7 @@ export function registerConnectionIpc(): void {
 
       let res: Response;
       try {
-        res = await fetch(ep.url, {
+        res = await fetchWithTimeout(ep.url, {
           method: 'GET',
           headers: { ...ep.headers, ...authHeaders },
         });
@@ -378,7 +403,7 @@ export function registerConnectionIpc(): void {
 
     let res: Response;
     try {
-      res = await fetch(ep.url, {
+      res = await fetchWithTimeout(ep.url, {
         method: 'GET',
         headers: { ...ep.headers, ...authHeaders },
       });
@@ -435,7 +460,10 @@ export function registerConnectionIpc(): void {
 
     let res: Response;
     try {
-      res = await fetch(ep.url, { method: 'GET', headers: { ...ep.headers, ...authHeaders } });
+      res = await fetchWithTimeout(ep.url, {
+        method: 'GET',
+        headers: { ...ep.headers, ...authHeaders },
+      });
     } catch (err) {
       const { code, hint } = classifyNetworkError(err);
       return {


### PR DESCRIPTION
## Summary
- Wrap all three connection IPC `fetch` calls (`connection:v1:test`, `models:v1:list`, `connection:v1:test-active`) in a `fetchWithTimeout` helper backed by `AbortController` (default 10s).
- Surface AbortError as a clear NETWORK hint so the user sees a timeout message instead of a permanently spinning button.
- Add a unit test that drives the helper with a hanging fake `fetch` and asserts the abort fires.

## Why
Without an `AbortSignal`, an unreachable or slow `baseUrl` would pin the renderer's "Test connection" spinner indefinitely (no main-side timeout, no Node-default fetch timeout). 10s is well above the <1s normal /models latency but short enough that the UI fails fast.

## PRINCIPLES §5b
- Compatibility green — same response shape, same error codes
- Upgradeability green — `CONNECTION_FETCH_TIMEOUT_MS` exported as a single source of truth
- No bloat green — pure stdlib, no new deps
- Elegance green — one helper, three call sites

## Test plan
- [x] `pnpm --filter @open-codesign/desktop exec vitest run src/main/connection-ipc.test.ts` — 41/41 pass (incl. new fetchWithTimeout abort test)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — 0 errors (pre-existing complexity warnings unrelated)