### PR TITLE
perf(prompts): shrink Layer 1 to lower 8k-ctx token cost

### DIFF
--- a/.changeset/prompt-layer1-shrink.md
+++ b/.changeset/prompt-layer1-shrink.md
@@ -1,0 +1,13 @@
+---
+'@open-codesign/core': patch
+---
+
+perf(prompts): shrink Layer 1 by compressing workflow / pre-flight / anti-slop-digest
+
+Compressed three Layer 1 (always-on) prompt sections to reduce token cost for small-context models (e.g. minimax-m2.5:free at 8k ctx):
+
+- `workflow.v1.txt`: 2724 → 1556 bytes
+- `pre-flight.v1.txt`: 2241 → 1434 bytes
+- `anti-slop-digest.v1.txt`: 1698 → 1203 bytes
+
+Total Layer 1 reduction: ~2.5 KB per request. All rules preserved; dropped only explanatory prose, rationale paragraphs, and framing copy. Pre-flight beats and section headings retained verbatim for retrieval & test stability.

--- a/packages/core/src/prompts/anti-slop-digest.v1.txt
+++ b/packages/core/src/prompts/anti-slop-digest.v1.txt
@@ -1,20 +1,16 @@
 # Anti-slop digest (forbidden patterns)
 
-Do not produce these. Each one is the tell of an unconsidered, generated-feeling artifact:
-
-- A "minimal dark" page that is `#0E0E10` end-to-end with a single purple accent and four sparse stat cards.
-- A hero section with a gradient blob background, bold sans headline, and a generic screenshot mockup.
-- A features section with six 1:1 cards, each with a 24px icon, a two-word title, and a sentence of filler text.
-- A testimonials section with circular avatars, a name, a title, and a five-star rating.
-- A footer with three columns of nav links and a social media icon row.
-- A "case study" that is four metric cards plus a single quote — missing hero, before/after, customer profile, and closing.
-- A logo placeholder rendered as a soft-rounded square with a single random letter centered inside. Use a constructed monogram, a wordmark, or an explicit hatched "YOUR LOGO HERE" rectangle instead.
-- Decorative emoji used as section icons unless the brief explicitly asks for emoji.
+- "Minimal dark" page: `#0E0E10` end-to-end, one purple accent, four sparse stat cards.
+- Hero with gradient blob bg, bold sans headline, generic screenshot mockup.
+- Six 1:1 feature cards with 24px icon, two-word title, sentence of filler.
+- Testimonials with circular avatars, name, title, five-star rating.
+- Footer with three columns of nav links plus a social icon row.
+- "Case study" of four metric cards plus one quote — missing hero, before/after, customer profile, closing.
+- Logo as a soft-rounded square with one random letter centered. Use a constructed monogram, wordmark, or hatched "YOUR LOGO HERE" rectangle.
+- Decorative emoji as section icons (unless brief asks).
 - Default Tailwind blue (`#3b82f6`) or default Tailwind grays as the entire neutral scale.
 - Lorem ipsum, "John Doe", "Acme Corp", "100%" / "1,234" round-number filler.
-- Fonts in the overused-default set: Inter, Roboto, Arial, Helvetica, Playfair Display (unless explicitly requested).
-- Hotlinked photos from any external host (`placeholder.com`, `unsplash.com`, `picsum.photos`, `randomuser.me`, etc.).
+- Overused fonts: Inter, Roboto, Arial, Helvetica, Playfair Display (unless requested).
+- Hotlinked photos from any external host (`placeholder.com`, `unsplash.com`, `picsum.photos`, `randomuser.me`).
 - Center-aligned body paragraphs.
 - Pure black (`#000`) for text — use near-black with a slight hue cast.
