### PR TITLE
feat(scripts): pnpm smoke — batch model/prompt API tester

### DIFF
--- a/.changeset/smoke-fail-fast-unknown-provider.md
+++ b/.changeset/smoke-fail-fast-unknown-provider.md
@@ -1,0 +1,8 @@
+---
+"open-codesign": patch
+---
+
+Make the `scripts/smoke-models.ts` harness fail fast when the smoke config
+references a provider not registered in `ENV_KEY`. Previously the script
+silently skipped the model (treating it as "no API key set"), masking config
+typos and producing false-green smoke runs.

--- a/.changeset/smoke-models-cli.md
+++ b/.changeset/smoke-models-cli.md
@@ -9,3 +9,5 @@ feat(scripts): add `pnpm smoke` batch model/prompt tester
 API keys come from environment variables (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.) — never stored in the repo. Models and prompts live in `scripts/smoke-models.toml`.
 
 CLI flags: `--model`, `--prompt`, `--only-failed`, `--config`.
+
+Sanitize TOML prompt names against path traversal — model/prompt slugs now collapse any non-`[a-zA-Z0-9._-]` character to `_`, and the resolved artifact path is verified to stay inside `/tmp/smoke/` before write.

--- a/.changeset/smoke-models-cli.md
+++ b/.changeset/smoke-models-cli.md
@@ -1,0 +1,11 @@
+---
+'open-codesign': minor
+---
+
+feat(scripts): add `pnpm smoke` batch model/prompt tester
+
+`scripts/smoke-models.ts` runs a (provider × model × prompt) matrix through the same `generate()` code path the desktop app uses, saves each artifact to `/tmp/smoke/`, and prints a colored report with quality flags (multiple `<main>` elements, emoji icons, missing EDITMODE block, JS syntax errors via acorn).
+
+API keys come from environment variables (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc.) — never stored in the repo. Models and prompts live in `scripts/smoke-models.toml`.
+
+CLI flags: `--model`, `--prompt`, `--only-failed`, `--config`.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ test-results/
 .env
 .env.*
 !.env.example
+scripts/.smoke-keys.env
 
 # Editor
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs:dev": "pnpm --filter open-codesign-website dev",
     "docs:build": "pnpm --filter open-codesign-website build",
     "docs:preview": "pnpm --filter open-codesign-website preview",
+    "smoke": "tsx scripts/smoke-models.ts",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish"
@@ -35,7 +36,13 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.27.11",
+    "@iarna/toml": "^2.2.5",
+    "@open-codesign/core": "workspace:*",
+    "@open-codesign/shared": "workspace:*",
+    "@types/node": "^22.10.2",
+    "acorn": "^8.14.0",
     "husky": "^9.1.7",
+    "tsx": "^4.19.2",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,27 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.11
         version: 2.31.0(@types/node@22.19.17)
+      '@iarna/toml':
+        specifier: ^2.2.5
+        version: 2.2.5
+      '@open-codesign/core':
+        specifier: workspace:*
+        version: link:packages/core
+      '@open-codesign/shared':
+        specifier: workspace:*
+        version: link:packages/shared
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.17
+      acorn:
+        specifier: ^8.14.0
+        version: 8.16.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       turbo:
         specifier: ^2.3.3
         version: 2.9.6
@@ -95,7 +113,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
@@ -110,7 +128,7 @@ importers:
         version: 26.8.1(dmg-builder@26.8.1)
       electron-vite:
         specifier: ^2.3.0
-        version: 2.3.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 2.3.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
@@ -119,7 +137,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.5
-        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)(happy-dom@20.9.0)(lightningcss@1.32.0)
@@ -826,6 +844,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -834,6 +858,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -850,6 +880,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -858,6 +894,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -874,6 +916,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -882,6 +930,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -898,6 +952,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -906,6 +966,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -922,6 +988,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -930,6 +1002,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -946,6 +1024,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -954,6 +1038,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -970,6 +1060,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -978,6 +1074,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -994,6 +1096,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -1002,6 +1110,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1018,8 +1132,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1036,8 +1162,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1054,8 +1192,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1072,6 +1222,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -1080,6 +1236,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1096,6 +1258,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -1104,6 +1272,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1991,6 +2165,11 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2612,6 +2791,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2812,6 +2996,9 @@ packages:
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -3748,6 +3935,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
@@ -4069,6 +4259,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -5334,10 +5529,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -5346,10 +5547,16 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -5358,10 +5565,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -5370,10 +5583,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -5382,10 +5601,16 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -5394,10 +5619,16 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -5406,10 +5637,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -5418,10 +5655,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -5430,7 +5673,13 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -5439,7 +5688,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -5448,7 +5703,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -5457,10 +5718,16 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -5469,10 +5736,16 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@fontsource-variable/fraunces@5.2.9': {}
@@ -6333,7 +6606,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -6341,7 +6614,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6492,6 +6765,8 @@ snapshots:
   '@xmldom/xmldom@0.8.12': {}
 
   abbrev@3.0.1: {}
