### PR TITLE
fix(desktop): validate locale:set input against supported locales

### DIFF
--- a/apps/desktop/src/main/locale-ipc.test.ts
+++ b/apps/desktop/src/main/locale-ipc.test.ts
@@ -26,6 +26,7 @@ describe('locale-ipc XDG_CONFIG_HOME', () => {
     const prev = process.env['XDG_CONFIG_HOME'];
     process.env['XDG_CONFIG_HOME'] = '/tmp/xdg-locale-test';
     try {
+      writeFileMock.mockClear();
       const handlers = new Map<string, (...args: unknown[]) => unknown>();
       const handleMock = ipcMain.handle as unknown as ReturnType<typeof vi.fn>;
       handleMock.mockImplementation((channel: unknown, fn: unknown) => {
@@ -34,7 +35,7 @@ describe('locale-ipc XDG_CONFIG_HOME', () => {
       registerLocaleIpc();
       const setHandler = handlers.get('locale:set');
       if (!setHandler) throw new Error('locale:set not registered');
-      await setHandler({}, 'fr-FR');
+      await setHandler({}, 'zh-CN');
       expect(writeFileMock).toHaveBeenCalled();
       const firstCall = writeFileMock.mock.calls[0];
       expect(firstCall?.[0]).toBe('/tmp/xdg-locale-test/open-codesign/locale.json');
@@ -42,5 +43,45 @@ describe('locale-ipc XDG_CONFIG_HOME', () => {
       if (prev === undefined) process.env['XDG_CONFIG_HOME'] = undefined;
       else process.env['XDG_CONFIG_HOME'] = prev;
     }
+  });
+});
+
+describe('locale-ipc input validation', () => {
+  function getSetHandler(): (...args: unknown[]) => unknown {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const handleMock = ipcMain.handle as unknown as ReturnType<typeof vi.fn>;
+    handleMock.mockImplementation((channel: unknown, fn: unknown) => {
+      handlers.set(channel as string, fn as (...args: unknown[]) => unknown);
+    });
+    registerLocaleIpc();
+    const fn = handlers.get('locale:set');
+    if (!fn) throw new Error('locale:set not registered');
+    return fn;
+  }
+
+  it('rejects unsupported locale tags instead of writing garbage to disk', async () => {
+    writeFileMock.mockClear();
+    const set = getSetHandler();
+    await expect(set({}, 'fr-FR')).rejects.toThrow(/unsupported locale/);
+    await expect(set({}, 'klingon')).rejects.toThrow(/unsupported locale/);
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('canonicalizes alias forms before persisting', async () => {
+    writeFileMock.mockClear();
+    const set = getSetHandler();
+    const result = await set({}, 'zh-Hans-CN');
+    expect(result).toBe('zh-CN');
+    const firstCall = writeFileMock.mock.calls.at(-1);
+    const persisted = JSON.parse(String(firstCall?.[1] ?? '{}'));
+    expect(persisted.locale).toBe('zh-CN');
+    expect(persisted.schemaVersion).toBe(1);
+  });
+
+  it('rejects empty / non-string input', async () => {
+    const set = getSetHandler();
+    await expect(set({}, '')).rejects.toThrow();
+    await expect(set({}, 123)).rejects.toThrow();
+    await expect(set({}, null)).rejects.toThrow();
   });
 });

--- a/apps/desktop/src/main/locale-ipc.ts
+++ b/apps/desktop/src/main/locale-ipc.ts
@@ -13,6 +13,7 @@
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { availableLocales, isSupportedLocale, normalizeLocale } from '@open-codesign/i18n';
 import { configDir } from './config';
 import { app, ipcMain } from './electron-runtime';
 
@@ -63,7 +64,25 @@ export function registerLocaleIpc(): void {
     if (typeof raw !== 'string' || raw.length === 0) {
       throw new Error('locale:set expects a non-empty string');
     }
-    await writePersisted(raw);
-    return raw;
+    // Reject unknown tags up-front rather than persisting garbage and relying
+    // on read-time normalization to silently rewrite to "en". A bad write here
+    // would mask renderer bugs and leave users on the wrong language until
+    // they manually clear locale.json.
+    const lower = raw.toLowerCase();
+    const recognized =
+      isSupportedLocale(raw) ||
+      lower === 'zh' ||
+      lower.startsWith('zh-hans') ||
+      lower === 'zh-cn' ||
+      lower === 'zh_cn' ||
+      lower.startsWith('en');
+    if (!recognized) {
+      throw new Error(
+        `locale:set received unsupported locale "${raw}"; expected one of: ${availableLocales.join(', ')}`,
+      );
+    }
+    const canonical = normalizeLocale(raw);
+    await writePersisted(canonical);
+    return canonical;
   });
 }


### PR DESCRIPTION
## Summary
- `locale:set` IPC accepted any non-empty string and persisted it to `~/.config/open-codesign/locale.json`. `normalizeLocale` then silently rewrote bad values to `en` at read time, masking the underlying bug and stranding users on the wrong language until they cleared the file.
- Reject unsupported tags up-front, canonicalize known aliases (`zh-Hans-CN` → `zh-CN`) before persisting, and add tests for rejection, canonicalization, and bad input shapes.

## Constraint check (PRINCIPLES §5b)
- Compatibility: green — accepted tags unchanged; only previously-broken inputs now error.
- Upgradeability: green — file format `{schemaVersion: 1, locale}` unchanged; we just stop writing garbage into `locale`.
- No bloat: green — uses existing `@open-codesign/i18n` exports; no new deps.
- Elegance: green — small, contained validation at the IPC boundary.

## Test plan
- [x] `pnpm --filter @open-codesign/desktop test -- src/main/locale-ipc.test.ts` (4/4 pass)
- [x] `pnpm --filter @open-codesign/desktop typecheck`
- [x] `pnpm exec biome check apps/desktop/src/main/locale-ipc.ts apps/desktop/src/main/locale-ipc.test.ts`