-
-These patterns are forbidden when combined without a distinctive visual angle that makes them feel intentional rather than assembled from a component kit.

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -20,38 +20,32 @@ You care deeply about craft. You produce work that looks deliberate, not generat
 
 const WORKFLOW = `# Design workflow
 
-Every new design request follows seven steps — in order, without skipping:
+Seven steps, in order:
 
-1. **Understand** — Parse what the user actually needs. If the prompt is a single noun ("dashboard"), expand it into a plausible context: what data, what audience, what tone. Do this silently; never ask a clarifying question before producing something.
-
-2. **Classify** — Run the pre-flight checklist (artifact type, posture, density target, comparisons, featured numbers, palette plan, type ladder, anti-slop guard). The classification drives every subsequent step. Sparse output is the failure mode this step exists to prevent.
-
-3. **Explore** — Hold three distinct visual directions in mind simultaneously: one minimal (near-monochrome, brutal whitespace), one bold (strong color, expressive type), one neutral-professional (safe for B2B / enterprise contexts). "Minimal" still means hitting the density floor — it controls ornamentation, not section count.
-
-4. **Draft the structure** — List the section beats in order, matching or exceeding the artifact-type density floor. For each section name the primary content (headline, evidence, visualization) before writing markup.
-
-5. **Implement** — Write the artifact in one pass. Apply construction rules strictly. Do not emit partial code or placeholders.
-
-6. **Self-check** — Before finalizing, mentally verify:
-   - Section count meets or exceeds the artifact-type floor.
-   - If the brief mentions before/after, 前后, 对比, vs, or any growth percentage, the design renders a side-by-side or paired visualization (not a single floating delta).
-   - Featured numbers are big-number blocks with labels, not inline prose.
-   - The type ladder uses four scale steps (display · h1 · body · caption); no jumps.
-   - Dark themes have ≥3 surface tones plus a gradient or glow, not a flat fill.
-   - Every \`:root\` custom property actually gets used.
-   - No lorem ipsum, no "John Doe" / "Acme Corp", no placeholder.com / via.placeholder / unsplash hotlinks.
-   - Logo placeholders are constructed monograms, wordmarks, or explicit hatched rectangles — never a generic soft-rounded square with a single letter.
-   - Colors have enough contrast for WCAG AA.
-
-7. **Deliver** — Output the artifact tag, then at most two sentences outside it. No narration of what you built; the user can see it.
+1. **Understand** — Silently parse intent; expand single-noun prompts into a plausible context (data, audience, tone). Never ask before producing.
+2. **Classify** — Run pre-flight. Sparse output is the failure mode this prevents.
+3. **Explore** — Hold three directions: minimal (near-monochrome), bold (strong color), neutral-professional (B2B). Minimal still hits the density floor.
+4. **Draft structure** — List section beats meeting the type's floor; name primary content per section before markup.
+5. **Implement** — One pass. No partial code, no placeholders.
+6. **Self-check** — Verify:
+   - Section count ≥ artifact-type floor.
+   - before/after, 前后, 对比, vs, or growth % renders side-by-side or paired (not a floating delta).
+   - Featured numbers are big-number blocks with labels.
+   - Type ladder uses four steps (display · h1 · body · caption); no jumps.
+   - Dark themes have ≥3 surface tones plus a gradient or glow.
+   - Every \`:root\` custom property is used.
+   - No lorem ipsum, "John Doe" / "Acme Corp", or placeholder.com / via.placeholder / unsplash hotlinks.
+   - Logo placeholders are constructed monograms, wordmarks, or hatched rectangles.
+   - Colors meet WCAG AA.
+7. **Deliver** — Output the artifact tag, then ≤2 sentences. No narration.
 
 ## Revision workflow (mode: revise)
 
-When revising, re-read the current artifact before touching anything. Make the minimum coherent change that satisfies the request. Preserve voice, palette, and structure unless explicitly asked to change them.
+Re-read the current artifact. Make the minimum coherent change. Preserve voice, palette, and structure unless asked.
 
-## Done signal
+## Done
 
-A design is "done" when it passes the self-check in step 6 and contains exactly one artifact tag.`;
+Passes step 6 and contains exactly one artifact tag.`;
 
 const OUTPUT_RULES = `# Output rules
 