+
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -7093,7 +7368,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@2.3.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)):
+  electron-vite@2.3.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -7101,7 +7376,7 @@ snapshots:
       esbuild: 0.21.5
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7230,6 +7505,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -7451,6 +7755,10 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-uri@6.0.5:
     dependencies:
@@ -8411,6 +8719,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
@@ -8781,6 +9091,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -8899,7 +9216,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0):
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8912,6 +9229,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
 
   vitepress@1.6.4(@algolia/client-search@5.50.2)(@types/node@22.19.17)(lightningcss@1.32.0)(postcss@8.5.10)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:

--- a/scripts/smoke-models.toml
+++ b/scripts/smoke-models.toml
@@ -1,0 +1,49 @@
+# Smoke-test matrix
+#
+# Drives `pnpm smoke`. API keys are NEVER stored here — set them in your
+# environment (one per provider you want to test):
+#
+#   export OPENROUTER_API_KEY=sk-or-...
+#   export ANTHROPIC_API_KEY=sk-ant-...
+#   export OPENAI_API_KEY=sk-...
+#   export GOOGLE_API_KEY=...
+#   export GROQ_API_KEY=...
+#
+# Add or remove rows freely. Rows referencing a provider with no key are
+# skipped with a warning, not failed.
+
+[[prompts]]
+name = "dashboard"
+text = "做一个数据看板，含 3 张图：条形图（销量）、折线图（留存）、饼图（细分）。深色主题。"
+
+[[prompts]]
+name = "mobile_onboarding"
+text = "iOS 移动端 onboarding 三屏：欢迎、权限请求、登录。Liquid Glass 风格，每屏构图不同。"
+
+[[prompts]]
+name = "marketing_landing"
+text = "Landing page for an indie design tool called Open Codesign. Warm cream tones, editorial display serif (Fraunces), dense layout with hero / 3 feature blocks / pricing / FAQ / CTA."
+
+[[prompts]]
+name = "settings"
+text = "应用设置页面，含账户、通知、外观三个 tab。深色主题，sidebar 导航 + 右侧表单。"
+
+[[models]]
+provider = "openrouter"
+modelId = "anthropic/claude-sonnet-4.5"
+
+[[models]]
+provider = "openrouter"
+modelId = "anthropic/claude-3.5-sonnet"
+
+[[models]]
+provider = "openrouter"
+modelId = "openai/gpt-oss-120b:free"
+
+[[models]]
+provider = "openrouter"
+modelId = "minimax/minimax-m2.5:free"
+
+[[models]]
+provider = "anthropic"
+modelId = "claude-sonnet-4-6"

--- a/scripts/smoke-models.toml
+++ b/scripts/smoke-models.toml
@@ -9,6 +9,10 @@
 #   export GOOGLE_API_KEY=...
 #   export GROQ_API_KEY=...
 #
+# Or stash them in a gitignored file and source on demand:
+#   echo 'export OPENROUTER_API_KEY=sk-or-...' > scripts/.smoke-keys.env
+#   set -a && source scripts/.smoke-keys.env && set +a && pnpm smoke
+#
 # Add or remove rows freely. Rows referencing a provider with no key are
 # skipped with a warning, not failed.
 
@@ -28,22 +32,54 @@ text = "Landing page for an indie design tool called Open Codesign. Warm cream t
 name = "settings"
 text = "应用设置页面，含账户、通知、外观三个 tab。深色主题，sidebar 导航 + 右侧表单。"
 
-[[models]]
-provider = "openrouter"
-modelId = "anthropic/claude-sonnet-4.5"
+# ─── Free OpenRouter models worth comparing ───────────────────────
+# These all run on $OPENROUTER_API_KEY. No charge.
 
 [[models]]
 provider = "openrouter"
