### PR TITLE
fix(artifacts): close remaining streaming parser leak paths

### DIFF
--- a/.changeset/parser-quote-aware-open-tag.md
+++ b/.changeset/parser-quote-aware-open-tag.md
@@ -1,0 +1,7 @@
+---
+'@open-codesign/artifacts': patch
+---
+
+fix(artifacts): close remaining streaming parser leak paths
+
+The open-tag scanner is now quote-aware: a `>` inside a quoted attribute value (e.g. `title="a > b"`) no longer truncates the tag, drops the title, or leaks raw `<artifact ...` markup into a text event when the stream split lands mid-attribute.

--- a/packages/artifacts/src/parser.test.ts
+++ b/packages/artifacts/src/parser.test.ts
@@ -2,16 +2,23 @@
  * Tests for the streaming artifact parser.
  */
 import { describe, expect, it } from 'vitest';
-import { createArtifactParser } from './parser';
+import { type ArtifactEvent, createArtifactParser } from './parser';
 
-function collectEvents(chunks: string[]): unknown[] {
+function collectEvents(chunks: string[]): ArtifactEvent[] {
   const parser = createArtifactParser();
-  const events: unknown[] = [];
+  const events: ArtifactEvent[] = [];
   for (const chunk of chunks) {
     for (const ev of parser.feed(chunk)) events.push(ev);
   }
   for (const ev of parser.flush()) events.push(ev);
   return events;
+}
+
+function joinText(events: ArtifactEvent[]): string {
+  return events
+    .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+    .map((e) => e.delta)
+    .join('');
 }
 
 describe('artifact parser', () => {
@@ -60,15 +67,10 @@ describe('artifact parser', () => {
       title: 't',
     });
     const endEvent = events.find(
-      (e): e is { type: 'artifact:end'; identifier: string; fullContent: string } =>
-        (e as { type: string }).type === 'artifact:end',
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
     );
     expect(endEvent?.fullContent).toBe('body');
-    const textLeak = events.find(
-      (e) =>
-        (e as { type: string }).type === 'text' &&
-        /<artifact/i.test((e as { delta: string }).delta),
-    );
+    const textLeak = events.find((e) => e.type === 'text' && /<artifact/i.test(e.delta));
     expect(textLeak).toBeUndefined();
   });
 
@@ -78,36 +80,151 @@ describe('artifact parser', () => {
       'ifact>',
     ]);
     const endEvent = events.find(
-      (e): e is { type: 'artifact:end'; identifier: string; fullContent: string } =>
-        (e as { type: string }).type === 'artifact:end',
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
     );
     expect(endEvent?.fullContent).toBe('hello');
   });
 