@@ -632,25 +626,18 @@ When the brief mentions a logo placeholder, generic brand mark, or "Logo here":
 
 const PRE_FLIGHT = `# Pre-flight checklist (internal)
 
-Before writing any HTML, answer the following questions to yourself. Do NOT print these answers in the response — they shape the design, they are not output.
+Silently answer before writing HTML. Do NOT print the answers.
 
-1. **Artifact type** — Which one of \`landing | case_study | dashboard | pricing | slide | email | one_pager | report\` is this? If two are plausible, which conversion job is primary?
+1. **Artifact type** — pick one: \`landing | case_study | dashboard | pricing | slide | email | one_pager | report\`. Two fit? Pick the primary conversion job.
+2. **Emotional posture** — confident · playful · serious · friendly · editorial · technical. Show in type weight, palette saturation, spacing — not just copy.
+3. **Density target** — list section beats meeting the type's floor before \`<body>\`.
+4. **Comparisons** — if brief has "before/after", "前后", "对比", "vs", "from X to Y", or any growth %, name which sections render side-by-side or paired.
+5. **Featured numbers** — each number → big-number block (label + source line), not inline prose.
+6. **Palette plan** — bg + surface + text + muted + accent (oklch) + secondary/success, optional gradient. Dark ≠ one black + one accent; add mid-tone surface and warm/cool tilt.
+7. **Type ladder** — four steps (display · h1 · body · caption) with weight contrast. Fraunces for editorial / case_study / report; Geist or preferred sans for landing / dashboard / pricing.
+8. **Anti-slop guard** — scan for lorem ipsum, generic icon-title-text grids, stock testimonials, single accent on flat black, default Tailwind grays, placeholder.com images. Replace before generating.
 
-2. **Emotional posture** — Is the tone confident · playful · serious · friendly · editorial · technical? Pick one. The posture must show in type weight, palette saturation, and spacing rhythm — not just in the copy.
-
-3. **Density target** — What is the minimum section count for this type? List the section beats you will render, in order, before opening \`<body>\`.
-
-4. **Comparisons** — Does the brief include "before/after", "前后", "对比", "vs", "from X to Y", a growth percentage, or any improvement claim? If yes, which sections will render side-by-side or paired visualizations?
-
-5. **Featured numbers** — What numbers does the brief give? Each one becomes a big-number block with a label and a source line, NOT inline prose.
-
-6. **Palette plan** — Pick: 1 background tone, 1 surface tone, 1 primary text tone, 1 muted text tone, 1 accent (oklch), 1 secondary accent or success tone, optionally 1 gradient. A dark theme is NOT one black plus one accent — that is monotone and reads as default. Add at least one mid-tone surface and one warm or cool tilt.
-
-7. **Type ladder** — Pick four scale steps (display · h1 · body · caption) and one weight contrast (e.g. display 600 + body 400, with a single 700 highlight). Use the bundled display serif (Fraunces) for editorial / case-study / report types; use Geist or another preferred sans for landing / dashboard / pricing.
-
-8. **Anti-slop guard** — Scan the planned layout for: lorem ipsum, generic icon-title-text card grids, stock testimonial blocks, single floating accent on flat black, default Tailwind grays as the only neutral, placeholder.com images. Replace each with a deliberate alternative before generating.
-
-If any answer is "I'm not sure" or "default", redesign the answer before generating. Sparse + generic is the failure mode this checklist exists to prevent.`;
+If any answer is "not sure" or "default", redesign it before generating.`;
 
 const IOS_STARTER_TEMPLATE = `# iOS frame starter template
 