-modelId = "anthropic/claude-3.5-sonnet"
+modelId = "qwen/qwen3-coder:free"
+# Currently the strongest free coder on OR (480B MoE, 262K ctx).
+
+[[models]]
+provider = "openrouter"
+modelId = "deepseek/deepseek-r1:free"
+# Reasoning-mandatory; exercises our self-healing retry path.
+
+[[models]]
+provider = "openrouter"
+modelId = "nvidia/nemotron-3-super:free"
+# Hybrid Mamba-Transformer MoE — different architecture for comparison.
+
+[[models]]
+provider = "openrouter"
+modelId = "meta-llama/llama-3.3-70b-instruct:free"
+# Solid general baseline.
 
 [[models]]
 provider = "openrouter"
 modelId = "openai/gpt-oss-120b:free"
+# Already verified working with the reasoning self-healing fix.
 
 [[models]]
 provider = "openrouter"
 modelId = "minimax/minimax-m2.5:free"
+# Reasoning-mandatory; another self-healing exercise.
 
 [[models]]
-provider = "anthropic"
-modelId = "claude-sonnet-4-6"
+provider = "openrouter"
+modelId = "mistralai/devstral-2:free"
+# Mistral coding-focused (123B dense).
+
+[[models]]
+provider = "openrouter"
+modelId = "xiaomi/mimo-v2-flash:free"
+# Reportedly matches Sonnet 4.5 on coding benchmarks — useful upper bound for free tier.
+
+# ─── Paid baselines (uncomment if you want a quality ceiling) ─────
+# [[models]]
+# provider = "openrouter"
+# modelId = "anthropic/claude-sonnet-4.5"
+#
+# [[models]]
+# provider = "anthropic"
+# modelId = "claude-sonnet-4-6"

--- a/scripts/smoke-models.ts
+++ b/scripts/smoke-models.ts
@@ -209,10 +209,16 @@ async function runMatrix(
   const results: RunResult[] = [];
   for (const m of models) {
     const envName = ENV_KEY[m.provider];
-    const apiKey = envName ? process.env[envName] : undefined;
+    if (!envName) {
+      throw new Error(
+        `Unsupported provider in smoke config: ${m.provider}. Add it to ENV_KEY or fix scripts/smoke-models.toml.`,
+      );
+    }
+
+    const apiKey = process.env[envName];
     if (!apiKey) {
       console.log(
-        `${COLOR.dim}— ${m.provider}/${m.modelId}  (no $${envName ?? '<unknown env>'}; skipped)${COLOR.reset}`,
+        `${COLOR.dim}— ${m.provider}/${m.modelId}  (no $${envName}; skipped)${COLOR.reset}`,
       );
       continue;
     }

--- a/scripts/smoke-models.ts
+++ b/scripts/smoke-models.ts
@@ -16,7 +16,7 @@
  *   GROQ_API_KEY, CEREBRAS_API_KEY, XAI_API_KEY, MISTRAL_API_KEY.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import * as TOML from '@iarna/toml';
 import { generate } from '@open-codesign/core';
@@ -151,7 +151,10 @@ async function runOne(model: SmokeModel, prompt: SmokePrompt, apiKey: string): P
     const ms = Date.now() - t0;
     const html = result.artifacts[0]?.content ?? '';
     const artifactPath = resolve(SMOKE_DIR, `${slug(model, prompt)}.html`);
-    if (!artifactPath.startsWith(`${SMOKE_DIR}/`)) {
+    // Use platform-aware containment instead of POSIX-only startsWith — slug
+    // sanitization should already prevent traversal, this is defense-in-depth.
+    const rel = relative(SMOKE_DIR, artifactPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
       throw new Error(`Refusing to write outside ${SMOKE_DIR}: ${artifactPath}`);
     }
     writeFileSync(artifactPath, html);

--- a/scripts/smoke-models.ts
+++ b/scripts/smoke-models.ts
@@ -149,7 +149,11 @@ async function runOne(model: SmokeModel, prompt: SmokePrompt, apiKey: string): P
       },
     });
     const ms = Date.now() - t0;
-    const html = result.artifacts[0]?.content ?? '';
+    const artifact = result.artifacts[0];
+    if (!artifact?.content?.trim()) {
+      throw new Error('No HTML artifact returned from generate()');
+    }
+    const html = artifact.content;
     const artifactPath = resolve(SMOKE_DIR, `${slug(model, prompt)}.html`);
     // Use platform-aware containment instead of POSIX-only startsWith — slug
     // sanitization should already prevent traversal, this is defense-in-depth.

