### PR TITLE
fix(desktop): load designs on app startup so persisted work reappears

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -20,6 +20,8 @@ export function App() {
   const config = useCodesignStore((s) => s.config);
   const configLoaded = useCodesignStore((s) => s.configLoaded);
   const loadConfig = useCodesignStore((s) => s.loadConfig);
+  const loadDesigns = useCodesignStore((s) => s.loadDesigns);
+  const switchDesign = useCodesignStore((s) => s.switchDesign);
   const sendPrompt = useCodesignStore((s) => s.sendPrompt);
   const isGenerating = useCodesignStore((s) => s.isGenerating);
   const setView = useCodesignStore((s) => s.setView);
@@ -38,8 +40,16 @@ export function App() {
   const [prompt, setPrompt] = useState('');
 
   useEffect(() => {
-    void loadConfig();
-  }, [loadConfig]);
+    async function bootstrap(): Promise<void> {
+      await Promise.all([loadConfig(), loadDesigns()]);
+      const state = useCodesignStore.getState();
+      if (state.currentDesignId === null && state.designs.length > 0) {
+        const first = state.designs[0];
+        if (first) await switchDesign(first.id);
+      }
+    }
+    void bootstrap();
+  }, [loadConfig, loadDesigns, switchDesign]);
 
   function submit(): void {
     const trimmed = prompt.trim();

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -748,3 +748,45 @@ describe('useCodesignStore artifact persistence', () => {
     ]);
   });
 });
+
+describe('loadDesigns startup', () => {
+  it('populates designs from listDesigns IPC so persisted work reappears after relaunch', async () => {
+    const designs = [
+      {
+        schemaVersion: 1 as const,
+        id: 'design-1',
+        name: 'Persisted A',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+        thumbnailText: null,
+        deletedAt: null,
+      },
+      {
+        schemaVersion: 1 as const,
+        id: 'design-2',
+        name: 'Persisted B',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        thumbnailText: null,
+        deletedAt: null,
+      },
+    ];
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          listDesigns: vi.fn(() => Promise.resolve(designs)),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({ designs: [], designsLoaded: false });
+    await useCodesignStore.getState().loadDesigns();
+
+    const state = useCodesignStore.getState();
+    expect(state.designs).toHaveLength(2);
+    expect(state.designs.map((d) => d.id)).toEqual(['design-1', 'design-2']);
+    expect(state.designsLoaded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Symptom

Users reported "退出再进来 design 都没了" — generated designs were correctly persisted to SQLite (`design_snapshots` rows confirmed present), but on relaunch the hub appeared empty.

## Root cause

`apps/desktop/src/renderer/src/App.tsx` only invoked `loadConfig()` in the startup `useEffect`. The store already had `loadDesigns()` (which calls `window.codesign.snapshots.listDesigns()` and populates `designs`), but nothing in the renderer ever called it on mount. So the in-memory list stayed empty even though the DB had rows.

## Fix

- App startup effect now runs `loadConfig` and `loadDesigns` in parallel.
- After they resolve, if `currentDesignId` is null and at least one persisted design exists, auto-`switchDesign` to the most recent one (first item — `listDesigns` is already sorted by activity), so users land back on their last work.
- Added a Vitest case in `store.test.ts` that stubs `listDesigns` to return 2 rows and verifies `state.designs.length === 2` plus `designsLoaded === true`.

This completes the persistence flow opened by #93.

## Four checks

- Compatibility: green — no IPC / schema changes, only renderer wiring.
- Upgradeability: green — uses existing `loadDesigns` / `switchDesign` actions.
- No bloat: green — no new deps, ~10 lines added in `App.tsx`.
- Elegance: green — reuses existing store actions; explicit, no factories.

## Test plan

- [x] `pnpm test` — 293 passed (was 292; +1 new case).
- [x] `pnpm lint` — passes (existing warnings only).
- [ ] Manual: start app → create design → quit → relaunch → confirm design appears in hub and last design is restored.