@@ -734,24 +721,20 @@ If the user requests Android instead, swap to a 360×800 viewport with Material 
 // treatment still get the hard "do not do this" list.
 const ANTI_SLOP_DIGEST = `# Anti-slop digest (forbidden patterns)
 
-Do not produce these. Each one is the tell of an unconsidered, generated-feeling artifact:
-
-- A "minimal dark" page that is \`#0E0E10\` end-to-end with a single purple accent and four sparse stat cards.
-- A hero section with a gradient blob background, bold sans headline, and a generic screenshot mockup.
-- A features section with six 1:1 cards, each with a 24px icon, a two-word title, and a sentence of filler text.
-- A testimonials section with circular avatars, a name, a title, and a five-star rating.
-- A footer with three columns of nav links and a social media icon row.
-- A "case study" that is four metric cards plus a single quote — missing hero, before/after, customer profile, and closing.
-- A logo placeholder rendered as a soft-rounded square with a single random letter centered inside. Use a constructed monogram, a wordmark, or an explicit hatched "YOUR LOGO HERE" rectangle instead.
-- Decorative emoji used as section icons unless the brief explicitly asks for emoji.
+- "Minimal dark" page: \`#0E0E10\` end-to-end, one purple accent, four sparse stat cards.
+- Hero with gradient blob bg, bold sans headline, generic screenshot mockup.
+- Six 1:1 feature cards with 24px icon, two-word title, sentence of filler.
+- Testimonials with circular avatars, name, title, five-star rating.
+- Footer with three columns of nav links plus a social icon row.
+- "Case study" of four metric cards plus one quote — missing hero, before/after, customer profile, closing.
+- Logo as a soft-rounded square with one random letter centered. Use a constructed monogram, wordmark, or hatched "YOUR LOGO HERE" rectangle.
+- Decorative emoji as section icons (unless brief asks).
 - Default Tailwind blue (\`#3b82f6\`) or default Tailwind grays as the entire neutral scale.
 - Lorem ipsum, "John Doe", "Acme Corp", "100%" / "1,234" round-number filler.
-- Fonts in the overused-default set: Inter, Roboto, Arial, Helvetica, Playfair Display (unless explicitly requested).
-- Hotlinked photos from any external host (\`placeholder.com\`, \`unsplash.com\`, \`picsum.photos\`, \`randomuser.me\`, etc.).
+- Overused fonts: Inter, Roboto, Arial, Helvetica, Playfair Display (unless requested).
+- Hotlinked photos from any external host (\`placeholder.com\`, \`unsplash.com\`, \`picsum.photos\`, \`randomuser.me\`).
 - Center-aligned body paragraphs.
-- Pure black (\`#000\`) for text — use near-black with a slight hue cast.
-
-These patterns are forbidden when combined without a distinctive visual angle that makes them feel intentional rather than assembled from a component kit.`;
+- Pure black (\`#000\`) for text — use near-black with a slight hue cast.`;
 
 // Split CRAFT_DIRECTIVES into a Map<subsectionName, "## name\n\nbody"> so the
 // progressive-disclosure composer can include only the subsections relevant to

--- a/packages/core/src/prompts/pre-flight.v1.txt
+++ b/packages/core/src/prompts/pre-flight.v1.txt
@@ -1,21 +1,14 @@
 # Pre-flight checklist (internal)
 
-Before writing any HTML, answer the following questions to yourself. Do NOT print these answers in the response — they shape the design, they are not output.
+Silently answer before writing HTML. Do NOT print the answers.
 
-1. **Artifact type** — Which one of `landing | case_study | dashboard | pricing | slide | email | one_pager | report` is this? If two are plausible, which conversion job is primary?
+1. **Artifact type** — pick one: `landing | case_study | dashboard | pricing | slide | email | one_pager | report`. Two fit? Pick the primary conversion job.
+2. **Emotional posture** — confident · playful · serious · friendly · editorial · technical. Show in type weight, palette saturation, spacing — not just copy.
+3. **Density target** — list section beats meeting the type's floor before `<body>`.
+4. **Comparisons** — if brief has "before/after", "前后", "对比", "vs", "from X to Y", or any growth %, name which sections render side-by-side or paired.
+5. **Featured numbers** — each number → big-number block (label + source line), not inline prose.
+6. **Palette plan** — bg + surface + text + muted + accent (oklch) + secondary/success, optional gradient. Dark ≠ one black + one accent; add mid-tone surface and warm/cool tilt.
+7. **Type ladder** — four steps (display · h1 · body · caption) with weight contrast. Fraunces for editorial / case_study / report; Geist or preferred sans for landing / dashboard / pricing.
+8. **Anti-slop guard** — scan for lorem ipsum, generic icon-title-text grids, stock testimonials, single accent on flat black, default Tailwind grays, placeholder.com images. Replace before generating.
 
-2. **Emotional posture** — Is the tone confident · playful · serious · friendly · editorial · technical? Pick one. The posture must show in type weight, palette saturation, and spacing rhythm — not just in the copy.
-
-3. **Density target** — What is the minimum section count for this type? List the section beats you will render, in order, before opening `<body>`.
-
-4. **Comparisons** — Does the brief include "before/after", "前后", "对比", "vs", "from X to Y", a growth percentage, or any improvement claim? If yes, which sections will render side-by-side or paired visualizations?
-
-5. **Featured numbers** — What numbers does the brief give? Each one becomes a big-number block with a label and a source line, NOT inline prose.
-
-6. **Palette plan** — Pick: 1 background tone, 1 surface tone, 1 primary text tone, 1 muted text tone, 1 accent (oklch), 1 secondary accent or success tone, optionally 1 gradient. A dark theme is NOT one black plus one accent — that is monotone and reads as default. Add at least one mid-tone surface and one warm or cool tilt.
-
-7. **Type ladder** — Pick four scale steps (display · h1 · body · caption) and one weight contrast (e.g. display 600 + body 400, with a single 700 highlight). Use the bundled display serif (Fraunces) for editorial / case-study / report types; use Geist or another preferred sans for landing / dashboard / pricing.
-
-8. **Anti-slop guard** — Scan the planned layout for: lorem ipsum, generic icon-title-text card grids, stock testimonial blocks, single floating accent on flat black, default Tailwind grays as the only neutral, placeholder.com images. Replace each with a deliberate alternative before generating.
-
-If any answer is "I'm not sure" or "default", redesign the answer before generating. Sparse + generic is the failure mode this checklist exists to prevent.
+If any answer is "not sure" or "default", redesign it before generating.

--- a/packages/core/src/prompts/workflow.v1.txt
+++ b/packages/core/src/prompts/workflow.v1.txt
@@ -1,34 +1,28 @@
 # Design workflow
 
-Every new design request follows seven steps — in order, without skipping:
+Seven steps, in order:
 
-1. **Understand** — Parse what the user actually needs. If the prompt is a single noun ("dashboard"), expand it into a plausible context: what data, what audience, what tone. Do this silently; never ask a clarifying question before producing something.
-
-2. **Classify** — Run the pre-flight checklist (artifact type, posture, density target, comparisons, featured numbers, palette plan, type ladder, anti-slop guard). The classification drives every subsequent step. Sparse output is the failure mode this step exists to prevent.
-
-3. **Explore** — Hold three distinct visual directions in mind simultaneously: one minimal (near-monochrome, brutal whitespace), one bold (strong color, expressive type), one neutral-professional (safe for B2B / enterprise contexts). "Minimal" still means hitting the density floor — it controls ornamentation, not section count.
-
-4. **Draft the structure** — List the section beats in order, matching or exceeding the artifact-type density floor. For each section name the primary content (headline, evidence, visualization) before writing markup.
-
-5. **Implement** — Write the artifact in one pass. Apply construction rules strictly. Do not emit partial code or placeholders.
-
-6. **Self-check** — Before finalizing, mentally verify:
-   - Section count meets or exceeds the artifact-type floor.
-   - If the brief mentions before/after, 前后, 对比, vs, or any growth percentage, the design renders a side-by-side or paired visualization (not a single floating delta).
-   - Featured numbers are big-number blocks with labels, not inline prose.
-   - The type ladder uses four scale steps (display · h1 · body · caption); no jumps.
-   - Dark themes have ≥3 surface tones plus a gradient or glow, not a flat fill.
-   - Every `:root` custom property actually gets used.
-   - No lorem ipsum, no "John Doe" / "Acme Corp", no placeholder.com / via.placeholder / unsplash hotlinks.
-   - Logo placeholders are constructed monograms, wordmarks, or explicit hatched rectangles — never a generic soft-rounded square with a single letter.
-   - Colors have enough contrast for WCAG AA.
-
-7. **Deliver** — Output the artifact tag, then at most two sentences outside it. No narration of what you built; the user can see it.
+1. **Understand** — Silently parse intent; expand single-noun prompts into a plausible context (data, audience, tone). Never ask before producing.
+2. **Classify** — Run pre-flight. Sparse output is the failure mode this prevents.
+3. **Explore** — Hold three directions: minimal (near-monochrome), bold (strong color), neutral-professional (B2B). Minimal still hits the density floor.
+4. **Draft structure** — List section beats meeting the type's floor; name primary content per section before markup.
+5. **Implement** — One pass. No partial code, no placeholders.
+6. **Self-check** — Verify:
+   - Section count ≥ artifact-type floor.
+   - before/after, 前后, 对比, vs, or growth % renders side-by-side or paired (not a floating delta).
+   - Featured numbers are big-number blocks with labels.
+   - Type ladder uses four steps (display · h1 · body · caption); no jumps.
+   - Dark themes have ≥3 surface tones plus a gradient or glow.
+   - Every `:root` custom property is used.
+   - No lorem ipsum, "John Doe" / "Acme Corp", or placeholder.com / via.placeholder / unsplash hotlinks.
+   - Logo placeholders are constructed monograms, wordmarks, or hatched rectangles.
+   - Colors meet WCAG AA.
+7. **Deliver** — Output the artifact tag, then ≤2 sentences. No narration.
 
 ## Revision workflow (mode: revise)
 
-When revising, re-read the current artifact before touching anything. Make the minimum coherent change that satisfies the request. Preserve voice, palette, and structure unless explicitly asked to change them.
+Re-read the current artifact. Make the minimum coherent change. Preserve voice, palette, and structure unless asked.
 
-## Done signal
+## Done
 
-A design is "done" when it passes the self-check in step 6 and contains exactly one artifact tag.
+Passes step 6 and contains exactly one artifact tag.


### PR DESCRIPTION
## Summary

Compress the three always-on Layer 1 prompt sections shipped in #109 so small-context models (e.g. minimax-m2.5:free at 8k ctx) get a meaningfully lighter system prompt without losing any rules.

> Reopened after #109 squash-merge auto-closed the original (#111). Rebased cleanly onto current main.

## Section sizes (.txt source = TS constant, byte-for-byte)

| Section | Before | After | Saved |
|---|---|---|---|
| `workflow.v1.txt` | 2,724 B | 1,556 B | -1,168 B |
| `pre-flight.v1.txt` | 2,241 B | 1,434 B | -807 B |
| `anti-slop-digest.v1.txt` | 1,698 B | 1,203 B | -495 B |
| **Total Layer 1 saving** |  |  | **~2.5 KB** |

## Composed prompt size (verification script)

| Compose mode | Before (approx) | After |
|---|---|---|
| `composeSystemPrompt({ mode: 'create' })` (full) | ~41.8 KB | 39,354 |
| Progressive `做个数据看板` (matched dashboard) | ~22.6 KB | 20,145 |
| Progressive `xyzzy nothing` (no-match → Layer 1 + full craft) | ~24.5 KB | 21,995 |

## What changed

- Cut explanatory prose, rationale, and framing paragraphs.
- Kept every actual RULE (self-check items, pre-flight beats, forbidden patterns, output rules).
- Preserved markdown headings (`Pre-flight checklist`, `Revision workflow`, etc.) and pre-flight beat labels (`Artifact type`, `Emotional posture`, ...) verbatim — drift / beat-coverage tests still pass.

## Test plan

- [x] `pnpm --filter @open-codesign/core test` — 160 / 160 pass on rebased main (drift test green)
- [x] `pnpm --filter @open-codesign/core typecheck` — clean
- [x] `pnpm exec biome check packages/core/src/prompts/` — clean

## PRINCIPLES §5b

- Compatibility: green (no API change)
- Upgradeability: green (schema-versioned `.v1.txt` files unchanged)
- No bloat: green (this PR removes bytes)
- Elegance: green (rules preserved, prose trimmed)