--- a/scripts/smoke-models.ts
+++ b/scripts/smoke-models.ts
@@ -79,8 +79,9 @@ function parseConfig(path: string): SmokeConfig {
 }
 
 function slug(model: SmokeModel, prompt: SmokePrompt): string {
-  const safeModel = `${model.provider}_${model.modelId}`.replace(/[/:]/g, '_');
-  return `${safeModel}__${prompt.name}`;
+  const safeModel = `${model.provider}_${model.modelId}`.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const safePrompt = prompt.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return `${safeModel}__${safePrompt}`;
 }
 
 function qualityCheck(html: string): string[] {
@@ -149,15 +150,18 @@ async function runOne(model: SmokeModel, prompt: SmokePrompt, apiKey: string): P
     });
     const ms = Date.now() - t0;
     const html = result.artifacts[0]?.content ?? '';
-    const path = `${SMOKE_DIR}/${slug(model, prompt)}.html`;
-    writeFileSync(path, html);
+    const artifactPath = resolve(SMOKE_DIR, `${slug(model, prompt)}.html`);
+    if (!artifactPath.startsWith(`${SMOKE_DIR}/`)) {
+      throw new Error(`Refusing to write outside ${SMOKE_DIR}: ${artifactPath}`);
+    }
+    writeFileSync(artifactPath, html);
     return {
       model: `${model.provider}/${model.modelId}`,
       prompt: prompt.name,
       ok: true,
       ms,
       bytes: html.length,
-      artifactPath: path,
+      artifactPath,
       issues: qualityCheck(html),
     };
   } catch (err) {

--- a/scripts/smoke-models.ts
+++ b/scripts/smoke-models.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env tsx
+/**
+ * smoke-models.ts — batch-test (provider, model, prompt) combos through the
+ * exact same `generate()` code path the desktop app uses. Saves each artifact
+ * to /tmp/smoke/, runs lightweight quality checks, prints a colored report.
+ *
+ * Usage:
+ *   pnpm smoke
+ *   pnpm smoke --model openai/gpt-oss-120b:free
+ *   pnpm smoke --prompt "数据看板"
+ *   pnpm smoke --only-failed
+ *   pnpm smoke --config scripts/my-models.toml
+ *
+ * API keys come from the environment (one per provider you want to hit):
+ *   OPENROUTER_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY,
+ *   GROQ_API_KEY, CEREBRAS_API_KEY, XAI_API_KEY, MISTRAL_API_KEY.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import * as TOML from '@iarna/toml';
+import { generate } from '@open-codesign/core';
+import { Parser } from 'acorn';
+
+interface SmokeModel {
+  provider: string;
+  modelId: string;
+}
+interface SmokePrompt {
+  name: string;
+  text: string;
+}
+interface SmokeConfig {
+  prompts: SmokePrompt[];
+  models: SmokeModel[];
+}
+
+interface RunResult {
+  model: string;
+  prompt: string;
+  ok: boolean;
+  ms: number;
+  bytes: number;
+  artifactPath?: string;
+  issues: string[];
+  error?: string;
+}
+
+const ENV_KEY: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  google: 'GOOGLE_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  groq: 'GROQ_API_KEY',
+  cerebras: 'CEREBRAS_API_KEY',
+  xai: 'XAI_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+};
+
+const COLOR = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+};
+
+const SMOKE_DIR = '/tmp/smoke';
+const LAST_RESULTS = `${SMOKE_DIR}/.last-results.json`;
+
+function parseConfig(path: string): SmokeConfig {
+  const raw = readFileSync(path, 'utf8');
+  const parsed = TOML.parse(raw) as unknown as SmokeConfig;
+  if (!Array.isArray(parsed.prompts) || !Array.isArray(parsed.models)) {
+    throw new Error(`${path} must declare [[prompts]] and [[models]] tables`);
+  }
+  return parsed;
+}
+
+function slug(model: SmokeModel, prompt: SmokePrompt): string {
+  const safeModel = `${model.provider}_${model.modelId}`.replace(/[/:]/g, '_');
+  return `${safeModel}__${prompt.name}`;
+}
+
+function qualityCheck(html: string): string[] {
+  const issues: string[] = [];
+
+  const mainCount = (html.match(/<main[\s>]/gi) ?? []).length;
+  if (mainCount > 1) issues.push(`${mainCount}x <main> elements`);
+
+  // Emoji used as content icons (anti-slop). Heuristic: emoji codepoint sitting
+  // inside a <div> with aria-hidden or a role suggesting decoration. Broad,
+  // intentionally — false positives are cheap signals here.
+  const emojiInIcon = html.match(
+    /aria-hidden=["']true["'][^>]*>[\s]*[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu,
+  );
+  if (emojiInIcon) issues.push(`${emojiInIcon.length} emoji icon(s)`);
+
+  // Validate every <script> body parses as JS. We deliberately don't
+  // distinguish module from script (Babel handles JSX in the artifact at
+  // runtime) — just check it's lexically clean enough that tools like esbuild
+  // wouldn't choke.
+  const scripts = [...html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/gi)];
+  for (const m of scripts) {
+    const body = m[1]?.trim();
+    if (!body) continue;
+    try {
+      Parser.parse(body, { ecmaVersion: 'latest', sourceType: 'script' });
+    } catch (err) {
+      issues.push(`script syntax error: ${(err as Error).message.split('\n')[0]}`);
+      break;
+    }
+  }
+
+  if (!/TWEAK_DEFAULTS\s*=\s*\/\*EDITMODE-BEGIN\*\//.test(html)) {
+    issues.push('no EDITMODE block');
+  }
+
+  return issues;
+}
+
+function printResult(r: RunResult): void {
+  if (r.ok) {
+    const head = `${COLOR.green}✓${COLOR.reset} ${COLOR.bold}${r.model}${COLOR.reset} × ${r.prompt}`;
+    const body = `${COLOR.dim}${(r.ms / 1000).toFixed(1)}s  ${(r.bytes / 1024).toFixed(1)}kb  →${COLOR.reset} ${r.artifactPath}`;
+    console.log(head);
+    console.log(`  ${body}`);
+    for (const issue of r.issues) {
+      console.log(`  ${COLOR.yellow}⚠${COLOR.reset} ${issue}`);
+    }
+  } else {
+    console.log(`${COLOR.red}✗${COLOR.reset} ${COLOR.bold}${r.model}${COLOR.reset} × ${r.prompt}`);
+    console.log(`  ${COLOR.red}${r.error}${COLOR.reset}`);
+  }
+}
+
+async function runOne(model: SmokeModel, prompt: SmokePrompt, apiKey: string): Promise<RunResult> {
+  const t0 = Date.now();
+  try {
+    const result = await generate({
+      prompt: prompt.text,
+      history: [],
+      model: { provider: model.provider as never, modelId: model.modelId },
+      apiKey,
+      onRetry: (info) => {
+        console.log(`  ${COLOR.dim}↻ retry: ${info.reason}${COLOR.reset}`);
+      },
+    });
+    const ms = Date.now() - t0;
+    const html = result.artifacts[0]?.content ?? '';
+    const path = `${SMOKE_DIR}/${slug(model, prompt)}.html`;
+    writeFileSync(path, html);
+    return {
+      model: `${model.provider}/${model.modelId}`,
+      prompt: prompt.name,
+      ok: true,
+      ms,
+      bytes: html.length,
+      artifactPath: path,
+      issues: qualityCheck(html),
+    };
+  } catch (err) {
+    return {
+      model: `${model.provider}/${model.modelId}`,
+      prompt: prompt.name,
+      ok: false,
+      ms: Date.now() - t0,
+      bytes: 0,
+      issues: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function selectModels(all: SmokeModel[], filter: string | undefined): SmokeModel[] {
+  if (!filter) return all;
+  const matched = all.filter(
+    (m) => `${m.provider}/${m.modelId}` === filter || m.modelId === filter,
+  );
+  if (matched.length === 0) {
+    console.error(`${COLOR.red}No model matched --model=${filter}${COLOR.reset}`);
+    process.exit(2);
+  }
+  return matched;
+}
+
+function selectPrompts(all: SmokePrompt[], override: string | undefined): SmokePrompt[] {
+  if (!override) return all;
+  return [{ name: 'cli', text: override }];
+}
+
+function loadFailedKeys(): Set<string> | null {
+  if (!existsSync(LAST_RESULTS)) return null;
+  const last = JSON.parse(readFileSync(LAST_RESULTS, 'utf8')) as RunResult[];
+  const failed = new Set(last.filter((r) => !r.ok).map((r) => `${r.model}|${r.prompt}`));
+  if (failed.size === 0) {
+    console.log('No failed runs in last report. Nothing to retry.');
+    return new Set();
+  }
+  return failed;
+}
+
+async function runMatrix(
+  models: SmokeModel[],
+  prompts: SmokePrompt[],
+  onlyKeys: Set<string> | null,
+): Promise<RunResult[]> {
+  const results: RunResult[] = [];
+  for (const m of models) {
+    const envName = ENV_KEY[m.provider];
+    const apiKey = envName ? process.env[envName] : undefined;
+    if (!apiKey) {
+      console.log(
+        `${COLOR.dim}— ${m.provider}/${m.modelId}  (no $${envName ?? '<unknown env>'}; skipped)${COLOR.reset}`,
+      );
+      continue;
+    }
+    for (const p of prompts) {
+      if (onlyKeys && !onlyKeys.has(`${m.provider}/${m.modelId}|${p.name}`)) continue;
+      const r = await runOne(m, p, apiKey);
+      printResult(r);
+      results.push(r);
+    }
+  }
+  return results;
+}
+
+function printSummary(results: RunResult[]): void {
+  const passed = results.filter((r) => r.ok).length;
+  const issued = results.filter((r) => r.ok && r.issues.length > 0).length;
+  console.log('');
+  console.log(
+    `${COLOR.bold}${passed}/${results.length}${COLOR.reset} passed${
+      issued > 0 ? `, ${COLOR.yellow}${issued}${COLOR.reset} with quality warnings` : ''
+    }. Artifacts in ${SMOKE_DIR}/`,
+  );
+  process.exit(passed === results.length ? 0 : 1);
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      config: { type: 'string', default: 'scripts/smoke-models.toml' },
+      model: { type: 'string' },
+      prompt: { type: 'string' },
+      'only-failed': { type: 'boolean', default: false },
+    },
+  });
+
+  const cfg = parseConfig(resolve(values.config ?? 'scripts/smoke-models.toml'));
+  const models = selectModels(cfg.models, values.model);
+  const prompts = selectPrompts(cfg.prompts, values.prompt);
+  const onlyKeys = values['only-failed'] ? loadFailedKeys() : null;
+  if (onlyKeys && onlyKeys.size === 0) return;
+
+  mkdirSync(SMOKE_DIR, { recursive: true });
+  const results = await runMatrix(models, prompts, onlyKeys);
+  writeFileSync(LAST_RESULTS, JSON.stringify(results, null, 2));
+  printSummary(results);
+}
+
+main().catch((err) => {
+  console.error(`${COLOR.red}smoke harness crashed:${COLOR.reset}`, err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

- New \`scripts/smoke-models.ts\` runs a (provider × model × prompt) matrix through the **same** \`generate()\` code path the desktop app uses — same prompt assembly, same reasoning self-healing, same parser.
- Saves each artifact to \`/tmp/smoke/<provider>_<model>__<prompt>.html\` so they can be opened in a browser side by side.
- Quality checks per artifact: acorn JS syntax (catches the kind of typos we hit yesterday), multiple \`<main>\` elements, emoji-as-icon usage, missing \`TWEAK_DEFAULTS\` EDITMODE block.
- API keys come from environment variables (\`OPENROUTER_API_KEY\`, \`ANTHROPIC_API_KEY\`, etc.) — never stored in repo.

CLI flags:
\`\`\`
pnpm smoke
pnpm smoke --model openai/gpt-oss-120b:free
pnpm smoke --prompt "数据看板"
pnpm smoke --only-failed
\`\`\`

The \`scripts/smoke-models.toml\` ships with 5 default models × 4 default prompts (dashboard, mobile onboarding, marketing landing, settings) — easy to extend.

## Why

Manual loop of "type prompt in app → wait → look at result → switch model in Settings → repeat" was the bottleneck for debugging API issues (today's reasoning-mandatory bug, prompt quality gaps). \`pnpm smoke\` collapses that into one command across the whole model lineup.

## Test plan

- [x] Typechecks (\`pnpm exec tsc --noEmit ... scripts/smoke-models.ts\`)
- [x] Lints clean (\`pnpm exec biome check scripts/ package.json\`)
- [x] Dry-run with no API keys exits cleanly with \`0/0 passed\` and per-model "skipped (no \$KEY)" message
- [x] Bogus \`--model\` errors out with exit 2 and red message
- [ ] End-to-end run with real keys (deferred — requires user's keys; \`pnpm smoke\` after merge will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)