### PR TITLE
chore(deps): bump electron 33 → 39 (PR-A: dependency bump only)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -40,7 +40,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
-    "electron": "^33.2.1",
+    "electron": "^39.8.5",
     "electron-builder": "^25.1.8",
     "electron-vite": "^2.3.0",
     "tailwindcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
       electron:
-        specifier: ^33.2.1
-        version: 33.4.11
+        specifier: ^39.8.5
+        version: 39.8.8
       electron-builder:
         specifier: ^25.1.8
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
@@ -1799,9 +1799,6 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
-
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -2587,8 +2584,8 @@ packages:
       '@swc/core':
         optional: true
 
-  electron@33.4.11:
-    resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
+  electron@39.8.8:
+    resolution: {integrity: sha512-24MMLdwCg8xwlWzDxC1XZU2MqW0Xx2UPxt9EU15vMDoRSMHPqmi/BgRCEINXZaBLfFSeXEKGpg+QlBRdL5uwaw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -6362,10 +6359,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.19.39':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -7281,10 +7274,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@33.4.11:
+  electron@39.8.8:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.19.39
+      '@types/node': 22.19.17
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

PR-A of a 2-PR Electron upgrade. **Scope: dependency bump only.** No app code changes. PR-B will handle source-code regressions and the sqlite-binding strategy.

- `apps/desktop`: `electron` `^33.2.1` → `^39.8.5` (resolves to `39.8.8`)
- Lockfile updated accordingly
- Honors the CLAUDE.md ban on Electron 41.x — 39.x is the target

## Postinstall outcome — BLOCKER for boot

Electron itself postinstalls cleanly (`electron postinstall: Done`). However the desktop `postinstall` hook fails:

```
apps/desktop postinstall: [sqlite-bindings] downloading Electron prebuild (electron=39.8.8, darwin-arm64)
apps/desktop postinstall: prebuild-install warn install No prebuilt binaries found
  (target=39.8.8 runtime=electron arch=arm64 libc= platform=darwin)
apps/desktop postinstall: Failed
```

`better-sqlite3@11.10.0` does not publish an Electron-39 ABI prebuild for darwin-arm64. This is the documented stop condition (no source compile attempted).

## Boot smoke

Skipped — postinstall failure means the Electron 39 binary never gets the `better_sqlite3.node-electron.node` ABI file `snapshots-db.ts` requires. Boot would crash on first SQLite open. PR-B must resolve the binding before a real boot test is meaningful.

## Tests / typecheck

`pnpm test` (turbo cached) passed during the pre-commit hook (10/10 tasks successful). Unit tests use the Node-ABI binding which downloaded fine, so they are insensitive to the Electron-39 issue. Typecheck not separately re-run (no source changes).

## Deprecations observed

Only the install-time peer-dep warning carried over from before:

- `electron-vite 2.3.0` ✕ unmet peer `vite@^4.0.0 || ^5.0.0` (we ship vite 6) — pre-existing
- 14 deprecated transitive subdeps reported by pnpm — pre-existing, unchanged by this bump

No Electron-runtime deprecation warnings yet (couldn't boot).

## Recommended PR-B scope

1. **SQLite binding strategy (blocker).** Either bump `better-sqlite3` to a version with Electron-39 prebuilds, or switch the install script to `@electron/rebuild` against the user's local toolchain, or pin to a fork. The current `apps/desktop/scripts/install-sqlite-bindings.cjs` flow assumes prebuild availability.
2. After bindings work, do the real boot smoke and triage runtime deprecations / API renames in `apps/desktop/src/`.
3. Re-run `pnpm typecheck` against new Electron 39 type defs and fix any breaks (most likely `BrowserWindow` / `session` / `webContents` signature drift).

## Four PRINCIPLES

- Compatibility: pending — depends on PR-B sqlite resolution
- Upgradeability: green (we're moving forward two majors)
- No bloat: green (single dep bump, no new deps)
- Elegance: green (no abstractions added)