+  it('handles close tag split character by character', () => {
+    const chunks = [
+      '<artifact identifier="a1" type="html" title="t">hello',
+      ...Array.from('</artifact>'),
+    ];
+    const events = collectEvents(chunks);
+    const endEvent = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(endEvent?.fullContent).toBe('hello');
+    const textLeak = events.find((e) => e.type === 'text' && /<\/?artifact/.test(e.delta));
+    expect(textLeak).toBeUndefined();
+  });
+
   it('flushes a truncated artifact as a final end event', () => {
     const events = collectEvents(['<artifact identifier="a1" type="html" title="t">unfinished']);
-    const last = events[events.length - 1] as { type: string; fullContent?: string };
+    const last = events[events.length - 1] as Extract<ArtifactEvent, { type: 'artifact:end' }>;
     expect(last.type).toBe('artifact:end');
     expect(last.fullContent).toBe('unfinished');
   });
 
   it('does not stall on words that merely start with "<artifact" (letter follows)', () => {
     const events = collectEvents(['the <artifactual data', ' here']);
-    const text = events
-      .filter((e): e is { type: 'text'; delta: string } => (e as { type: string }).type === 'text')
-      .map((e) => e.delta)
-      .join('');
-    expect(text).toBe('the <artifactual data here');
-    expect(events.some((e) => (e as { type: string }).type === 'artifact:start')).toBe(false);
+    expect(joinText(events)).toBe('the <artifactual data here');
+    expect(events.some((e) => e.type === 'artifact:start')).toBe(false);
   });
 
   it('does not stall on "<artifact-like" (dash follows)', () => {
     const events = collectEvents(['something <artifact-like', ' suffix']);
-    const text = events
-      .filter((e): e is { type: 'text'; delta: string } => (e as { type: string }).type === 'text')
-      .map((e) => e.delta)
-      .join('');
-    expect(text).toBe('something <artifact-like suffix');
-    expect(events.some((e) => (e as { type: string }).type === 'artifact:start')).toBe(false);
+    expect(joinText(events)).toBe('something <artifact-like suffix');
+    expect(events.some((e) => e.type === 'artifact:start')).toBe(false);
+  });
+
+  // --- Leak audit tests (added in fix(artifacts): close remaining streaming parser leak paths) ---
+
+  it('parses attribute values that contain ">" (unescaped greater-than in title)', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="a > b">body</artifact>',
+    ]);
+    const start = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    expect(start).toEqual({
+      type: 'artifact:start',
+      identifier: 'a1',
+      artifactType: 'html',
+      title: 'a > b',
+    });
+    const end = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(end?.fullContent).toBe('body');
+  });
+
+  it('parses ">" inside a single-quoted attribute value', () => {
+    const events = collectEvents([
+      "<artifact identifier='a1' type='html' title='x > y'>body</artifact>",
+    ]);
+    const start = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    expect(start?.title).toBe('x > y');
+  });
+
+  it('does not leak the open tag when a streamed split lands inside a ">"-bearing attribute value', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="a >',
+      ' b">body</artifact>',
+    ]);
+    expect(events.some((e) => e.type === 'text' && /<artifact/i.test(e.delta))).toBe(false);
+    const start = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    expect(start?.title).toBe('a > b');
+    const end = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(end?.fullContent).toBe('body');
+  });
+
+  it('handles two artifacts in a single stream without state leak', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="t1">one</artifact>',
+      ' middle ',
+      '<artifact identifier="a2" type="html" title="t2">two</artifact>',
+    ]);
+    const starts = events.filter(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    const ends = events.filter(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(starts.map((s) => s.identifier)).toEqual(['a1', 'a2']);
+    expect(ends.map((e) => e.fullContent)).toEqual(['one', 'two']);
+    expect(joinText(events)).toBe(' middle ');
+  });
+
+  it('handles two back-to-back artifacts with the close+open boundary in one chunk', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="t1">one</artifact><artifact identifier="a2" type="html" title="t2">',
+      'two</artifact>',
+    ]);
+    const ends = events.filter(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(ends.map((e) => e.fullContent)).toEqual(['one', 'two']);
+  });
+
+  it('handles a multi-line open tag with newlines between attributes', () => {
+    const events = collectEvents([
+      '<artifact\n  identifier="a1"\n  type="html"\n  title="t"\n>body</artifact>',
+    ]);
+    const start = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    expect(start).toEqual({
+      type: 'artifact:start',
+      identifier: 'a1',
+      artifactType: 'html',
+      title: 't',
+    });
+  });
+
+  it('passes literal "<" in body through to artifact content (not confused with start-of-tag)', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="t"><div>1 < 2 && 3 > 0</div></artifact>',
+    ]);
+    const end = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(end?.fullContent).toBe('<div>1 < 2 && 3 > 0</div>');
+  });
+
+  it('passes a literal "<artifact" inside body content through unchanged', () => {
+    const events = collectEvents([
+      '<artifact identifier="a1" type="html" title="t">A code sample: <artifact id="x"> is the opening tag.</artifact>',
+    ]);
+    const end = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:end' }> => e.type === 'artifact:end',
+    );
+    expect(end?.fullContent).toBe('A code sample: <artifact id="x"> is the opening tag.');
   });
 });

--- a/packages/artifacts/src/parser.test.ts
+++ b/packages/artifacts/src/parser.test.ts
@@ -227,4 +227,23 @@ describe('artifact parser', () => {
     );
     expect(end?.fullContent).toBe('A code sample: <artifact id="x"> is the opening tag.');
   });
+
+  it('treats a bare <artifact> (no attributes) as plain prose, not an artifact tag', () => {
+    const events = collectEvents(['the <artifact>plain</artifact> token in prose']);
+    expect(events.some((e) => e.type === 'artifact:start')).toBe(false);
+    expect(joinText(events)).toBe('the <artifact>plain</artifact> token in prose');
+  });
+
+  it('still recognizes a real <artifact identifier=... type=...> open tag', () => {
+    const events = collectEvents(['<artifact identifier="a1" type="html">body</artifact>']);
+    const start = events.find(
+      (e): e is Extract<ArtifactEvent, { type: 'artifact:start' }> => e.type === 'artifact:start',
+    );
+    expect(start).toEqual({
+      type: 'artifact:start',
+      identifier: 'a1',
+      artifactType: 'html',
+      title: '',
+    });
+  });
 });

--- a/packages/artifacts/src/parser.ts
+++ b/packages/artifacts/src/parser.ts
@@ -199,8 +199,11 @@ function findOpenTag(buffer: string): OpenTagMatch {
       // Buffer ends exactly at `<artifact`; can't yet decide if it's a real tag.
       return { kind: 'partial', start: idx };
     }
