### PR TITLE
fix(core): enable reasoning for OpenRouter mandate-reasoning models (gpt-oss)

### DIFF
--- a/packages/core/src/generate.test.ts
+++ b/packages/core/src/generate.test.ts
@@ -304,6 +304,67 @@ describe('generate()', () => {
     expect(opts.reasoning).toBeUndefined();
   });
 
+  // Upstream returns 400 "Reasoning is mandatory for this endpoint and cannot
+  // be disabled." for openai/gpt-oss-* served via OpenRouter. The whitelist
+  // here must keep that path working without re-opening the silent-fallback
+  // problem on other pass-through ids.
+  it('passes reasoning=high for OpenRouter openai/gpt-oss-120b:free (mandates reasoning upstream)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'openai/gpt-oss-120b:free' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('high');
+  });
+
+  it('passes reasoning=high for OpenRouter openai/gpt-oss-20b (mandates reasoning upstream)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'openai/gpt-oss-20b' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBe('high');
+  });
+
+  it('omits reasoning for OpenRouter meta-llama/llama-3-70b (not on mandate-reasoning list)', async () => {
+    completeMock.mockResolvedValueOnce({
+      content: RESPONSE,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+    });
+
+    await generate({
+      prompt: 'design a meditation app',
+      history: [],
+      model: { provider: 'openrouter', modelId: 'meta-llama/llama-3-70b' },
+      apiKey: 'sk-test',
+    });
+
+    const opts = completeMock.mock.calls[0]?.[2] as { reasoning?: string };
+    expect(opts.reasoning).toBeUndefined();
+  });
+
   it('omits reasoning for older Anthropic Claude models (avoids accidental extended thinking)', async () => {
     completeMock.mockResolvedValueOnce({
       content: RESPONSE,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -411,6 +411,13 @@ const CLAUDE_4_MODEL_RE = /claude-(?:opus|sonnet)-4/i;
 /** OpenAI reasoning families (o-series and gpt-5). Anchored to the start of
  *  the modelId so a tenant prefix or pass-through path can't sneak through. */
 const OPENAI_REASONING_MODEL_RE = /^(?:o1|o3|o4|gpt-5)(?:[-.].*)?$/i;
+/** OpenRouter pass-through ids that *mandate* reasoning at the upstream
+ *  endpoint — sending the request without `reasoning` returns HTTP 400
+ *  ("Reasoning is mandatory for this endpoint and cannot be disabled.").
+ *  This is a strict whitelist on the namespaced id OpenRouter exposes; we do
+ *  NOT trust substring matches across other pass-through providers. Add new
+ *  entries only after observing the mandate-reasoning 400 in the wild. */
+const OPENROUTER_MANDATORY_REASONING_RE = /^openai\/gpt-oss(?:[-/].*)?$/i;
 
 function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
   // Whitelist by (provider, modelId) pair. Substring matches across providers
@@ -424,8 +431,14 @@ function reasoningForModel(model: ModelRef): ReasoningLevel | undefined {
       return CLAUDE_4_MODEL_RE.test(model.modelId) ? 'high' : undefined;
     case 'openai':
       return OPENAI_REASONING_MODEL_RE.test(model.modelId) ? 'high' : undefined;
+    case 'openrouter':
+      // Narrow whitelist: only models whose upstream endpoint *requires*
+      // reasoning (sending `reasoning: undefined` returns HTTP 400). Other
+      // pass-through ids stay undefined — we trust the namespaced prefix
+      // OpenRouter publishes, but not arbitrary substring matches.
+      return OPENROUTER_MANDATORY_REASONING_RE.test(model.modelId) ? 'high' : undefined;
     default:
-      // openrouter, groq, cerebras, xai, mistral, bedrock, azure, vercel-ai-gateway:
+      // groq, cerebras, xai, mistral, bedrock, azure, vercel-ai-gateway:
       // all pass-through or multi-tenant. Even if they serve a reasoning model,
       // we cannot trust the model id alone, and pi-ai will silently drop or
       // mistranslate the reasoning knob. Stay conservative.


### PR DESCRIPTION
## Bug

OpenRouter rejects requests to `openai/gpt-oss-*` served via its pass-through endpoint with HTTP 400 when the `reasoning` knob is omitted. From `/tmp/codesign-dev.log`:

```
provider=openrouter modelId=openai/gpt-oss-120b:free
message: '400 Reasoning is mandatory for this endpoint and cannot be disabled.'
code: PROVIDER_ERROR
```

## Root cause

`reasoningForModel()` in `packages/core/src/index.ts` returns `undefined` for *every* non-anthropic / non-openai provider. The original guard treats all pass-through ids as untrusted to avoid silently enabling reasoning on the wrong model — but that also silently breaks gpt-oss, which **requires** reasoning.

## Fix

Add a strict, namespaced whitelist on the `openrouter` branch — only ids whose upstream endpoint is known to *require* reasoning (currently `openai/gpt-oss-*`) are matched. Other pass-through ids stay `undefined`, preserving the existing "no silent fallback on substring matches" guarantee.

The whitelist is intentionally narrow: new entries are only added after observing the mandate-reasoning 400 in the wild. We do **not** add `anthropic/claude-*` pass-through (those work fine without reasoning and the existing test pins that contract).

## Files changed

- `packages/core/src/index.ts` — new `OPENROUTER_MANDATORY_REASONING_RE` + `openrouter` case in `reasoningForModel()`
- `packages/core/src/generate.test.ts` — three new Vitest cases

## Test plan

- [x] `pnpm --filter @open-codesign/core test -- --run` → 143/143 passing (3 new)
- [x] `pnpm --filter @open-codesign/core typecheck` → clean
- [x] `pnpm exec biome check` on changed files → clean
- [x] New cases:
  - `openrouter` + `openai/gpt-oss-120b:free` → reasoning='high'
  - `openrouter` + `openai/gpt-oss-20b` → reasoning='high'
  - `openrouter` + `meta-llama/llama-3-70b` → undefined
- [x] Existing `openrouter` + `anthropic/claude-sonnet-4` still returns `undefined` (unchanged)
- [x] Existing `openrouter` + `mystery-lab/o1-lookalike` still returns `undefined` (unchanged)

## PRINCIPLES §5b

- Compatibility ✅ — no schema or IPC change
- Upgradeability ✅ — whitelist additions are local, no migration needed
- No bloat ✅ — one regex + one switch arm + tests
- Elegance ✅ — same whitelist pattern as the existing anthropic/openai cases