### PR TITLE
feat(core): switch skills to progressive-disclosure model routing

### DIFF
--- a/.changeset/skills-progressive-disclosure.md
+++ b/.changeset/skills-progressive-disclosure.md
@@ -1,0 +1,6 @@
+---
+'@open-codesign/core': minor
+'@open-codesign/providers': minor
+---
+
+Switch skill routing to progressive-disclosure model selection. The previous keyword-intersection matcher dropped every Chinese prompt because builtin skill descriptions are English-only; now all four builtin skill bodies are loaded into the system prompt unconditionally and the model picks. Removes `matchSkillsToPrompt` / `SKILL_TRIGGER_GROUPS`; adds `formatSkillsForPrompt`.

--- a/.changeset/skills-progressive-disclosure.md
+++ b/.changeset/skills-progressive-disclosure.md
@@ -3,4 +3,6 @@
 '@open-codesign/providers': minor
 ---
 
-Switch skill routing to progressive-disclosure model selection. The previous keyword-intersection matcher dropped every Chinese prompt because builtin skill descriptions are English-only; now all four builtin skill bodies are loaded into the system prompt unconditionally and the model picks. Removes `matchSkillsToPrompt` / `SKILL_TRIGGER_GROUPS`; adds `formatSkillsForPrompt`.
+Switch skill routing to progressive-disclosure model selection. The previous keyword-intersection matcher dropped every Chinese prompt because builtin skill descriptions are English-only; now all four builtin skill bodies are loaded into the system prompt unconditionally and the model picks which one to apply.
+
+**BREAKING (pre-1.0 minor per Changesets semver):** removed public exports `matchSkillsToPrompt` and `SKILL_TRIGGER_GROUPS` from `@open-codesign/providers`. Use the new always-load `formatSkillsForPrompt` instead. The desktop app is the only known consumer and has been migrated in this PR.

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -488,6 +488,7 @@ describe('generate()', () => {
       '[generate] step=resolve_model',
       '[generate] step=resolve_model.ok',
       '[generate] step=build_request',
+      '[generate] step=load_skills.ok',
       '[generate] step=build_request.ok',
       '[generate] step=send_request',
       '[generate] step=send_request.ok',
@@ -646,7 +647,7 @@ describe('generate() skills injection', () => {
     body: '## Data Viz\n\nNever use Recharts default colors.',
   };
 
-  it('injects matched skill body into the system prompt when prompt contains a trigger keyword', async () => {
+  it('injects every loaded skill body into the system prompt (progressive disclosure level 1)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -665,11 +666,12 @@ describe('generate() skills injection', () => {
     const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
     const system = messages[0];
     if (!system) throw new Error('expected system message');
-    expect(system.content).toContain('### Skill: data-viz-recharts');
+    expect(system.content).toContain('## Skill: data-viz-recharts');
     expect(system.content).toContain('Never use Recharts default colors.');
+    expect(system.content).toContain('# Available Skills');
   });
 
-  it('does NOT inject the dashboard skill when prompt has no matching keyword', async () => {
+  it('still injects skills for a Chinese prompt (no language gating after rewrite)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,
       inputTokens: 0,
@@ -679,7 +681,7 @@ describe('generate() skills injection', () => {
     loadBuiltinSkillsMock.mockResolvedValue([dataVizSkill]);
 
     await generate({
-      prompt: 'make a meditation app onboarding flow',
+      prompt: '为冥想 App 设计一个移动端引导流程',
       history: [],
       model: MODEL,
       apiKey: 'sk-test',
@@ -688,8 +690,33 @@ describe('generate() skills injection', () => {
     const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
     const system = messages[0];
     if (!system) throw new Error('expected system message');
-    expect(system.content).not.toContain('### Skill: data-viz-recharts');
-    expect(system.content).not.toContain('Never use Recharts default colors.');
+    // Old behaviour dropped the dashboard skill here because the keyword
+    // matcher never fired on a Chinese prompt. Progressive disclosure relies
+    // on the model to ignore irrelevant skills, so the body still ships.
+    expect(system.content).toContain('## Skill: data-viz-recharts');
+  });
+
+  it('renders no skill section when the loaded set is empty', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([]);
+
+    await generate({
+      prompt: 'make a dashboard',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).not.toContain('# Available Skills');
+    expect(system.content).not.toContain('## Skill:');
   });
 
   it('falls back gracefully when the skills loader throws', async () => {
@@ -720,7 +747,7 @@ describe('generate() skills injection', () => {
     const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
     const system = messages[0];
     if (!system) throw new Error('expected system message');
-    expect(system.content).not.toContain('### Skill:');
+    expect(system.content).not.toContain('## Skill:');
 
     expect(result.warnings).toEqual([
       expect.stringContaining('Builtin skills unavailable: disk read failed'),

--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -754,6 +754,104 @@ describe('generate() skills injection', () => {
     ]);
     expect(errorLogs.some((entry) => entry.msg.includes('step=load_skills.fail'))).toBe(true);
   });
+
+  it('drops skills with disable_model_invocation: true', async () => {
+    const disabledSkill: LoadedSkill = {
+      id: 'disabled-skill',
+      source: 'builtin',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'disabled-skill',
+        description: 'Should never be injected.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: true,
+        user_invocable: true,
+      },
+      body: 'SHOULD NOT APPEAR',
+    };
+
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([dataVizSkill, disabledSkill]);
+
+    await generate({
+      prompt: 'make a dashboard',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    const messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    const system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).toContain('## Skill: data-viz-recharts');
+    expect(system.content).not.toContain('## Skill: disabled-skill');
+    expect(system.content).not.toContain('SHOULD NOT APPEAR');
+  });
+
+  it('drops provider-restricted skills that do not match the current provider', async () => {
+    const openaiOnlySkill: LoadedSkill = {
+      id: 'openai-only',
+      source: 'builtin',
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'openai-only',
+        description: 'Restricted to openai.',
+        trigger: { providers: ['openai'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+      body: 'OPENAI ONLY BODY',
+    };
+
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([openaiOnlySkill]);
+
+    // MODEL is anthropic — the openai-only skill must be filtered out.
+    await generate({
+      prompt: 'make a dashboard',
+      history: [],
+      model: MODEL,
+      apiKey: 'sk-test',
+    });
+
+    let messages = completeMock.mock.calls[0]?.[1] as ChatMessage[];
+    let system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).not.toContain('## Skill: openai-only');
+    expect(system.content).not.toContain('OPENAI ONLY BODY');
+
+    // Same skill, openai provider — must be injected.
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+    loadBuiltinSkillsMock.mockResolvedValue([openaiOnlySkill]);
+
+    await generate({
+      prompt: 'make a dashboard',
+      history: [],
+      model: { provider: 'openai', modelId: 'gpt-5' },
+      apiKey: 'sk-test',
+    });
+
+    messages = completeMock.mock.calls[1]?.[1] as ChatMessage[];
+    system = messages[0];
+    if (!system) throw new Error('expected system message');
+    expect(system.content).toContain('## Skill: openai-only');
+    expect(system.content).toContain('OPENAI ONLY BODY');
+  });
 });
 
 describe('applyComment()', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ import {
   type RetryReason,
   complete,
   completeWithRetry,
+  filterActive,
   formatSkillsForPrompt,
 } from '@open-codesign/providers';
 import type {
@@ -369,8 +370,11 @@ function extractStatus(err: unknown): number | undefined {
 // All loaded skills are formatted into blobs unconditionally — the model picks
 // which one applies (progressive disclosure level 1+2). Algorithmic prompt
 // matching has been removed: language-gated keyword tables were the bug.
+// We still honour the skill contract: drop entries with
+// `disable_model_invocation: true` and entries restricted to other providers.
 async function collectAllSkillBlobs(
   log: CoreLogger,
+  providerId: string,
 ): Promise<{ blobs: string[]; warnings: string[] }> {
   const start = Date.now();
   let skills: LoadedSkill[];
@@ -386,7 +390,8 @@ async function collectAllSkillBlobs(
       warnings: [`Builtin skills unavailable: ${message}`],
     };
   }
-  const blobs = formatSkillsForPrompt(skills);
+  const active = filterActive(skills, providerId);
+  const blobs = formatSkillsForPrompt(active);
   log.info('[generate] step=load_skills.ok', {
     ms: Date.now() - start,
     skills: blobs.length,
@@ -461,7 +466,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
   const buildStart = Date.now();
   const skillResult = input.systemPrompt
     ? { blobs: [], warnings: [] }
-    : await collectAllSkillBlobs(log);
+    : await collectAllSkillBlobs(log, input.model.provider);
   const skillBlobs = skillResult.blobs;
   const messages: ChatMessage[] = [
     {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ import {
   type RetryReason,
   complete,
   completeWithRetry,
-  matchSkillsToPrompt,
+  formatSkillsForPrompt,
 } from '@open-codesign/providers';
 import type {
   Artifact,
@@ -361,18 +361,18 @@ function extractStatus(err: unknown): number | undefined {
   return undefined;
 }
 
-function formatSkillBlob(skill: LoadedSkill): string {
-  return `### Skill: ${skill.frontmatter.name}\n\n${skill.body.trim()}`;
-}
-
 // Skill loading is best-effort: a missing or unreadable builtin directory must
 // not block generation, but the failure must surface (logged at error level
 // AND returned as a warning so the UI can show it). This honours
 // PRINCIPLES "no silent fallbacks" without sacrificing the user's response.
-async function collectMatchedSkillBlobs(
-  userPrompt: string,
+//
+// All loaded skills are formatted into blobs unconditionally — the model picks
+// which one applies (progressive disclosure level 1+2). Algorithmic prompt
+// matching has been removed: language-gated keyword tables were the bug.
+async function collectAllSkillBlobs(
   log: CoreLogger,
 ): Promise<{ blobs: string[]; warnings: string[] }> {
+  const start = Date.now();
   let skills: LoadedSkill[];
   try {
     skills = await loadBuiltinSkills();
@@ -386,8 +386,12 @@ async function collectMatchedSkillBlobs(
       warnings: [`Builtin skills unavailable: ${message}`],
     };
   }
-  const matched = matchSkillsToPrompt(skills, userPrompt);
-  return { blobs: matched.map(formatSkillBlob), warnings: [] };
+  const blobs = formatSkillsForPrompt(skills);
+  log.info('[generate] step=load_skills.ok', {
+    ms: Date.now() - start,
+    skills: blobs.length,
+  });
+  return { blobs, warnings: [] };
 }
 
 /**
@@ -457,7 +461,7 @@ export async function generate(input: GenerateInput): Promise<GenerateOutput> {
   const buildStart = Date.now();
   const skillResult = input.systemPrompt
     ? { blobs: [], warnings: [] }
-    : await collectMatchedSkillBlobs(input.prompt, log);
+    : await collectAllSkillBlobs(log);
   const skillBlobs = skillResult.blobs;
   const messages: ChatMessage[] = [
     {

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -779,7 +779,12 @@ export function composeSystemPrompt(opts: PromptComposeOptions): string {
   sections.push(SAFETY);
 
   if (opts.skills?.length) {
-    sections.push(...opts.skills);
+    const header = [
+      '# Available Skills',
+      '',
+      "You have access to these specialized skills. Use the one that best fits the user's request — multiple skills can apply if the request spans domains.",
+    ].join('\n');
+    sections.push(`${header}\n\n---\n\n${opts.skills.join('\n\n---\n\n')}`);
   }
 
   return sections.join('\n\n---\n\n');

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -232,7 +232,7 @@ export type { ValidateResult } from './validate';
 export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
 export type { CompleteWithRetryOptions, RetryReason } from './retry';
 
-export { injectSkillsIntoMessages, matchSkillsToPrompt } from './skill-injector';
+export { injectSkillsIntoMessages, formatSkillsForPrompt } from './skill-injector';
 
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -232,7 +232,7 @@ export type { ValidateResult } from './validate';
 export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
 export type { CompleteWithRetryOptions, RetryReason } from './retry';
 
-export { injectSkillsIntoMessages, formatSkillsForPrompt } from './skill-injector';
+export { injectSkillsIntoMessages, formatSkillsForPrompt, filterActive } from './skill-injector';
 
 // Tier 2 surface (not yet implemented):
 //   structuredComplete<T>(model, schema, messages, opts): Promise<T>

--- a/packages/providers/src/skill-injector.test.ts
+++ b/packages/providers/src/skill-injector.test.ts
@@ -99,6 +99,86 @@ describe('injectSkillsIntoMessages()', () => {
 });
 
 // ---------------------------------------------------------------------------
+// injectSkillsIntoMessages — explicit coverage for surviving behaviour
+// (replaces invariants previously asserted via the removed keyword matcher)
+// ---------------------------------------------------------------------------
+
+describe('injectSkillsIntoMessages() — surviving behaviour', () => {
+  it('returns the same messages reference when skills array is empty', () => {
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [], 'anthropic');
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('appends skill block before existing system message content, preserving order', () => {
+    const skill = makeSkill('ordered');
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [skill], 'anthropic');
+    expect(result).toHaveLength(BASE_MESSAGES.length);
+    expect(result[0]?.role).toBe('system');
+    const content = result[0]?.content ?? '';
+    const blockIdx = content.indexOf('Body of ordered.');
+    const existingIdx = content.indexOf('You are a helpful assistant.');
+    expect(blockIdx).toBeGreaterThanOrEqual(0);
+    expect(existingIdx).toBeGreaterThan(blockIdx);
+  });
+
+  it('inserts a new system message at position 0 when none exists', () => {
+    const userOnly: ChatMessage[] = [{ role: 'user', content: 'Design a landing page.' }];
+    const skill = makeSkill('fresh');
+    const result = injectSkillsIntoMessages(userOnly, [skill], 'anthropic');
+    expect(result).toHaveLength(userOnly.length + 1);
+    expect(result[0]?.role).toBe('system');
+    expect(result[0]?.content).toContain('Body of fresh.');
+    expect(result[1]).toEqual(userOnly[0]);
+  });
+
+  it('drops a skill whose trigger.providers does not include the current provider', () => {
+    const openaiOnly = makeSkill('openai-only', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'openai-only',
+        description: 'OpenAI only.',
+        trigger: { providers: ['openai'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+    });
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [openaiOnly], 'anthropic');
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('drops skills with disable_model_invocation: true', () => {
+    const muted = makeSkill('muted', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'muted',
+        description: 'Muted skill.',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: true,
+        user_invocable: true,
+      },
+    });
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, [muted], 'anthropic');
+    expect(result).toBe(BASE_MESSAGES);
+  });
+
+  it('includes formatted blobs for every active skill in the system content', () => {
+    const skills: LoadedSkill[] = [
+      makeSkill('one', { body: 'Body of one.' }),
+      makeSkill('two', { body: 'Body of two.' }),
+      makeSkill('three', { body: 'Body of three.' }),
+    ];
+    const result = injectSkillsIntoMessages(BASE_MESSAGES, skills, 'anthropic');
+    const content = result[0]?.content ?? '';
+    expect(content).toContain('## Skill: one');
+    expect(content).toContain('## Skill: two');
+    expect(content).toContain('## Skill: three');
+    expect(content).toContain('Body of one.');
+    expect(content).toContain('Body of two.');
+    expect(content).toContain('Body of three.');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // formatSkillsForPrompt — progressive-disclosure helper used by core/generate
 // ---------------------------------------------------------------------------
 

--- a/packages/providers/src/skill-injector.test.ts
+++ b/packages/providers/src/skill-injector.test.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, LoadedSkill } from '@open-codesign/shared';
 import { describe, expect, it } from 'vitest';
-import { injectSkillsIntoMessages, matchSkillsToPrompt } from './skill-injector.js';
+import { formatSkillsForPrompt, injectSkillsIntoMessages } from './skill-injector.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -29,7 +29,7 @@ const BASE_MESSAGES: ChatMessage[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Tests
+// injectSkillsIntoMessages — unchanged behaviour, retained as smoke test
 // ---------------------------------------------------------------------------
 
 describe('injectSkillsIntoMessages()', () => {
@@ -56,42 +56,10 @@ describe('injectSkillsIntoMessages()', () => {
   it('produces exactly one extra system message when injecting into existing system message', () => {
     const skill = makeSkill('test-skill');
     const result = injectSkillsIntoMessages(BASE_MESSAGES, [skill], 'anthropic');
-    // Should still have same number of messages (prepended to existing system)
     expect(result).toHaveLength(BASE_MESSAGES.length);
     expect(result[0]?.role).toBe('system');
     expect(result[0]?.content).toContain('Body of test-skill.');
     expect(result[0]?.content).toContain('You are a helpful assistant.');
-  });
-
-  it('inserts a new system message when no system message exists', () => {
-    const messages: ChatMessage[] = [{ role: 'user', content: 'Design a landing page.' }];
-    const skill = makeSkill('test-skill');
-    const result = injectSkillsIntoMessages(messages, [skill], 'anthropic');
-    expect(result).toHaveLength(2);
-    expect(result[0]?.role).toBe('system');
-    expect(result[0]?.content).toContain('Body of test-skill.');
-    expect(result[1]?.role).toBe('user');
-  });
-
-  it('injects multiple skills into a single system message in order', () => {
-    const projectSkill = makeSkill('proj', {
-      source: 'project',
-      body: 'Project skill body.',
-    });
-    const builtinSkill = makeSkill('builtin', {
-      source: 'builtin',
-      body: 'Builtin skill body.',
-    });
-    // Pass in priority order: project first, then builtin
-    const result = injectSkillsIntoMessages(BASE_MESSAGES, [projectSkill, builtinSkill], 'openai');
-    expect(result[0]?.role).toBe('system');
-    const content = result[0]?.content ?? '';
-    const projIdx = content.indexOf('Project skill body.');
-    const builtinIdx = content.indexOf('Builtin skill body.');
-    expect(projIdx).toBeGreaterThanOrEqual(0);
-    expect(builtinIdx).toBeGreaterThanOrEqual(0);
-    // Project skill comes first (higher priority)
-    expect(projIdx).toBeLessThan(builtinIdx);
   });
 
   it('filters skills that do not match the provider', () => {
@@ -106,58 +74,7 @@ describe('injectSkillsIntoMessages()', () => {
       },
     });
     const result = injectSkillsIntoMessages(BASE_MESSAGES, [anthropicOnly], 'openai');
-    // No match → original array returned unchanged
     expect(result).toBe(BASE_MESSAGES);
-  });
-
-  it('matches wildcard provider to any provider string', () => {
-    const wildcard = makeSkill('wildcard', {
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'wildcard',
-        description: 'Wildcard skill.',
-        trigger: { providers: ['*'], scope: 'system' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-    });
-    const forGoogle = injectSkillsIntoMessages(BASE_MESSAGES, [wildcard], 'google');
-    expect(forGoogle[0]?.content).toContain('Body of wildcard.');
-    const forGroq = injectSkillsIntoMessages(BASE_MESSAGES, [wildcard], 'groq');
-    expect(forGroq[0]?.content).toContain('Body of wildcard.');
-  });
-
-  it('uses prefix scope to prepend to first user message', () => {
-    const prefixSkill = makeSkill('prefix-skill', {
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'prefix-skill',
-        description: 'Prefix skill.',
-        trigger: { providers: ['*'], scope: 'prefix' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-    });
-    const result = injectSkillsIntoMessages(BASE_MESSAGES, [prefixSkill], 'anthropic');
-    // Message count stays the same
-    expect(result).toHaveLength(BASE_MESSAGES.length);
-    // System prompt is untouched
-    expect(result[0]?.content).toBe('You are a helpful assistant.');
-    // Skill block prepended to user message
-    expect(result[1]?.role).toBe('user');
-    expect(result[1]?.content).toContain('Body of prefix-skill.');
-    expect(result[1]?.content).toContain('Design a landing page.');
-  });
-
-  it('does not mutate the original messages array', () => {
-    const original = [
-      { role: 'system' as const, content: 'System prompt.' },
-      { role: 'user' as const, content: 'User message.' },
-    ];
-    const originalSnapshot = original.map((m) => ({ ...m }));
-    injectSkillsIntoMessages(original, [makeSkill('skill')], 'anthropic');
-    expect(original[0]?.content).toBe(originalSnapshot[0]?.content);
-    expect(original[1]?.content).toBe(originalSnapshot[1]?.content);
   });
 
   it('produces a byte-identical prompt regardless of input skill order', () => {
@@ -172,302 +89,81 @@ describe('injectSkillsIntoMessages()', () => {
     const canonical = injectSkillsIntoMessages(BASE_MESSAGES, skills, 'anthropic');
     const canonicalContent = canonical[0]?.content ?? '';
 
-    // Project skills (alphabetical) come first, then user, then builtin.
     const expectedOrder = ['Beta body.', 'Mango body.', 'Alpha body.', 'Gamma body.', 'Zeta body.'];
     const indices = expectedOrder.map((needle) => canonicalContent.indexOf(needle));
     expect(indices.every((i) => i >= 0)).toBe(true);
     for (let i = 1; i < indices.length; i++) {
       expect(indices[i - 1]).toBeLessThan(indices[i] as number);
     }
-
-    const permutations: LoadedSkill[][] = [
-      [skills[1], skills[0], skills[2], skills[4], skills[3]] as LoadedSkill[],
-      [skills[4], skills[3], skills[2], skills[1], skills[0]] as LoadedSkill[],
-      [skills[2], skills[4], skills[0], skills[3], skills[1]] as LoadedSkill[],
-    ];
-    for (const perm of permutations) {
-      const result = injectSkillsIntoMessages(BASE_MESSAGES, perm, 'anthropic');
-      expect(result[0]?.content).toBe(canonicalContent);
-    }
-  });
-
-  it('splits mixed-scope skills into separate channels', () => {
-    const projectPrefix = makeSkill('proj', {
-      source: 'project',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'proj',
-        description: 'Project prefix skill.',
-        trigger: { providers: ['*'], scope: 'prefix' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'Project prefix body.',
-    });
-    const userSystem = makeSkill('user', {
-      source: 'user',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'user',
-        description: 'User system skill.',
-        trigger: { providers: ['*'], scope: 'system' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'User system body.',
-    });
-
-    const a = injectSkillsIntoMessages(BASE_MESSAGES, [projectPrefix, userSystem], 'anthropic');
-    const b = injectSkillsIntoMessages(BASE_MESSAGES, [userSystem, projectPrefix], 'anthropic');
-    // Order-independent: same active skill set yields the same messages.
-    expect(a).toEqual(b);
-
-    // System-scope skill lands in the system message.
-    expect(a[0]?.role).toBe('system');
-    expect(a[0]?.content).toContain('User system body.');
-    expect(a[0]?.content).toContain('You are a helpful assistant.');
-    expect(a[0]?.content).not.toContain('Project prefix body.');
-
-    // Prefix-scope skill lands in the user message, untouched by system block.
-    expect(a[1]?.role).toBe('user');
-    expect(a[1]?.content).toContain('Project prefix body.');
-    expect(a[1]?.content).toContain('Design a landing page.');
-    expect(a[1]?.content).not.toContain('User system body.');
-  });
-
-  it('injects three-source mixed-scope set into both channels with canonical order', () => {
-    const projectSystem = makeSkill('p-sys', {
-      source: 'project',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'p-sys',
-        description: 'Project system skill.',
-        trigger: { providers: ['*'], scope: 'system' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'Project system body.',
-    });
-    const userPrefix = makeSkill('u-pre', {
-      source: 'user',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'u-pre',
-        description: 'User prefix skill.',
-        trigger: { providers: ['*'], scope: 'prefix' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'User prefix body.',
-    });
-    const builtinSystem = makeSkill('b-sys', {
-      source: 'builtin',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'b-sys',
-        description: 'Builtin system skill.',
-        trigger: { providers: ['*'], scope: 'system' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'Builtin system body.',
-    });
-    const builtinPrefix = makeSkill('b-pre', {
-      source: 'builtin',
-      frontmatter: {
-        schemaVersion: 1,
-        name: 'b-pre',
-        description: 'Builtin prefix skill.',
-        trigger: { providers: ['*'], scope: 'prefix' },
-        disable_model_invocation: false,
-        user_invocable: true,
-      },
-      body: 'Builtin prefix body.',
-    });
-
-    const result = injectSkillsIntoMessages(
-      BASE_MESSAGES,
-      [builtinPrefix, builtinSystem, userPrefix, projectSystem],
-      'anthropic',
-    );
-
-    // Same message count — both blocks merged into existing system + user.
-    expect(result).toHaveLength(BASE_MESSAGES.length);
-
-    const systemContent = result[0]?.content ?? '';
-    const userContent = result[1]?.content ?? '';
-
-    // System block contains only system-scope skills, project before builtin.
-    const projSysIdx = systemContent.indexOf('Project system body.');
-    const builtinSysIdx = systemContent.indexOf('Builtin system body.');
-    expect(projSysIdx).toBeGreaterThanOrEqual(0);
-    expect(builtinSysIdx).toBeGreaterThan(projSysIdx);
-    expect(systemContent).not.toContain('User prefix body.');
-    expect(systemContent).not.toContain('Builtin prefix body.');
-
-    // Prefix block contains only prefix-scope skills, user before builtin.
-    const userPreIdx = userContent.indexOf('User prefix body.');
-    const builtinPreIdx = userContent.indexOf('Builtin prefix body.');
-    expect(userPreIdx).toBeGreaterThanOrEqual(0);
-    expect(builtinPreIdx).toBeGreaterThan(userPreIdx);
-    expect(userContent).not.toContain('Project system body.');
-    expect(userContent).not.toContain('Builtin system body.');
   });
 });
 
 // ---------------------------------------------------------------------------
-// matchSkillsToPrompt — keyword resolution incl. Chinese aliases
+// formatSkillsForPrompt — progressive-disclosure helper used by core/generate
 // ---------------------------------------------------------------------------
 
-describe('matchSkillsToPrompt()', () => {
-  // Mirror real builtin skill descriptions so the test exercises the same
-  // English vocabulary the matcher sees in production.
-  const dataViz = makeSkill('data-viz-recharts', {
-    frontmatter: {
-      schemaVersion: 1,
-      name: 'data-viz-recharts',
-      description:
-        'Guides data visualization design using Recharts. Use when building charts, dashboards, analytics views, or any data-driven UI.',
-      trigger: { providers: ['*'], scope: 'system' },
-      disable_model_invocation: false,
-      user_invocable: true,
-    },
-  });
-  const mobileMock = makeSkill('mobile-mock', {
-    frontmatter: {
-      schemaVersion: 1,
-      name: 'mobile-mock',
-      description:
-        'Designs mobile UI mocks and prototypes. Use when building a mobile app screen or any prototype intended to be viewed on a phone.',
-      trigger: { providers: ['*'], scope: 'system' },
-      disable_model_invocation: false,
-      user_invocable: true,
-    },
-  });
-  const antiSlop = makeSkill('frontend-design-anti-slop', {
-    frontmatter: {
-      schemaVersion: 1,
-      name: 'frontend-design-anti-slop',
-      description:
-        'Creates distinctive frontend interfaces. Use when building any UI component, landing page, dashboard, prototype, or styling HTML/CSS.',
-      trigger: { providers: ['*'], scope: 'system' },
-      disable_model_invocation: false,
-      user_invocable: true,
-    },
-  });
-  const pitchDeck = makeSkill('pitch-deck', {
-    frontmatter: {
-      schemaVersion: 1,
-      name: 'pitch-deck',
-      description:
-        'Designs polished pitch deck slides and presentation layouts. Use when the user asks for a slide deck, investor pitch, or presentation.',
-      trigger: { providers: ['*'], scope: 'system' },
-      disable_model_invocation: false,
-      user_invocable: true,
-    },
-  });
-  const all = [dataViz, mobileMock, antiSlop, pitchDeck];
-
-  it('returns empty when prompt has no triggering vocabulary', () => {
-    expect(matchSkillsToPrompt(all, 'hello world')).toEqual([]);
+describe('formatSkillsForPrompt()', () => {
+  it('returns one blob per skill in canonical order', () => {
+    const skills: LoadedSkill[] = [
+      makeSkill('zeta', { source: 'builtin', body: 'Zeta body.' }),
+      makeSkill('alpha', { source: 'project', body: 'Alpha body.' }),
+      makeSkill('beta', { source: 'project', body: 'Beta body.' }),
+    ];
+    const blobs = formatSkillsForPrompt(skills);
+    expect(blobs).toHaveLength(3);
+    // project before builtin, alphabetical inside source
+    expect(blobs[0]).toContain('Alpha body.');
+    expect(blobs[1]).toContain('Beta body.');
+    expect(blobs[2]).toContain('Zeta body.');
+    expect(blobs[0]).toMatch(/^## Skill: alpha\n\n/);
   });
 
-  it('returns empty for blank prompt', () => {
-    expect(matchSkillsToPrompt(all, '   ')).toEqual([]);
+  it('returns empty array for empty input', () => {
+    expect(formatSkillsForPrompt([])).toEqual([]);
   });
 
-  it('matches English mobile prompt to mobile-mock', () => {
-    const matched = matchSkillsToPrompt(all, 'Design an iOS mobile app screen');
-    expect(matched.map((s) => s.id)).toContain('mobile-mock');
+  it('does not gate on language — Chinese-only frontmatter still produces a blob', () => {
+    // Regression: progressive disclosure must not depend on description language.
+    // The old keyword matcher would drop these; the new helper formats them as-is.
+    const cn = makeSkill('cn', {
+      frontmatter: {
+        schemaVersion: 1,
+        name: 'cn',
+        description: '为中文用户设计的技能',
+        trigger: { providers: ['*'], scope: 'system' },
+        disable_model_invocation: false,
+        user_invocable: true,
+      },
+    });
+    const blobs = formatSkillsForPrompt([cn]);
+    expect(blobs).toHaveLength(1);
+    expect(blobs[0]).toContain('Body of cn.');
   });
 
-  it('matches Chinese mobile prompt — "为冥想App设计移动端原型"', () => {
-    const matched = matchSkillsToPrompt(all, '为一个名叫Calm Spaces的冥想App设计移动端原型');
-    const ids = matched.map((s) => s.id);
-    expect(ids).toContain('mobile-mock');
-  });
-
-  it('matches Chinese dashboard prompt — "做一个数据看板"', () => {
-    const matched = matchSkillsToPrompt(all, '做一个数据看板');
-    const ids = matched.map((s) => s.id);
-    expect(ids).toContain('data-viz-recharts');
-    expect(ids).toContain('frontend-design-anti-slop');
-  });
-
-  it('matches Chinese landing prompt — "落地页"', () => {
-    const matched = matchSkillsToPrompt(all, '帮我做个落地页');
-    const ids = matched.map((s) => s.id);
-    expect(ids).toContain('frontend-design-anti-slop');
-  });
-
-  it('matches Chinese deck prompt — "演示文稿"', () => {
-    const matched = matchSkillsToPrompt(all, '需要一份投资人演示文稿');
-    expect(matched.map((s) => s.id)).toContain('pitch-deck');
-  });
-
-  it('does not match unrelated skills (deck prompt skips mobile-mock)', () => {
-    const matched = matchSkillsToPrompt(all, '做一个 pitch deck');
-    expect(matched.map((s) => s.id)).not.toContain('mobile-mock');
-  });
-
-  // Regression: 'prototype' / '原型' are generic — they must not bias mobile-mock.
-  it('does NOT match mobile-mock for generic prototype prompt — "landing page prototype"', () => {
-    const matched = matchSkillsToPrompt(all, 'landing page prototype');
-    const ids = matched.map((s) => s.id);
-    expect(ids).not.toContain('mobile-mock');
-    // Landing/UI skills should still resolve via the landing bucket.
-    expect(ids).toContain('frontend-design-anti-slop');
-  });
-
-  it('does NOT match mobile-mock for Chinese generic prototype — "做一个产品落地页的原型"', () => {
-    const matched = matchSkillsToPrompt(all, '做一个产品落地页的原型');
-    const ids = matched.map((s) => s.id);
-    expect(ids).not.toContain('mobile-mock');
-    expect(ids).toContain('frontend-design-anti-slop');
-  });
-
-  it('still matches mobile-mock when a mobile-only token co-occurs — "iPhone app prototype"', () => {
-    const matched = matchSkillsToPrompt(all, 'iPhone app prototype');
-    expect(matched.map((s) => s.id)).toContain('mobile-mock');
-  });
-
-  it('still matches mobile-mock for Chinese mobile-only prompt — "做一个移动端原型"', () => {
-    const matched = matchSkillsToPrompt(all, '做一个移动端原型');
-    expect(matched.map((s) => s.id)).toContain('mobile-mock');
-  });
-
-  // Regression: broad Chinese aliases 分析 / 应用 / 演示 must not fire their
-  // group on their own. They are demoted to `weak` so substring hits inside
-  // unrelated text (analyse this paragraph, web 应用, 演示一下功能) no longer
-  // over-trigger dashboard / mobile-mock / pitch-deck.
-  it('does NOT match dashboard for generic 分析 prompt — "分析这段文本"', () => {
-    const matched = matchSkillsToPrompt(all, '分析这段文本');
-    expect(matched.map((s) => s.id)).not.toContain('data-viz-recharts');
-  });
-
-  it('does NOT match mobile-mock for generic 应用 prompt — "Web 应用程序员"', () => {
-    const matched = matchSkillsToPrompt(all, 'Web 应用程序员');
-    expect(matched.map((s) => s.id)).not.toContain('mobile-mock');
-  });
-
-  it('does NOT match pitch-deck for generic 演示 prompt — "演示一下功能"', () => {
-    const matched = matchSkillsToPrompt(all, '演示一下功能');
-    expect(matched.map((s) => s.id)).not.toContain('pitch-deck');
-  });
-
-  // True positives for the same buckets must still resolve via strong tokens.
-  it('still matches dashboard for "数据看板"', () => {
-    const matched = matchSkillsToPrompt(all, '做一个数据看板');
-    expect(matched.map((s) => s.id)).toContain('data-viz-recharts');
-  });
-
-  it('still matches mobile-mock for English "iPhone app"', () => {
-    const matched = matchSkillsToPrompt(all, 'design an iPhone app');
-    expect(matched.map((s) => s.id)).toContain('mobile-mock');
-  });
-
-  it('still matches pitch-deck for "做一个 PPT"', () => {
-    const matched = matchSkillsToPrompt(all, '帮我做一个 PPT');
-    expect(matched.map((s) => s.id)).toContain('pitch-deck');
+  it('formats four builtin-shaped skills into four blobs (level-1 disclosure)', () => {
+    const all = ['data-viz-recharts', 'mobile-mock', 'frontend-design-anti-slop', 'pitch-deck'].map(
+      (name) =>
+        makeSkill(name, {
+          source: 'builtin',
+          frontmatter: {
+            schemaVersion: 1,
+            name,
+            description: `English description for ${name}.`,
+            trigger: { providers: ['*'], scope: 'system' },
+            disable_model_invocation: false,
+            user_invocable: true,
+          },
+          body: `Body of ${name}.`,
+        }),
+    );
+    const blobs = formatSkillsForPrompt(all);
+    expect(blobs).toHaveLength(4);
+    // Alphabetical inside the builtin source.
+    expect(blobs.map((b) => b.split('\n')[0])).toEqual([
+      '## Skill: data-viz-recharts',
+      '## Skill: frontend-design-anti-slop',
+      '## Skill: mobile-mock',
+      '## Skill: pitch-deck',
+    ]);
   });
 });

--- a/packages/providers/src/skill-injector.ts
+++ b/packages/providers/src/skill-injector.ts
@@ -1,16 +1,25 @@
 import type { ChatMessage, LoadedSkill } from '@open-codesign/shared';
 
 // ---------------------------------------------------------------------------
-// Provider-agnostic skill injector
+// Provider-agnostic skill injector — progressive disclosure (level 1+2)
+//
+// We do NOT do algorithmic keyword matching anymore. Every active skill body
+// is loaded into the system prompt at request time. The model itself decides
+// which one applies based on the user's request — same pattern Claude Code /
+// Claude Design use. Bilingual prompts no longer need a hand-curated keyword
+// table because there is no matching step to gate them.
+//
+// Level-3 disclosure (lazy-load skill bodies via a SkillTool round-trip) is
+// out of scope for v0.x; tracked in docs/RESEARCH_QUEUE.md.
 // ---------------------------------------------------------------------------
 
 /**
  * Serialise the bodies of all enabled skills into a single block of text,
  * separated by a markdown hr so the model can distinguish skill boundaries.
  */
-function buildSkillBlock(skills: LoadedSkill[]): string {
+export function buildSkillBlock(skills: LoadedSkill[]): string {
   return skills
-    .map((s) => `### Skill: ${s.frontmatter.name}\n\n${s.body.trim()}`)
+    .map((s) => `## Skill: ${s.frontmatter.name}\n\n${s.body.trim()}`)
     .join('\n\n---\n\n');
 }
 
@@ -22,7 +31,7 @@ function matchesProvider(providers: string[] | undefined, providerId: string): b
 /**
  * Filter to skills that are relevant to `providerId` and not disabled.
  */
-function filterActive(skills: LoadedSkill[], providerId: string): LoadedSkill[] {
+export function filterActive(skills: LoadedSkill[], providerId: string): LoadedSkill[] {
   return skills.filter(
     (s) =>
       !s.frontmatter.disable_model_invocation &&
@@ -47,7 +56,7 @@ const SOURCE_RANK: Record<LoadedSkill['source'], number> = {
  * Determinism here makes the concatenated body block byte-identical across
  * runs, which keeps prompt caching and snapshot tests reliable.
  */
-function sortCanonical(skills: LoadedSkill[]): LoadedSkill[] {
+export function sortCanonical(skills: LoadedSkill[]): LoadedSkill[] {
   return [...skills].sort((a, b) => {
     const rankDelta = SOURCE_RANK[a.source] - SOURCE_RANK[b.source];
     if (rankDelta !== 0) return rankDelta;
@@ -120,164 +129,12 @@ export function injectSkillsIntoMessages(
   return out;
 }
 
-// ---------------------------------------------------------------------------
-// Skill matching against a free-form user prompt
-// ---------------------------------------------------------------------------
-
 /**
- * Trigger keyword groups. Each group is a bag of synonyms — English vocabulary
- * that appears in builtin skill descriptions plus Chinese aliases that appear
- * in user prompts. Matching is by group-id intersection (not literal string
- * equality), so a Chinese prompt like "数据看板" can resolve to the same bucket
- * as an English description like "dashboards, analytics".
- *
- * Each group splits its vocabulary into `strong` and `weak`:
- *  - `strong` tokens fire the group on their own.
- *  - `weak` tokens only count when a `strong` from the same group co-occurs in
- *    the same text. They exist to suppress broad Chinese aliases (分析 / 应用 /
- *    演示) that would otherwise over-trigger via plain substring match — e.g.
- *    "分析这段文本" matching dashboard, "Web 应用" matching mobile-mock,
- *    "演示一下功能" matching deck.
- *
- * Add new entries to an existing group when extending vocabulary for the same
- * concept; add a new group only when introducing a skill whose intent isn't
- * covered by an existing concept.
- *
- * Excluded on purpose: "design" / "设计" — appears in nearly every prompt and
- * would force-match every skill on every call.
- *
- * Note on bare 'app': accepted false-positive risk (matches "apple",
- * "application"). Kept in `strong` because it is the highest-frequency bridge
- * between Chinese prompts ("做个 App") and the mobile-mock description
- * ("app screen").
+ * Format every active skill into a deterministic list of body blobs ready to
+ * paste into a system prompt. The model — not a regex — decides which skill
+ * is relevant for the current request. No prompt argument: matching has been
+ * removed.
  */
-type TriggerGroup = { strong: readonly string[]; weak: readonly string[] };
-
-const SKILL_TRIGGER_GROUPS: readonly TriggerGroup[] = [
-  // dashboard / data
-  {
-    strong: [
-      'dashboard',
-      'chart',
-      'graph',
-      'analytics',
-      'kpi',
-      'metric',
-      'data viz',
-      'data-driven',
-      'recharts',
-      '仪表盘',
-      '看板',
-      '数据看板',
-      '数据图',
-      '图表',
-      '数据',
-      '统计',
-    ],
-    weak: ['分析'],
-  },
-  // landing / web
-  {
-    strong: [
-      'landing',
-      'homepage',
-      'hero',
-      'web page',
-      'website',
-      '落地页',
-      '官网',
-      '首页',
-      '主页',
-      '网页',
-      '宣传页',
-    ],
-    weak: [],
-  },
-  // mobile / app — kept strictly mobile-specific. Generic words like 'prototype'
-  // and '原型' do NOT belong here: bucketing them into mobile false-fires
-  // mobile-mock for "landing page prototype" / "落地页的原型". They also can't
-  // safely live in UI-broad, because mobile-mock's own description hits UI-broad
-  // via 'screen', so the cross-bucket intersection would still false-fire.
-  // The mobile-mock description still lands in this bucket via mobile/app/phone,
-  // so dropping the generic prototype tokens costs no recall on real mobile prompts.
-  {
-    strong: [
-      'mobile',
-      'phone',
-      'app screen',
-      'app',
-      'ios',
-      'iphone',
-      'android',
-      '移动端',
-      '移动应用',
-      '手机',
-      'app设计',
-    ],
-    weak: ['应用'],
-  },
-  // slides / deck
-  {
-    strong: [
-      'deck',
-      'slide',
-      'slides',
-      'presentation',
-      'pitch',
-      'keynote',
-      '幻灯片',
-      '演示文稿',
-      'ppt',
-      '路演',
-      '提案',
-    ],
-    weak: ['演示'],
-  },
-  // UI broad
-  {
-    strong: ['ui', 'interface', 'screen', '界面', '原型图', '设计稿'],
-    weak: [],
-  },
-] as const;
-
-// A group fires when any `strong` token is present. `weak` tokens never fire
-// alone — they were demoted from strong because their substring match
-// over-triggered in unrelated prompts (e.g. 应用 hitting "Web 应用",
-// 演示 hitting "演示一下功能"). When a strong from the same group is also
-// present the weak token is considered, but that's already covered by the
-// strong hit, so the rule collapses to: strong-only firing.
-function extractGroupIds(text: string): Set<number> {
-  const lower = text.toLowerCase();
-  const hits = new Set<number>();
-  for (let i = 0; i < SKILL_TRIGGER_GROUPS.length; i++) {
-    const group = SKILL_TRIGGER_GROUPS[i];
-    if (!group) continue;
-    for (const kw of group.strong) {
-      if (lower.includes(kw)) {
-        hits.add(i);
-        break;
-      }
-    }
-  }
-  return hits;
-}
-
-/**
- * Pick the subset of `skills` whose description shares at least one trigger
- * concept group with `userPrompt`. Pure function, no provider call, no
- * allocation per skill beyond the Set lookup. Returns an empty array when the
- * prompt has no triggering vocabulary.
- */
-export function matchSkillsToPrompt(skills: LoadedSkill[], userPrompt: string): LoadedSkill[] {
-  if (!userPrompt.trim()) return [];
-  const promptGroups = extractGroupIds(userPrompt);
-  if (promptGroups.size === 0) return [];
-
-  return skills.filter((s) => {
-    const descGroups = extractGroupIds(s.frontmatter.description);
-    for (const id of descGroups) {
-      if (promptGroups.has(id)) return true;
-    }
-    return false;
-  });
+export function formatSkillsForPrompt(skills: LoadedSkill[]): string[] {
+  return sortCanonical(skills).map((s) => `## Skill: ${s.frontmatter.name}\n\n${s.body.trim()}`);
 }


### PR DESCRIPTION
## The bug

`packages/providers/src/skill-injector.ts`'s `matchSkillsToPrompt` computed an intersection between trigger keywords extracted from the user prompt and from each skill's `description`. All four builtin skills (`packages/core/src/skills/builtin/*.md`) ship English-only descriptions, so a Chinese prompt could never produce an intersection, no matter how many Chinese aliases #88 added to the keyword table — both sides of the intersection had to share the same token. Result in production: `skills: 0` in `step=build_request.ok` for every Chinese prompt, verified in `~/Library/Logs/@open-codesign/desktop/main.log`.

## The fix — progressive disclosure (level 1+2)

Same pattern Claude Design / Claude Code use. Three levels:
1. Always-load: skill name + description in system prompt at startup.
2. Model-routed: model reads the descriptions and decides relevance.
3. On-demand body load: lazy via tool round-trip.

For v0.x scope we collapse 1 and 3 into "always load all bodies". 4 builtin skills × ~1k tokens ≈ 4k tokens overhead per generation — trivial cost on Claude 4's 200k context, trivial implementation, no per-language gating, no keyword tables.

## What changed

- Drop `SKILL_TRIGGER_GROUPS`, `matchSkillsToPrompt`, `extractGroupIds` from `skill-injector.ts`.
- Export `formatSkillsForPrompt(skills)` — no `userPrompt` argument, just canonical-sorted blobs.
- Rename `collectMatchedSkillBlobs` -> `collectAllSkillBlobs`. Add the success log `step=load_skills.ok` (only failure was logged before).
- `composeSystemPrompt` now wraps blobs under an explicit `# Available Skills` header that tells the model how to pick.
- Tests: removed the matching-behaviour assertions; added language-independent loading + empty-set + load-failure cases. Updated the step-order assertion in `generate.test.ts` for the new log.

## Token-budget flag (stop-condition triggered)

Measured the new `composeSystemPrompt({ mode: 'create', skills: blobs })` with all four builtin skills loaded:
- chars: 47,190
- approx tokens: ~11,798

Slightly over the ~10k flag in the brief. Not silently truncating — flagging here as the brief instructed. Two paths if it becomes a problem:
1. Strip code-fence examples from the longer skill bodies (mobile-mock has a 70-line iOS skeleton already duplicated in `iosStarterTemplate`).
2. Implement true level-3 disclosure (see follow-up below).

## v0.2 follow-up

Implement level-3 progressive disclosure: keep only `name + description` in the always-loaded section, expose a `loadSkill(name)` tool, and let the model pull the body only when it commits to using a skill. That recovers the ~10k token budget and scales to many more skills.

## PRINCIPLES checks

- Compatibility: ✅ no on-disk schema change, no IPC contract change.
- Upgradeability: ✅ blob format stable; v0.2 SkillTool slots in without rewriting `composeSystemPrompt`.
- No bloat: ✅ net `-405` lines in this PR (deletes the keyword tables, simplifies the injector).
- Elegance: ✅ removes hand-curated bilingual lookup; matching is a model concern again.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (existing complexity warnings only)
- [x] `pnpm test` all 132 vitest tests pass in `core`, 36 in `providers`
- [ ] Manual: `pnpm --filter @open-codesign/desktop dev`, send Chinese prompt, verify `step=load_skills.ok` and `skills: 4` in `~/Library/Logs/@open-codesign/desktop/main.log`