-    if (next !== '>' && !/\s/.test(next)) {
-      // `<artifactual`, `<artifact-like`, etc. — not our tag, keep searching.
+    if (!/\s/.test(next)) {
+      // Real Claude artifacts always carry `identifier`/`type` attributes,
+      // so a bare `<artifact>` (or `<artifactual`, `<artifact-like`, …) is
+      // not our tag — keep searching so prose mentioning the literal token
+      // is preserved as text.
       from = afterPrefix;
       continue;
     }

--- a/packages/artifacts/src/parser.ts
+++ b/packages/artifacts/src/parser.ts
@@ -41,8 +41,13 @@ interface ParserState {
   content: string;
 }
 
-const OPEN_TAG_RE = /<artifact\s+([^>]*?)>/;
+const OPEN_PREFIX = '<artifact';
 const CLOSE_TAG = '</artifact>';
+
+type OpenTagMatch =
+  | { kind: 'complete'; start: number; end: number; attrs: string }
+  | { kind: 'partial'; start: number }
+  | { kind: 'none' };
 
 export function createArtifactParser() {
   const state: ParserState = {
@@ -75,28 +80,31 @@ export function createArtifactParser() {
 
     while (state.buffer.length > 0) {
       if (!state.inside) {
-        const open = OPEN_TAG_RE.exec(state.buffer);
-        if (!open) {
-          // No open tag in buffer. Emit everything except a possible partial '<artifact'
-          const safeUpTo = findSafeFlushPoint(state.buffer);
-          if (safeUpTo > 0) {
-            yield { type: 'text', delta: state.buffer.slice(0, safeUpTo) };
-            state.buffer = state.buffer.slice(safeUpTo);
+        const open = findOpenTag(state.buffer);
+        if (open.kind === 'none') {
+          yield { type: 'text', delta: state.buffer };
+          state.buffer = '';
+          return;
+        }
+        if (open.kind === 'partial') {
+          if (open.start > 0) {
+            yield { type: 'text', delta: state.buffer.slice(0, open.start) };
+            state.buffer = state.buffer.slice(open.start);
           }
           return;
         }
 
-        if (open.index > 0) {
-          yield { type: 'text', delta: state.buffer.slice(0, open.index) };
+        if (open.start > 0) {
+          yield { type: 'text', delta: state.buffer.slice(0, open.start) };
         }
 
-        const attrs = parseAttrs(open[1] as string);
+        const attrs = parseAttrs(open.attrs);
         state.inside = true;
         state.identifier = attrs['identifier'] ?? '';
         state.artifactType = attrs['type'] ?? '';
         state.title = attrs['title'] ?? '';
         state.content = '';
-        state.buffer = state.buffer.slice(open.index + open[0].length);
+        state.buffer = state.buffer.slice(open.end);
 
         yield {
           type: 'artifact:start',
@@ -157,27 +165,67 @@ export function createArtifactParser() {
 }
 
 /**
- * Find the largest index up to which we can safely emit text without
- * potentially splitting an "<artifact ...>" open tag in two.
+ * Locate the next `<artifact ...>` open tag in `buffer`, scanning attribute
+ * values in a quote-aware manner so that a `>` inside a quoted attribute
+ * value (e.g. `title="a > b"`) does not prematurely terminate the tag.
  *
- * Two cases must hold the tail back:
- *   1. tail is a strict prefix of "<artifact"  (e.g. "<art")
- *   2. tail already begins "<artifact" but the closing ">" hasn't arrived
- *      (e.g. `<artifact identifier="a1" type="html"`) — without this guard
- *      a stream split mid-attribute leaks the open tag into a `text` event
- *      and the artifact is silently lost.
+ * Returns:
+ *   - `complete`: a full open tag is present in the buffer
+ *   - `partial`:  a candidate prefix is present but the closing `>` (or
+ *                 enough of `<artifact` itself) hasn't arrived yet — caller
+ *                 must hold back from `start` and wait for more input
+ *   - `none`:     no candidate; caller may flush the entire buffer as text
  */
-function findSafeFlushPoint(buffer: string): number {
-  const ltIdx = buffer.lastIndexOf('<');
-  if (ltIdx === -1) return buffer.length;
-  const tail = buffer.slice(ltIdx);
-  if ('<artifact'.startsWith(tail)) return ltIdx;
-  if (tail.startsWith('<artifact') && !tail.includes('>')) {
-    // Only hold back when the next char is whitespace (attributes coming) or
-    // we don't yet have a next char to decide. A letter/digit/dash means this
-    // is an unrelated word like `<artifactual` or `<artifact-like` — flush it.
-    const next = tail.charAt('<artifact'.length);
-    if (next === '' || /\s/.test(next)) return ltIdx;
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: quote-aware tag scanning is inherently branchy; splitting hurts clarity
+function findOpenTag(buffer: string): OpenTagMatch {
+  let from = 0;
+  while (from <= buffer.length) {
+    const idx = buffer.indexOf(OPEN_PREFIX, from);
+    if (idx === -1) {
+      // No full `<artifact` left. Maybe a strict prefix at the tail (e.g. `<art`).
+      const tail = buffer.lastIndexOf('<', buffer.length - 1);
+      if (tail !== -1) {
+        const slice = buffer.slice(tail);
+        if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
+          return { kind: 'partial', start: tail };
+        }
+      }
+      return { kind: 'none' };
+    }
+
+    const afterPrefix = idx + OPEN_PREFIX.length;
+    const next = buffer.charAt(afterPrefix);
+    if (next === '') {
+      // Buffer ends exactly at `<artifact`; can't yet decide if it's a real tag.
+      return { kind: 'partial', start: idx };
+    }
+    if (next !== '>' && !/\s/.test(next)) {
+      // `<artifactual`, `<artifact-like`, etc. — not our tag, keep searching.
+      from = afterPrefix;
+      continue;
+    }
+
+    // Scan forward for the closing `>` while respecting quoted attribute values.
+    let i = afterPrefix;
+    let quote: '"' | "'" | null = null;
+    while (i < buffer.length) {
+      const c = buffer.charAt(i);
+      if (quote !== null) {
+        if (c === quote) quote = null;
+      } else if (c === '"' || c === "'") {
+        quote = c;
+      } else if (c === '>') {
+        return {
+          kind: 'complete',
+          start: idx,
+          end: i + 1,
+          attrs: buffer.slice(afterPrefix, i),
+        };
+      }
+      i++;
+    }
+    // Reached end of buffer without finding the closing `>`.
+    return { kind: 'partial', start: idx };
   }
-  return buffer.length;
+  return { kind: 'none' };
 }


### PR DESCRIPTION
## Summary

Audit follow-up to #95. Re-checked the streaming artifact parser on 8 leak axes; one real leak class found and fixed, the other 7 were already robust and now have regression tests.

### Real leak fixed: `>` inside a quoted attribute value

`OPEN_TAG_RE = /<artifact\s+([^>]*?)>/` cannot tell a real `>` from one inside a quoted attribute value, so input like:

```ts
'<artifact identifier="a1" type="html" title="a > b">body</artifact>'
```

silently dropped `title`, corrupted the body, and (when the stream split landed mid-attribute) leaked raw `<artifact ...` markup into a `text` event:

```ts
['<artifact identifier="a1" type="html" title="a >', ' b">body</artifact>']
```

Replaced both `OPEN_TAG_RE` and `findSafeFlushPoint` with a single quote-aware scanner `findOpenTag` returning `complete` / `partial` / `none`. The `partial` case subsumes the previous prefix-holdback logic.

### Already robust (regression tests added)

| Axis | Status |
| --- | --- |
| `</artifact>` close-tag split across deltas | already robust (10-char holdback) |
| Close tag arriving one char at a time | already robust |
| Multiple `<artifact>` blocks in one stream | already robust (state resets in loop) |
| Back-to-back artifacts with close+open in same chunk | already robust |
| Multi-line tag declaration (`<artifact\n  identifier=...`) | already robust (`\s+`) |
| Truncated artifact at stream end | already robust (`flush()` emits final end) |
| Literal `<` and literal `<artifact` in body content | already robust (only `</artifact>` exits inside-mode) |

### Not fixed (out of scope, exceptional)

- Literal `</artifact>` inside body — not disambiguable without a delimiter; models do not emit this in practice.
- HTML entity decoding inside attribute values — models do not escape attrs; would only matter if they did.

## Principles check

- Compatibility: green — no schema/IPC change
- Upgradeability: green — pure parser internals
- No bloat: green — net delta is one helper function; no new deps
- Elegance: green — `findOpenTag` collapses the regex + the prefix-holdback helper into one quote-aware pass

## Test plan

- [x] `pnpm --filter @open-codesign/artifacts test` — 17 / 17 pass (3 new failing tests now pass)
- [x] `pnpm test` — all packages green
- [x] `pnpm lint` — no new warnings (parser.ts complexity suppressed in line with existing convention in `feed`)
- [x] `pnpm typecheck` — green