### PR TITLE
fix(desktop): persist generated artifacts so designs reload correctly

### DIFF
--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -616,3 +616,135 @@ describe('useCodesignStore previewZoom', () => {
     expect(useCodesignStore.getState().previewZoom).toBe(150);
   });
 });
+
+describe('useCodesignStore artifact persistence', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('writes a design_snapshots row after generate.ok and rehydrates the preview on switchDesign', async () => {
+    const designId = 'design-persist';
+    const designRow = {
+      schemaVersion: 1 as const,
+      id: designId,
+      name: 'Untitled design 1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      thumbnailText: null,
+      deletedAt: null,
+    };
+
+    // Stand-in for the SQLite-backed snapshots table.
+    type SnapshotRow = {
+      schemaVersion: 1;
+      id: string;
+      designId: string;
+      parentId: string | null;
+      type: 'initial' | 'edit' | 'fork';
+      prompt: string | null;
+      artifactType: 'html' | 'react' | 'svg';
+      artifactSource: string;
+      createdAt: string;
+      message?: string;
+    };
+    const snapshotsByDesign = new Map<string, SnapshotRow[]>();
+    let nextSnapshotId = 1;
+
+    const generate = vi.fn(() =>
+      Promise.resolve({
+        artifacts: [{ type: 'html', content: '<html><body>persisted</body></html>' }],
+        message: 'Generated.',
+      }),
+    );
+    const replaceMessages = vi.fn(() => Promise.resolve([]));
+    const setThumbnail = vi.fn(() => Promise.resolve(designRow));
+    const renameDesign = vi.fn(() => Promise.resolve(designRow));
+    const listDesigns = vi.fn(() => Promise.resolve([designRow]));
+    const list = vi.fn((id: string) =>
+      Promise.resolve([...(snapshotsByDesign.get(id) ?? [])].reverse()),
+    );
+    const create = vi.fn((input: Omit<SnapshotRow, 'id' | 'createdAt' | 'schemaVersion'>) => {
+      const row: SnapshotRow = {
+        schemaVersion: 1,
+        id: `snap-${nextSnapshotId++}`,
+        createdAt: new Date().toISOString(),
+        ...input,
+      };
+      const bucket = snapshotsByDesign.get(input.designId) ?? [];
+      bucket.push(row);
+      snapshotsByDesign.set(input.designId, bucket);
+      return Promise.resolve(row);
+    });
+    const listMessages = vi.fn(() =>
+      Promise.resolve([
+        {
+          schemaVersion: 1 as const,
+          designId,
+          ordinal: 0,
+          role: 'user' as const,
+          content: 'make a hero section',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          schemaVersion: 1 as const,
+          designId,
+          ordinal: 1,
+          role: 'assistant' as const,
+          content: 'Generated.',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ]),
+    );
+
+    vi.stubGlobal('window', {
+      codesign: {
+        generate,
+        snapshots: {
+          listDesigns,
+          list,
+          create,
+          replaceMessages,
+          setThumbnail,
+          renameDesign,
+          listMessages,
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({ currentDesignId: designId, designs: [designRow] });
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'make a hero section' });
+    // persistDesignState fires-and-forgets; drain microtasks until create resolves.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(create).toHaveBeenCalledOnce();
+    const createArg = create.mock.calls[0]?.[0];
+    expect(createArg).toMatchObject({
+      designId,
+      parentId: null,
+      type: 'initial',
+      artifactType: 'html',
+      artifactSource: '<html><body>persisted</body></html>',
+      prompt: 'make a hero section',
+    });
+    expect(snapshotsByDesign.get(designId)).toHaveLength(1);
+
+    // Simulate a fresh app load: blow away in-memory state then switchDesign.
+    useCodesignStore.setState({
+      currentDesignId: null,
+      messages: [],
+      previewHtml: null,
+    });
+
+    await useCodesignStore.getState().switchDesign(designId);
+
+    const restored = useCodesignStore.getState();
+    expect(restored.currentDesignId).toBe(designId);
+    expect(restored.previewHtml).toBe('<html><body>persisted</body></html>');
+    expect(restored.messages).toEqual([
+      { role: 'user', content: 'make a hero section' },
+      { role: 'assistant', content: 'Generated.' },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/store.toSnapshotArtifactType.test.ts
+++ b/apps/desktop/src/renderer/src/store.toSnapshotArtifactType.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { toSnapshotArtifactType } from './store';
+
+describe('toSnapshotArtifactType', () => {
+  it('folds html/slides/bundle/undefined into html', () => {
+    expect(toSnapshotArtifactType(undefined)).toBe('html');
+    expect(toSnapshotArtifactType('html')).toBe('html');
+    expect(toSnapshotArtifactType('slides')).toBe('html');
+    expect(toSnapshotArtifactType('bundle')).toBe('html');
+  });
+
+  it('passes svg and react through', () => {
+    expect(toSnapshotArtifactType('svg')).toBe('svg');
+    expect(toSnapshotArtifactType('react')).toBe('react');
+  });
+
+  it('throws on unknown coreType instead of silently returning html', () => {
+    expect(() => toSnapshotArtifactType('mystery')).toThrow(
+      /Unsupported artifact type for snapshot persistence: mystery/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -283,13 +283,25 @@ function isDefaultDesignName(name: string): boolean {
 }
 
 // Core emits 'html' | 'svg' | 'slides' | 'bundle' but the snapshots schema only
-// stores 'html' | 'react' | 'svg' (see DesignSnapshotV1). 'slides'/'bundle' fall
-// through to 'html' because their on-disk source is HTML — keeping the column
+// stores 'html' | 'react' | 'svg' (see DesignSnapshotV1). 'slides'/'bundle' fold
+// into 'html' because their on-disk source is HTML — keeping the column
 // constraint stable means we don't need a schema migration to persist them.
-function toSnapshotArtifactType(coreType: string | undefined): 'html' | 'react' | 'svg' {
-  if (coreType === 'svg') return 'svg';
-  if (coreType === 'react') return 'react';
-  return 'html';
+// Unknown types throw so a new core ArtifactType doesn't silently round-trip
+// as the wrong renderer.
+export function toSnapshotArtifactType(coreType: string | undefined): 'html' | 'react' | 'svg' {
+  switch (coreType) {
+    case undefined:
+    case 'html':
+    case 'slides':
+    case 'bundle':
+      return 'html';
+    case 'svg':
+      return 'svg';
+    case 'react':
+      return 'react';
+    default:
+      throw new Error(`Unsupported artifact type for snapshot persistence: ${coreType}`);
+  }
 }
 
 interface PersistArtifact {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -282,11 +282,55 @@ function isDefaultDesignName(name: string): boolean {
   return name === 'Untitled design' || /^Untitled design \d+$/.test(name);
 }
 
+// Core emits 'html' | 'svg' | 'slides' | 'bundle' but the snapshots schema only
+// stores 'html' | 'react' | 'svg' (see DesignSnapshotV1). 'slides'/'bundle' fall
+// through to 'html' because their on-disk source is HTML — keeping the column
+// constraint stable means we don't need a schema migration to persist them.
+function toSnapshotArtifactType(coreType: string | undefined): 'html' | 'react' | 'svg' {
+  if (coreType === 'svg') return 'svg';
+  if (coreType === 'react') return 'react';
+  return 'html';
+}
+
+interface PersistArtifact {
+  type: string | undefined;
+  content: string;
+  prompt: string | null;
+  message: string | null;
+}
+
+function artifactFromResult(
+  source: { type?: string; content: string } | undefined,
+  prompt: string | null,
+  message: string | null,
+): PersistArtifact | null {
+  if (!source) return null;
+  return { type: source.type, content: source.content, prompt, message };
+}
+
+async function persistArtifactSnapshot(designId: string, artifact: PersistArtifact): Promise<void> {
+  if (!window.codesign) return;
+  // Look up the latest snapshot to chain parentId; the first generation in a
+  // design has no parent and uses type='initial', subsequent ones use 'edit'.
+  const existing = await window.codesign.snapshots.list(designId);
+  const parent = existing[0] ?? null;
+  await window.codesign.snapshots.create({
+    designId,
+    parentId: parent?.id ?? null,
+    type: parent ? 'edit' : 'initial',
+    prompt: artifact.prompt,
+    artifactType: toSnapshotArtifactType(artifact.type),
+    artifactSource: artifact.content,
+    ...(artifact.message ? { message: artifact.message } : {}),
+  });
+}
+
 async function persistDesignState(
   get: GetState,
   designId: string,
   messages: ChatMessage[],
   previewHtml: string | null,
+  artifact: PersistArtifact | null,
 ): Promise<void> {
   if (!window.codesign) return;
   try {
@@ -294,6 +338,9 @@ async function persistDesignState(
       designId,
       messages.map((m) => ({ role: m.role, content: m.content })),
     );
+    if (artifact !== null) {
+      await persistArtifactSnapshot(designId, artifact);
+    }
     if (previewHtml !== null) {
       const firstUser = messages.find((m) => m.role === 'user');
       const thumbText = firstUser ? firstUser.content.slice(0, 200) : null;
@@ -363,14 +410,13 @@ function applyGenerateSuccess(
   set: SetState,
   get: GetState,
   generationId: string,
-  result: { artifacts: Array<{ content: string }>; message: string },
+  prompt: string,
+  result: { artifacts: Array<{ type?: string; content: string }>; message: string },
 ): void {
   const firstArtifact = result.artifacts[0];
+  const assistantMessage = result.message || tr('common.done');
   finishIfCurrent(set, generationId, (state) => ({
-    messages: [
-      ...state.messages,
-      { role: 'assistant', content: result.message || tr('common.done') },
-    ],
+    messages: [...state.messages, { role: 'assistant', content: assistantMessage }],
     previewHtml: firstArtifact?.content ?? state.previewHtml,
     isGenerating: false,
     activeGenerationId: null,
@@ -378,7 +424,8 @@ function applyGenerateSuccess(
   }));
   const designId = get().currentDesignId;
   if (designId) {
-    void persistDesignState(get, designId, get().messages, get().previewHtml);
+    const artifact = artifactFromResult(firstArtifact, prompt, assistantMessage);
+    void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
   }
 }
 
@@ -435,7 +482,8 @@ async function runGenerate(
     set,
     get,
     generationId,
-    result as { artifacts: Array<{ content: string }>; message: string },
+    payload.prompt,
+    result as { artifacts: Array<{ type?: string; content: string }>; message: string },
   );
 }
 
@@ -736,15 +784,18 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
         attachments,
       });
       const firstArtifact = result.artifacts[0];
+      const assistantText = result.message || tr('common.applied');
       set((s) => ({
-        messages: [
-          ...s.messages,
-          { role: 'assistant', content: result.message || tr('common.applied') },
-        ],
+        messages: [...s.messages, { role: 'assistant', content: assistantText }],
         previewHtml: firstArtifact?.content ?? s.previewHtml,
         isGenerating: false,
         selectedElement: null,
       }));
+      const designId = get().currentDesignId;
+      if (designId) {
+        const artifact = artifactFromResult(firstArtifact, userMessage.content, assistantText);
+        void persistDesignState(get, designId, get().messages, get().previewHtml, artifact);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : tr('errors.unknown');
       set((s) => ({


### PR DESCRIPTION
## Bug

After a successful generation the renderer showed the artifact, but reopening the design later showed only an empty assistant message wrapper (` ```html\n\n``` `). Inspection of `~/Library/Application Support/@open-codesign/desktop/designs.db` confirmed the cause:

- `designs`: 2 rows
- `design_messages`: contained the user prompt + an assistant text wrapper
- `design_snapshots`: **0 rows**

The `generate.ok` IPC log reported `artifacts: 1`, so the artifact reached the renderer fine — but the persist path (`persistDesignState`) only wrote messages + thumbnail and never created a snapshot. `switchDesign` reads `previewHtml` from the latest snapshot, so the preview came back empty on reload.

## Fix (option a — write to `design_snapshots`)

That table is already purpose-built (`artifact_type`, `artifact_source`, `prompt`, `parent_id` chain) and the IPC channel `snapshots:v1:create` was already wired through preload. We:

1. Pass the produced artifact (`type`, `content`, `prompt`, `message`) into `persistDesignState` after both `applyGenerateSuccess` and `applyInlineComment`.
2. Look up the latest snapshot for the design to get `parentId`; first generation uses `type: 'initial'`, subsequent ones `type: 'edit'`.
3. Map core's `Artifact.type` (`'html' | 'svg' | 'slides' | 'bundle'`) onto the snapshot column's allowed values (`'html' | 'react' | 'svg'`); `slides` / `bundle` fall through to `'html'` because their on-disk source is HTML — keeps the CHECK constraint stable, no migration needed.
4. `switchDesign` already rehydrates `previewHtml` from `snapshots[0].artifactSource`, so the reload path now restores the artifact correctly.

Option (b) — embedding the source into the assistant message body — was rejected because it would duplicate large HTML blobs into chat history, defeat existing snapshot lineage / parent_id chaining, and waste the schema we already pay for.

## Tests

New Vitest in `apps/desktop/src/renderer/src/store.test.ts` covering the full round-trip:
- Mock `generate` to return one HTML artifact.
- Run `sendPrompt` against a known `currentDesignId`.
- Assert `snapshots.create` was invoked with `{ type: 'initial', artifactType: 'html', artifactSource, prompt, parentId: null }` and that the in-memory snapshots store now holds the row.
- Wipe in-memory state to simulate a fresh app load, call `switchDesign`, and assert `previewHtml` + `messages` are restored.

All 289 desktop tests pass; lint + typecheck clean.

## PRINCIPLES check

- Compatibility: green — no schema bump, existing rows stay valid, no IPC channel signature changed.
- Upgradeability: green — reuses the schema-versioned `snapshots:v1:*` channels and `DesignSnapshotV1.schemaVersion = 1`.
- No bloat: green — zero new dependencies, ~60 LOC of store wiring + a small mapping helper.
- Elegance: green — the persist path now mirrors the read path (snapshots in / snapshots out); no parallel storage formats.