### PR TITLE
feat(providers): Ollama builtin + editable custom providers

### DIFF
--- a/.changeset/wacky-spoons-hang.md
+++ b/.changeset/wacky-spoons-hang.md
@@ -1,0 +1,12 @@
+---
+'@open-codesign/desktop': minor
+'@open-codesign/shared': minor
+'@open-codesign/providers': patch
+---
+
+feat(providers): first-class Ollama support + editable custom providers
+
+- Ollama joins the builtin provider set. `requiresApiKey: false` on the schema lets any provider — builtin or custom — opt out of API keys; `isKeylessProviderAllowed` now honors it. `extractModelIds` accepts the `{name}` shape used by Ollama's `/api/tags` endpoint as a fallback.
+- New `ollama:v1:probe` IPC does a 2s liveness check against `http://localhost:11434/api/tags`, so the UI can distinguish "running", "not installed", and "unreachable" states without racing the 10s models-list timeout.
+- Custom and builtin providers now have an `Edit` action. `AddCustomProviderModal` accepts an `editTarget` prop that pre-fills every field and routes save through `updateProvider` (rotates the stored secret only when the user actually types a new one — leaving it blank keeps the current mask). Builtin rows lock `baseUrl`/`wire` so users can't accidentally repoint `anthropic` at an unrelated host; only the API key and default model are editable.
+- `config:v1:update-provider` gained an optional `apiKey` field with tri-state semantics (omit = keep, empty string = clear, non-empty = rotate). Runs against missing-entry builtins too, seeding from `BUILTIN_PROVIDERS` so edits work on fresh installs.

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -17,6 +17,7 @@ import {
   fetchWithTimeout,
   getCacheKey,
   normalizeBaseUrl,
+  normalizeOllamaBaseUrl,
 } from './connection-ipc';
 
 // ---------------------------------------------------------------------------
@@ -794,5 +795,48 @@ describe('Claude Code identity header injection', () => {
 
     const oa = buildAuthHeaders('openai', '', 'https://keyless.example.com');
     expect(oa['authorization']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeOllamaBaseUrl — input sanitization for ollama:v1:probe
+// ---------------------------------------------------------------------------
+
+describe('normalizeOllamaBaseUrl', () => {
+  it('returns the default localhost URL when input is empty or whitespace', () => {
+    expect(normalizeOllamaBaseUrl('')).toBe('http://localhost:11434');
+    expect(normalizeOllamaBaseUrl('   ')).toBe('http://localhost:11434');
+  });
+
+  it('auto-prefixes http:// when scheme is missing', () => {
+    expect(normalizeOllamaBaseUrl('localhost:11434')).toBe('http://localhost:11434');
+    expect(normalizeOllamaBaseUrl('192.168.1.10:11434')).toBe('http://192.168.1.10:11434');
+    // IPv6 users still get a usable URL — fetch handles bracketed hosts.
+    expect(normalizeOllamaBaseUrl('[::1]:11434')).toBe('http://[::1]:11434');
+  });
+
+  it('preserves an explicit https:// scheme', () => {
+    expect(normalizeOllamaBaseUrl('https://ollama.example.com')).toBe('https://ollama.example.com');
+  });
+
+  it('strips a trailing /v1 suffix so /api/tags lives at the root', () => {
+    expect(normalizeOllamaBaseUrl('http://localhost:11434/v1')).toBe('http://localhost:11434');
+    expect(normalizeOllamaBaseUrl('http://localhost:11434/v1/')).toBe('http://localhost:11434');
+  });
+
+  it('throws IPC_BAD_INPUT on non-http(s) schemes (no silent localhost fallback)', () => {
+    // `file://` has an explicit scheme and reaches the protocol check.
+    expect(() => normalizeOllamaBaseUrl('file:///etc/passwd')).toThrow(/must use http/);
+    expect(() => normalizeOllamaBaseUrl('ftp://example.com')).toThrow(/must use http/);
+    // `javascript:alert(1)` doesn't match `scheme://`, so it falls into the
+    // auto-prefix path. `http://javascript:alert(1)` fails URL parsing —
+    // we just require that it's rejected, not which branch rejects it.
+    expect(() => normalizeOllamaBaseUrl('javascript:alert(1)')).toThrow();
+  });
+
+  it('throws IPC_BAD_INPUT on malformed URLs', () => {
+    // The scheme-coercion path prepends `http://`, so truly malformed inputs
+    // like "http://" with an empty host still reach URL() and reject there.
+    expect(() => normalizeOllamaBaseUrl('http://')).toThrow(/not a valid URL/);
   });
 });

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -219,6 +219,21 @@ describe('extractIds', () => {
   it('returns null when an id is a number instead of a string', () => {
     expect(extractIds([{ id: 'a' }, { id: 123 }])).toBeNull();
   });
+
+  // Ollama's /api/tags returns `{ models: [{ name: "llama3.2:latest" }] }`
+  // instead of OpenAI/Anthropic's `id` field. Without this fallback, a user
+  // who points a custom provider at `http://localhost:11434` (no /v1 suffix)
+  // would silently get a PARSE error from the model list endpoint.
+  it('accepts items with a `name` field for Ollama /api/tags shape', () => {
+    expect(extractIds([{ name: 'llama3.2:latest' }, { name: 'qwen2.5' }])).toEqual([
+      'llama3.2:latest',
+      'qwen2.5',
+    ]);
+  });
+
+  it('prefers `id` over `name` when both are present', () => {
+    expect(extractIds([{ id: 'official-id', name: 'display-name' }])).toEqual(['official-id']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -297,6 +297,15 @@ const modelsCache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 export function getCacheKey(provider: string, baseUrl: string, apiKey: string): string {
+  // SHA-256 here is a cache-key discriminator, not a password hash — the
+  // Map lives in-process with a 5-minute TTL, never persists, and never
+  // leaves the main process. Using bcrypt/scrypt (as CodeQL's default
+  // rule suggests) would make every cache lookup take hundreds of ms
+  // and defeat the purpose of caching. Hashing apiKey (rather than
+  // embedding it verbatim in the Map key) is defense-in-depth so plaintext
+  // keys don't end up in memory-dump strings a third-party crash reporter
+  // might pick up.
+  // codeql[js/insufficient-password-hash]
   const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16);
   return `${provider}::${baseUrl}::${keyHash}`;
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -249,10 +249,13 @@ export function extractIds(items: unknown[]): string[] | null {
   for (const item of items) {
     if (item && typeof item === 'object') {
       const rec = item as { id?: unknown; name?: unknown };
-      // OpenAI/Anthropic use `id`; Ollama's /api/tags uses `name` (e.g.
-      // "llama3.2:latest"). Accept either so a user who points the custom
-      // provider at http://localhost:11434 (no /v1 suffix) still gets a
-      // model list instead of a PARSE error.
+      // OpenAI/Anthropic/OpenRouter all return a canonical `id` string; we
+      // prefer it unconditionally. The `name` fallback exists solely for
+      // Ollama's /api/tags shape (`{models: [{ name: "llama3.2:latest" }]}`)
+      // which has no `id` field. No known API-key provider returns objects
+      // with `name` but no `id`, so this fallback never silently misroutes
+      // for existing providers — but a future provider that ships display
+      // names without ids would also land here.
       if (typeof rec.id === 'string') {
         ids.push(rec.id);
         continue;
@@ -781,12 +784,30 @@ export type OllamaProbeResponse =
   | { ok: false; code: string; message: string };
 
 function parseOllamaProbePayload(raw: unknown): string {
-  if (raw === undefined || raw === null) return 'http://localhost:11434';
-  if (typeof raw === 'string' && raw.trim().length > 0) {
-    // Strip any /v1 suffix — /api/tags lives at the root.
-    return raw.trim().replace(/\/v1\/?$/, '');
+  const DEFAULT_BASE_URL = 'http://localhost:11434';
+  if (typeof raw !== 'string') return DEFAULT_BASE_URL;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return DEFAULT_BASE_URL;
+  // Auto-prefix scheme so users who paste "localhost:11434" or "[::1]:11434"
+  // don't get a confusing "not running" probe failure. `fetch` requires a
+  // full URL — a missing scheme is a far more common user typo than a real
+  // security-sensitive input.
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  // Reject anything that isn't http(s) — covers file://, ftp://, javascript:,
+  // and accidental paste of an Anthropic key prefix. We deliberately do NOT
+  // restrict to loopback because some users run Ollama on a LAN box; the
+  // threat model is the same as config:v1:test-endpoint (renderer is trusted,
+  // main-process fetch is the intended egress path for BYOK).
+  try {
+    const parsed = new URL(withScheme);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return DEFAULT_BASE_URL;
+    }
+  } catch {
+    return DEFAULT_BASE_URL;
   }
-  return 'http://localhost:11434';
+  // Strip any /v1 suffix — /api/tags lives at the root.
+  return withScheme.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 interface TestEndpointPayload {

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -749,7 +749,19 @@ export function registerConnectionIpc(): void {
   // disabled the OpenAI-compat server. Short 2s timeout because the user is
   // staring at a spinner in the onboarding flow.
   ipcMain.handle('ollama:v1:probe', async (_e, raw: unknown): Promise<OllamaProbeResponse> => {
-    const baseUrl = parseOllamaProbePayload(raw);
+    let baseUrl: string;
+    try {
+      baseUrl = parseOllamaProbePayload(raw);
+    } catch (err) {
+      // Surface invalid URL / unsupported scheme as an explicit IPC error
+      // instead of silently coercing back to localhost — the renderer needs
+      // to see the mistake to let the user fix their typed baseUrl.
+      return {
+        ok: false,
+        code: 'IPC_BAD_INPUT',
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
     const url = `${baseUrl.replace(/\/+$/, '')}/api/tags`;
     let res: Response;
     try {
@@ -784,28 +796,55 @@ export type OllamaProbeResponse =
   | { ok: false; code: string; message: string };
 
 function parseOllamaProbePayload(raw: unknown): string {
+  return normalizeOllamaBaseUrl(typeof raw === 'string' ? raw : '');
+}
+
+/**
+ * Exported for unit tests. Turns whatever string the renderer sent into the
+ * base URL for the /api/tags probe. Returns the default `http://localhost:11434`
+ * ONLY when the input is empty — any other garbage (malformed URL,
+ * `file://`, `javascript:` etc.) throws a `CodesignError` so the IPC handler
+ * can surface the mistake instead of silently probing localhost.
+ */
+export function normalizeOllamaBaseUrl(raw: string): string {
   const DEFAULT_BASE_URL = 'http://localhost:11434';
-  if (typeof raw !== 'string') return DEFAULT_BASE_URL;
   const trimmed = raw.trim();
   if (trimmed.length === 0) return DEFAULT_BASE_URL;
-  // Auto-prefix scheme so users who paste "localhost:11434" or "[::1]:11434"
-  // don't get a confusing "not running" probe failure. `fetch` requires a
-  // full URL — a missing scheme is a far more common user typo than a real
-  // security-sensitive input.
-  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
-  // Reject anything that isn't http(s) — covers file://, ftp://, javascript:,
-  // and accidental paste of an Anthropic key prefix. We deliberately do NOT
-  // restrict to loopback because some users run Ollama on a LAN box; the
-  // threat model is the same as config:v1:test-endpoint (renderer is trusted,
-  // main-process fetch is the intended egress path for BYOK).
+
+  // Treat the input as "already has a scheme" only if it starts with a
+  // recognizable `scheme://` prefix. That lets us reject `file://` /
+  // `ftp://` without also misclassifying `localhost:11434` (which the
+  // plain `URL()` constructor parses as scheme="localhost:" because of
+  // the host:port shape). `javascript:alert(1)` and similar scheme-only
+  // tricks fail the `://` gate and instead get `http://` prepended, which
+  // then fails URL parsing in the second pass and is rejected below.
+  const hasScheme = /^[a-z][a-z0-9+.\-]*:\/\//i.test(trimmed);
+  const withScheme = hasScheme ? trimmed : `http://${trimmed}`;
+
+  let parsed: URL;
   try {
-    const parsed = new URL(withScheme);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return DEFAULT_BASE_URL;
-    }
+    parsed = new URL(withScheme);
   } catch {
-    return DEFAULT_BASE_URL;
+    throw new CodesignError(
+      `Ollama baseUrl "${trimmed}" is not a valid URL`,
+      ERROR_CODES.IPC_BAD_INPUT,
+    );
   }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new CodesignError(
+      `Ollama baseUrl must use http(s), got "${parsed.protocol}"`,
+      ERROR_CODES.IPC_BAD_INPUT,
+    );
+  }
+  if (parsed.hostname.length === 0) {
+    throw new CodesignError(
+      `Ollama baseUrl "${trimmed}" is not a valid URL`,
+      ERROR_CODES.IPC_BAD_INPUT,
+    );
+  }
+  // We deliberately do NOT restrict to loopback because some users run
+  // Ollama on a LAN box; the threat model matches config:v1:test-endpoint
+  // (renderer is trusted, main-process fetch is the intended egress path).
   // Strip any /v1 suffix — /api/tags lives at the root.
   return withScheme.replace(/\/+$/, '').replace(/\/v1$/, '');
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -764,7 +764,14 @@ export function registerConnectionIpc(): void {
     } catch {
       return { ok: false, code: 'PARSE', message: 'Non-JSON response' };
     }
-    const models = extractModelIds(body) ?? [];
+    const models = extractModelIds(body);
+    if (models === null) {
+      // Don't silently pretend Ollama is up with zero models — that would
+      // push the UI into an "available but empty" state that's actually a
+      // parser bug. Surface PARSE so the renderer can flag the probe as
+      // broken rather than rendering an empty model picker.
+      return { ok: false, code: 'PARSE', message: 'Unexpected /api/tags shape' };
+    }
     return { ok: true, models };
   });
 }

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -72,15 +72,22 @@ function parseConnectionTestPayload(raw: unknown): ConnectionTestPayloadV1 {
       ERROR_CODES.IPC_BAD_INPUT,
     );
   }
-  if (typeof r['apiKey'] !== 'string' || r['apiKey'].trim().length === 0) {
+  if (typeof r['apiKey'] !== 'string') {
+    throw new CodesignError('apiKey must be a string', ERROR_CODES.IPC_BAD_INPUT);
+  }
+  // Keyless builtins (Ollama) legitimately send an empty apiKey from the
+  // onboarding form. Non-keyless providers still require a non-empty key.
+  const provider = r['provider'] as SupportedOnboardingProvider;
+  const apiKey = r['apiKey'].trim();
+  if (apiKey.length === 0 && BUILTIN_PROVIDERS[provider].requiresApiKey !== false) {
     throw new CodesignError('apiKey must be a non-empty string', ERROR_CODES.IPC_BAD_INPUT);
   }
   if (typeof r['baseUrl'] !== 'string' || r['baseUrl'].trim().length === 0) {
     throw new CodesignError('baseUrl must be a non-empty string', ERROR_CODES.IPC_BAD_INPUT);
   }
   return {
-    provider: r['provider'],
-    apiKey: r['apiKey'].trim(),
+    provider,
+    apiKey,
     baseUrl: r['baseUrl'].trim(),
   };
 }
@@ -96,15 +103,20 @@ function parseModelsListPayload(raw: unknown): ModelsListPayloadV1 {
       ERROR_CODES.IPC_BAD_INPUT,
     );
   }
-  if (typeof r['apiKey'] !== 'string' || r['apiKey'].trim().length === 0) {
+  if (typeof r['apiKey'] !== 'string') {
+    throw new CodesignError('apiKey must be a string', ERROR_CODES.IPC_BAD_INPUT);
+  }
+  const provider = r['provider'] as SupportedOnboardingProvider;
+  const apiKey = r['apiKey'].trim();
+  if (apiKey.length === 0 && BUILTIN_PROVIDERS[provider].requiresApiKey !== false) {
     throw new CodesignError('apiKey must be a non-empty string', ERROR_CODES.IPC_BAD_INPUT);
   }
   if (typeof r['baseUrl'] !== 'string' || r['baseUrl'].trim().length === 0) {
     throw new CodesignError('baseUrl must be a non-empty string', ERROR_CODES.IPC_BAD_INPUT);
   }
   return {
-    provider: r['provider'],
-    apiKey: r['apiKey'].trim(),
+    provider,
+    apiKey,
     baseUrl: r['baseUrl'].trim(),
   };
 }
@@ -235,12 +247,22 @@ export async function fetchWithTimeout(
 export function extractIds(items: unknown[]): string[] | null {
   const ids: string[] = [];
   for (const item of items) {
-    if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
-      ids.push((item as { id: string }).id);
-    } else {
-      // Any item missing a string id field means the shape is unexpected — reject entirely.
-      return null;
+    if (item && typeof item === 'object') {
+      const rec = item as { id?: unknown; name?: unknown };
+      // OpenAI/Anthropic use `id`; Ollama's /api/tags uses `name` (e.g.
+      // "llama3.2:latest"). Accept either so a user who points the custom
+      // provider at http://localhost:11434 (no /v1 suffix) still gets a
+      // model list instead of a PARSE error.
+      if (typeof rec.id === 'string') {
+        ids.push(rec.id);
+        continue;
+      }
+      if (typeof rec.name === 'string') {
+        ids.push(rec.name);
+        continue;
+      }
     }
+    return null;
   }
   return ids;
 }
@@ -717,6 +739,47 @@ export function registerConnectionIpc(): void {
       return { ok: true, modelCount: ids?.length ?? 0, models: ids ?? [] };
     },
   );
+
+  // ── Ollama probe — used by onboarding to show "detected/not running" ─────
+  // We intentionally don't reuse the /v1/models endpoint because /api/tags is
+  // Ollama's canonical liveness probe, returns faster, and survives users who
+  // disabled the OpenAI-compat server. Short 2s timeout because the user is
+  // staring at a spinner in the onboarding flow.
+  ipcMain.handle('ollama:v1:probe', async (_e, raw: unknown): Promise<OllamaProbeResponse> => {
+    const baseUrl = parseOllamaProbePayload(raw);
+    const url = `${baseUrl.replace(/\/+$/, '')}/api/tags`;
+    let res: Response;
+    try {
+      res = await fetchWithTimeout(url, { method: 'GET' }, 2000);
+    } catch (err) {
+      const { code } = classifyNetworkError(err);
+      return { ok: false, code, message: err instanceof Error ? err.message : String(err) };
+    }
+    if (!res.ok) {
+      return { ok: false, code: 'HTTP', message: `HTTP ${res.status}` };
+    }
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return { ok: false, code: 'PARSE', message: 'Non-JSON response' };
+    }
+    const models = extractModelIds(body) ?? [];
+    return { ok: true, models };
+  });
+}
+
+export type OllamaProbeResponse =
+  | { ok: true; models: string[] }
+  | { ok: false; code: string; message: string };
+
+function parseOllamaProbePayload(raw: unknown): string {
+  if (raw === undefined || raw === null) return 'http://localhost:11434';
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    // Strip any /v1 suffix — /api/tags lives at the root.
+    return raw.trim().replace(/\/v1\/?$/, '');
+  }
+  return 'http://localhost:11434';
 }
 
 interface TestEndpointPayload {

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -643,6 +643,10 @@ interface UpdateProviderInput {
   queryParams?: Record<string, string>;
   wire?: WireApi;
   reasoningLevel?: ReasoningLevel | null;
+  /** When present AND non-empty, re-encrypt and replace the stored secret.
+   *  Empty string means "clear stored secret" for providers that became
+   *  keyless (e.g. switched to local Ollama). `undefined` means "leave alone". */
+  apiKey?: string;
 }
 
 function parseUpdateProviderPayload(raw: unknown): UpdateProviderInput {
@@ -694,6 +698,7 @@ function parseUpdateProviderPayload(raw: unknown): UpdateProviderInput {
     const parsed = ReasoningLevelSchema.safeParse(r['reasoningLevel']);
     if (parsed.success) out.reasoningLevel = parsed.data;
   }
+  if (typeof r['apiKey'] === 'string') out.apiKey = r['apiKey'];
   return out;
 }
 
@@ -702,7 +707,12 @@ async function runUpdateProvider(input: UpdateProviderInput): Promise<Onboarding
   if (cfg === null) {
     throw new CodesignError('No configuration found', ERROR_CODES.CONFIG_MISSING);
   }
-  const existing = cfg.providers[input.id];
+  // Builtin providers may not have an entry on disk yet on a fresh install
+  // (the providers map is seeded lazily). Fall back to BUILTIN_PROVIDERS so
+  // "change my Ollama baseUrl" works before the user ever opened onboarding.
+  const existing =
+    cfg.providers[input.id] ??
+    (isSupportedOnboardingProvider(input.id) ? { ...BUILTIN_PROVIDERS[input.id] } : undefined);
   if (existing === undefined) {
     throw new CodesignError(`Provider "${input.id}" not found`, ERROR_CODES.IPC_BAD_INPUT);
   }
@@ -724,11 +734,24 @@ async function runUpdateProvider(input: UpdateProviderInput): Promise<Onboarding
   } else if (input.reasoningLevel !== undefined) {
     updated.reasoningLevel = input.reasoningLevel;
   }
+  // Secret rotation: only touch secrets when the caller explicitly supplied
+  // an apiKey field. Empty string clears the secret (keyless providers);
+  // a non-empty value re-encrypts under the current safeStorage session key.
+  let nextSecrets = cfg.secrets;
+  if (input.apiKey !== undefined) {
+    const trimmed = input.apiKey.trim();
+    if (trimmed.length === 0) {
+      const { [input.id]: _removed, ...rest } = cfg.secrets;
+      nextSecrets = rest;
+    } else {
+      nextSecrets = { ...cfg.secrets, [input.id]: buildSecretRef(trimmed) };
+    }
+  }
   const next = hydrateConfig({
     version: 3,
     activeProvider: cfg.activeProvider,
     activeModel: cfg.activeModel,
-    secrets: cfg.secrets,
+    secrets: nextSecrets,
     providers: { ...cfg.providers, [input.id]: updated },
     ...(cfg.designSystem !== undefined ? { designSystem: cfg.designSystem } : {}),
   });

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -4,6 +4,7 @@ import {
   assertProviderHasStoredSecret,
   computeDeleteProviderResult,
   getAddProviderDefaults,
+  isKeylessProviderAllowed,
   resolveActiveModel,
   toProviderRows,
 } from './provider-settings';
@@ -166,6 +167,45 @@ describe('assertProviderHasStoredSecret', () => {
     });
 
     expect(() => assertProviderHasStoredSecret(cfg, 'codex-custom')).toThrow(CodesignError);
+  });
+});
+
+describe('isKeylessProviderAllowed', () => {
+  it('allows any provider whose entry declares requiresApiKey: false (e.g. Ollama)', () => {
+    const entry = {
+      id: 'ollama',
+      name: 'Ollama',
+      builtin: true,
+      wire: 'openai-chat',
+      baseUrl: 'http://localhost:11434/v1',
+      defaultModel: 'llama3.2',
+      requiresApiKey: false,
+    } as const;
+    expect(isKeylessProviderAllowed('ollama', entry)).toBe(true);
+  });
+
+  it('allows codex-family providers without an envKey (legacy contract)', () => {
+    const entry = {
+      id: 'codex-oss',
+      name: 'Codex (imported)',
+      builtin: false,
+      wire: 'openai-chat',
+      baseUrl: 'https://proxy.example.com/v1',
+      defaultModel: 'gpt-5-codex',
+    } as const;
+    expect(isKeylessProviderAllowed('codex-oss', entry)).toBe(true);
+  });
+
+  it('rejects generic custom providers that never opted out of API keys', () => {
+    const entry = {
+      id: 'custom-foo',
+      name: 'Foo',
+      builtin: false,
+      wire: 'openai-chat',
+      baseUrl: 'https://foo.example.com/v1',
+      defaultModel: 'foo-large',
+    } as const;
+    expect(isKeylessProviderAllowed('custom-foo', entry)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/provider-settings.ts
+++ b/apps/desktop/src/main/provider-settings.ts
@@ -7,6 +7,7 @@ import {
   PROVIDER_SHORTLIST,
   type ProviderEntry,
   type ReasoningLevel,
+  SUPPORTED_ONBOARDING_PROVIDERS,
   type WireApi,
   isSupportedOnboardingProvider,
 } from '@open-codesign/shared';
@@ -64,6 +65,10 @@ export function assertProviderHasStoredSecret(cfg: Config, provider: string): vo
 }
 
 export function isKeylessProviderAllowed(provider: string, entry?: ProviderEntry | null): boolean {
+  // Providers that explicitly opt out of API keys (e.g. local Ollama, a
+  // self-hosted LiteLLM fronting IP-whitelisted models). The flag lets any
+  // provider — builtin or custom — declare keyless-ness at config time.
+  if (entry?.requiresApiKey === false) return true;
   const isCodexFamily = provider.startsWith('codex-') || provider === 'chatgpt-codex';
   return isCodexFamily && entry?.requiresApiKey !== true && entry?.envKey === undefined;
 }
@@ -90,6 +95,16 @@ export function toProviderRows(
     ...Object.keys(cfg.providers ?? {}),
     ...Object.keys(cfg.secrets ?? {}),
   ]);
+  // Keyless builtins (e.g. Ollama) always surface as rows so users can
+  // discover + enable them without going through onboarding first. Without
+  // this, a fresh v3 install would hide Ollama entirely — the providers
+  // map gets populated lazily during onboarding, but Ollama has no
+  // onboarding step to run.
+  for (const builtinId of SUPPORTED_ONBOARDING_PROVIDERS) {
+    if (BUILTIN_PROVIDERS[builtinId].requiresApiKey === false) {
+      allIds.add(builtinId);
+    }
+  }
   for (const provider of allIds) {
     const ref = cfg.secrets?.[provider];
     const entry = resolveEntryFor(cfg, provider);

--- a/apps/desktop/src/main/provider-settings.ts
+++ b/apps/desktop/src/main/provider-settings.ts
@@ -18,7 +18,12 @@ export interface ProviderRow {
   maskedKey: string;
   baseUrl: string | null;
   isActive: boolean;
+  /** Human-readable display label. For codex-imported rows this is the
+   *  UI alias "Codex (imported)", not the stored entry name. */
   label: string;
+  /** Actual stored provider name — the value that round-trips through
+   *  updateProvider. Differs from `label` for codex rows. */
+  name: string;
   builtin: boolean;
   wire: WireApi;
   defaultModel: string;
@@ -141,6 +146,10 @@ export function toProviderRows(
       baseUrl: entry?.baseUrl ?? null,
       isActive: cfg.activeProvider === provider,
       label,
+      // The real stored name (or the builtin default) — used by the edit
+      // modal so a codex-imported row doesn't overwrite `entry.name` with
+      // the display alias "Codex (imported)" on save.
+      name: entry?.name ?? label,
       builtin: entry?.builtin ?? isSupportedOnboardingProvider(provider),
       wire: entry?.wire ?? 'openai-chat',
       defaultModel:

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -58,6 +58,9 @@ export interface ProviderRow {
   baseUrl: string | null;
   isActive: boolean;
   label: string;
+  /** Stored entry name — differs from `label` for codex-imported rows
+   *  where `label` is the localized alias "Codex (imported)". */
+  name: string;
   builtin: boolean;
   wire: WireApi;
   defaultModel: string;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -328,6 +328,9 @@ const api = {
       /** `null` explicitly clears the override and falls back to the model
        *  default; a level string sets it; omit to leave untouched. */
       reasoningLevel?: ReasoningLevel | null;
+      /** Non-empty string rotates the stored secret; empty string clears it
+       *  (keyless providers); omit to leave the existing secret untouched. */
+      apiKey?: string;
     }) => ipcRenderer.invoke('config:v1:update-provider', input) as Promise<OnboardingState>,
     removeProvider: (id: string) =>
       ipcRenderer.invoke('config:v1:remove-provider', id) as Promise<OnboardingState>,
@@ -391,6 +394,12 @@ const api = {
     }) => ipcRenderer.invoke('models:v1:list', input) as Promise<ModelsListResponse>,
     listForProvider: (providerId: string) =>
       ipcRenderer.invoke('models:v1:list-for-provider', providerId) as Promise<ModelsListResponse>,
+  },
+  ollama: {
+    probe: (baseUrl?: string) =>
+      ipcRenderer.invoke('ollama:v1:probe', baseUrl) as Promise<
+        { ok: true; models: string[] } | { ok: false; code: string; message: string }
+      >,
   },
   snapshots: {
     listDesigns: () =>

--- a/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
@@ -20,6 +20,26 @@ interface Props {
     wire?: WireApi;
     defaultModel?: string;
   };
+  /**
+   * Edit-mode: pre-fill every field from an existing provider and save via
+   * `updateProvider` (keeps id stable, rotates secret only when user types
+   * a new key). When undefined, falls back to create-mode.
+   */
+  editTarget?: {
+    id: string;
+    name: string;
+    baseUrl: string;
+    wire: WireApi;
+    defaultModel: string;
+    builtin: boolean;
+    /** When true, lock baseUrl/wire so users can't accidentally break a
+     *  builtin. Builtins still allow API key + defaultModel edits. */
+    lockEndpoint: boolean;
+    /** Display mask of existing key (e.g. "sk-ant-***xyz9") — shown as
+     *  placeholder so user knows there's a stored key, and an empty submit
+     *  doesn't wipe it. */
+    keyMask?: string;
+  };
 }
 
 type TestState =
@@ -38,16 +58,23 @@ export function AddCustomProviderModal({
   onClose,
   initialSetAsActive = true,
   initialValues,
+  editTarget,
 }: Props) {
   const t = useT();
-  const [name, setName] = useState(initialValues?.name ?? '');
-  const [baseUrl, setBaseUrl] = useState(initialValues?.baseUrl ?? '');
+  const isEdit = editTarget !== undefined;
+  const lockEndpoint = editTarget?.lockEndpoint === true;
+  const [name, setName] = useState(editTarget?.name ?? initialValues?.name ?? '');
+  const [baseUrl, setBaseUrl] = useState(editTarget?.baseUrl ?? initialValues?.baseUrl ?? '');
   const [apiKey, setApiKey] = useState('');
-  const [defaultModel, setDefaultModel] = useState(initialValues?.defaultModel ?? '');
-  const [wire, setWire] = useState<WireApi>(initialValues?.wire ?? 'openai-chat');
-  // If the caller pre-specified a wire, they know what they want — don't
-  // overwrite it when the user edits baseUrl.
-  const [wireAuto, setWireAuto] = useState(initialValues?.wire === undefined);
+  const [defaultModel, setDefaultModel] = useState(
+    editTarget?.defaultModel ?? initialValues?.defaultModel ?? '',
+  );
+  const [wire, setWire] = useState<WireApi>(
+    editTarget?.wire ?? initialValues?.wire ?? 'openai-chat',
+  );
+  // In edit mode we trust the stored wire; in create mode we only auto-detect
+  // if the caller didn't pin one.
+  const [wireAuto, setWireAuto] = useState(!isEdit && initialValues?.wire === undefined);
   const [test, setTest] = useState<TestState>({ kind: 'idle' });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,21 +112,39 @@ export function AddCustomProviderModal({
     setSaving(true);
     setError(null);
     try {
-      const slug = slugify(name);
-      const id = `custom-${slug}-${Date.now().toString(36).slice(-4)}`;
-      // Canonicalize before persisting so pi-ai / Anthropic SDK always see
-      // the root they expect. Without this, a user pasting /v1/chat/completions
-      // would have it stored verbatim and then pi-ai would append another
-      // /chat/completions at inference time.
-      await window.codesign.config.addProvider({
-        id,
-        name: name.trim() || id,
-        wire,
-        baseUrl: canonicalBaseUrl(baseUrl.trim(), wire),
-        apiKey: apiKey.trim(),
-        defaultModel: defaultModel.trim(),
-        setAsActive: initialSetAsActive,
-      });
+      if (isEdit && editTarget !== undefined) {
+        // Edit mode: reuse id, rotate secret only when user typed something.
+        // Omitting `apiKey` leaves the stored secret untouched — matching the
+        // "leave empty to keep current key" UX hinted at by the mask placeholder.
+        const update: Parameters<NonNullable<typeof window.codesign.config.updateProvider>>[0] = {
+          id: editTarget.id,
+        };
+        if (name.trim() !== editTarget.name) update.name = name.trim() || editTarget.id;
+        if (defaultModel.trim() !== editTarget.defaultModel) {
+          update.defaultModel = defaultModel.trim();
+        }
+        if (!lockEndpoint) {
+          if (baseUrl.trim() !== editTarget.baseUrl) {
+            update.baseUrl = canonicalBaseUrl(baseUrl.trim(), wire);
+          }
+          if (wire !== editTarget.wire) update.wire = wire;
+        }
+        const typedKey = apiKey.trim();
+        if (typedKey.length > 0) update.apiKey = typedKey;
+        await window.codesign.config.updateProvider(update);
+      } else {
+        const slug = slugify(name);
+        const id = `custom-${slug}-${Date.now().toString(36).slice(-4)}`;
+        await window.codesign.config.addProvider({
+          id,
+          name: name.trim() || id,
+          wire,
+          baseUrl: canonicalBaseUrl(baseUrl.trim(), wire),
+          apiKey: apiKey.trim(),
+          defaultModel: defaultModel.trim(),
+          setAsActive: initialSetAsActive,
+        });
+      }
       onSave();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -109,13 +154,25 @@ export function AddCustomProviderModal({
   }
 
   const canTest = baseUrl.trim().length > 0 && test.kind !== 'testing';
-  const canSave = canTest && defaultModel.trim().length > 0 && name.trim().length > 0 && !saving;
+  const canSave = (() => {
+    if (saving) return false;
+    if (isEdit) {
+      // In edit mode, require at least the mandatory fields still hold values
+      // — but don't require the user to re-enter the API key.
+      return baseUrl.trim().length > 0 && defaultModel.trim().length > 0 && name.trim().length > 0;
+    }
+    return canTest && defaultModel.trim().length > 0 && name.trim().length > 0;
+  })();
+
+  const title = isEdit
+    ? t('settings.providers.custom.editTitle')
+    : t('settings.providers.custom.title');
 
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={t('settings.providers.custom.title')}
+      aria-label={title}
       className="fixed inset-0 z-[60] flex items-center justify-center p-6 bg-[var(--color-overlay)]"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
@@ -128,7 +185,7 @@ export function AddCustomProviderModal({
       >
         <div className="flex items-center justify-between">
           <h2 className="text-[var(--text-base)] font-semibold text-[var(--color-text-primary)]">
-            {t('settings.providers.custom.title')}
+            {title}
           </h2>
           <button
             type="button"
@@ -140,31 +197,38 @@ export function AddCustomProviderModal({
           </button>
         </div>
 
-        <Field label={t('settings.providers.custom.wire')}>
-          <div className="flex gap-3 flex-wrap">
-            {(['openai-chat', 'openai-responses', 'anthropic'] as const).map((w) => (
-              <label
-                key={w}
-                className="inline-flex items-center gap-1.5 text-[var(--text-xs)] cursor-pointer"
-              >
-                <input
-                  type="radio"
-                  name="wire"
-                  value={w}
-                  checked={wire === w}
-                  onChange={() => handleWireChange(w)}
-                  className="accent-[var(--color-accent)]"
-                />
-                <span className="text-[var(--color-text-secondary)]">
-                  {t(`settings.providers.custom.wires.${w}`)}
-                </span>
-              </label>
-            ))}
-          </div>
-        </Field>
+        {!lockEndpoint && (
+          <Field label={t('settings.providers.custom.wire')}>
+            <div className="flex gap-3 flex-wrap">
+              {(['openai-chat', 'openai-responses', 'anthropic'] as const).map((w) => (
+                <label
+                  key={w}
+                  className="inline-flex items-center gap-1.5 text-[var(--text-xs)] cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="wire"
+                    value={w}
+                    checked={wire === w}
+                    onChange={() => handleWireChange(w)}
+                    className="accent-[var(--color-accent)]"
+                  />
+                  <span className="text-[var(--color-text-secondary)]">
+                    {t(`settings.providers.custom.wires.${w}`)}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </Field>
+        )}
 
         <Field label={t('settings.providers.custom.name')}>
-          <TextInput value={name} onChange={setName} placeholder="My Provider" />
+          <TextInput
+            value={name}
+            onChange={setName}
+            placeholder="My Provider"
+            disabled={lockEndpoint}
+          />
         </Field>
 
         <Field label={t('settings.providers.custom.baseUrl')}>
@@ -172,11 +236,23 @@ export function AddCustomProviderModal({
             value={baseUrl}
             onChange={handleBaseUrlChange}
             placeholder="https://api.example.com/v1"
+            disabled={lockEndpoint}
           />
         </Field>
 
         <Field label={t('settings.providers.custom.apiKey')}>
-          <TextInput value={apiKey} onChange={setApiKey} type="password" placeholder="sk-..." />
+          <TextInput
+            value={apiKey}
+            onChange={setApiKey}
+            type="password"
+            placeholder={
+              isEdit && editTarget?.keyMask !== undefined && editTarget.keyMask.length > 0
+                ? t('settings.providers.custom.apiKeyEditPlaceholder', {
+                    mask: editTarget.keyMask,
+                  })
+                : 'sk-...'
+            }
+          />
         </Field>
 
         <Field label={t('settings.providers.custom.defaultModel')}>
@@ -220,7 +296,7 @@ export function AddCustomProviderModal({
             {t('common.cancel')}
           </Button>
           <Button size="sm" onClick={handleSave} disabled={!canSave}>
-            {t('settings.providers.custom.save')}
+            {isEdit ? t('settings.providers.custom.saveEdit') : t('settings.providers.custom.save')}
           </Button>
         </div>
       </div>
@@ -244,11 +320,13 @@ function TextInput({
   onChange,
   placeholder,
   type,
+  disabled,
 }: {
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
   type?: string;
+  disabled?: boolean;
 }) {
   return (
     <input
@@ -256,7 +334,8 @@ function TextInput({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+      disabled={disabled === true}
+      className="w-full h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:opacity-60 disabled:cursor-not-allowed"
     />
   );
 }

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1146,7 +1146,7 @@ function ModelsTab() {
           onClose={() => setEditingRow(null)}
           editTarget={{
             id: editingRow.provider,
-            name: editingRow.label,
+            name: editingRow.name,
             baseUrl: editingRow.baseUrl ?? '',
             wire: editingRow.wire,
             defaultModel: editingRow.defaultModel,

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
   MoreHorizontal,
   Palette,
+  Pencil,
   Plus,
   RotateCcw,
   Sliders,
@@ -147,15 +148,16 @@ function NativeSelect({
 // ─── Models tab ──────────────────────────────────────────────────────────────
 
 function ProviderOverflowMenu({
-  isActive,
   hasError,
   onTestConnection,
+  onEdit,
   onDelete,
   label,
 }: {
   isActive: boolean;
   hasError: boolean;
   onTestConnection: () => void;
+  onEdit: () => void;
   onDelete: () => void;
   label: string;
 }) {
@@ -215,6 +217,18 @@ function ProviderOverflowMenu({
               {t('settings.providers.testConnection')}
             </button>
           )}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              close();
+              onEdit();
+            }}
+            className={itemClass}
+          >
+            <Pencil className="w-3.5 h-3.5" />
+            {t('settings.providers.edit')}
+          </button>
           {confirmDelete ? (
             <div className="px-2.5 py-1.5 flex items-center gap-1.5">
               <button
@@ -258,12 +272,14 @@ function ProviderCard({
   config,
   onDelete,
   onActivate,
+  onEdit,
   onRowChanged,
 }: {
   row: ProviderRow;
   config: OnboardingState | null;
   onDelete: (p: string) => void;
   onActivate: (p: string) => void;
+  onEdit: (row: ProviderRow) => void;
   onRowChanged: (row: ProviderRow) => void;
 }) {
   const t = useT();
@@ -354,6 +370,7 @@ function ProviderCard({
             isActive={row.isActive}
             hasError={hasError}
             onTestConnection={handleTestConnection}
+            onEdit={() => onEdit(row)}
             onDelete={() => onDelete(row.provider)}
             label={label}
           />
@@ -829,6 +846,14 @@ function ModelsTab() {
       }
     | undefined
   >(undefined);
+  /** Open AddCustomProviderModal in edit-mode against this row. Works for
+   *  both builtin and custom providers; builtins get their endpoint fields
+   *  locked so users can't accidentally break them. */
+  const [editingRow, setEditingRow] = useState<ProviderRow | null>(null);
+
+  function handleEdit(row: ProviderRow) {
+    setEditingRow(row);
+  }
 
   useEffect(() => {
     if (!window.codesign) return;
@@ -1111,6 +1136,28 @@ function ModelsTab() {
         />
       )}
 
+      {editingRow !== null && (
+        <AddCustomProviderModal
+          onSave={async () => {
+            setEditingRow(null);
+            await reloadRows();
+            pushToast({ variant: 'success', title: t('settings.providers.toast.saved') });
+          }}
+          onClose={() => setEditingRow(null)}
+          editTarget={{
+            id: editingRow.provider,
+            name: editingRow.label,
+            baseUrl: editingRow.baseUrl ?? '',
+            wire: editingRow.wire,
+            defaultModel: editingRow.defaultModel,
+            builtin: editingRow.builtin,
+            lockEndpoint: editingRow.builtin,
+            ...(editingRow.maskedKey.length > 0 ? { keyMask: editingRow.maskedKey } : {}),
+          }}
+          initialSetAsActive={false}
+        />
+      )}
+
       <div className="space-y-[var(--space-3)]">
         <ChatgptLoginCard onStatusChange={reloadRows} />
         {externalConfigs !== null &&
@@ -1339,6 +1386,7 @@ function ModelsTab() {
                 config={config}
                 onDelete={handleDelete}
                 onActivate={handleActivate}
+                onEdit={handleEdit}
                 onRowChanged={(next) =>
                   setRows((prev) => prev.map((r) => (r.provider === next.provider ? next : r)))
                 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -179,6 +179,7 @@
       "reEnterKey": "Re-enter key",
       "confirm": "Confirm",
       "delete": "Delete",
+      "edit": "Edit",
       "testConnection": "Test connection",
       "moreActions": "More actions",
       "editModel": "Change model",
@@ -187,6 +188,7 @@
       "fast": "Fast",
       "custom": {
         "title": "Add custom endpoint",
+        "editTitle": "Edit provider",
         "wire": "Wire protocol",
         "wires": {
           "openai-chat": "OpenAI Chat",
@@ -196,10 +198,12 @@
         "name": "Label",
         "baseUrl": "Base URL",
         "apiKey": "API Key",
+        "apiKeyEditPlaceholder": "Leave empty to keep {{mask}}",
         "defaultModel": "Default model",
         "test": "Test connection",
         "testOk": "OK — {{count}} models available",
-        "save": "Save & continue"
+        "save": "Save & continue",
+        "saveEdit": "Save changes"
       },
       "import": {
         "action": "Import",
@@ -386,8 +390,13 @@
       "tryFreeSubtitle": "OpenRouter free tier - paste an OpenRouter key, then start with openrouter/free or type any model ID.",
       "useKey": "Use my API key",
       "useKeySubtitle": "Anthropic, OpenAI, or OpenRouter. Auto-detected from the key prefix.",
-      "useOllama": "Use local model (Ollama detected)",
-      "useOllamaSubtitle": "Coming in v0.2 - Ollama integration is on the roadmap.",
+      "useOllama": "Use local model (Ollama)",
+      "useOllamaSubtitle": "Runs 100% locally with zero API cost. Needs Ollama installed and running.",
+      "useOllamaDetected": "Ollama detected — {{count}} models available locally.",
+      "useOllamaNotRunning": "Ollama not detected at localhost:11434. Install or start it, then retry.",
+      "useOllamaProbing": "Checking for a local Ollama instance...",
+      "useOllamaRetry": "Retry probe",
+      "useOllamaInstall": "Install Ollama ↗",
       "whereToGetKey": "Where to get a key"
     },
     "paste": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -182,6 +182,7 @@
       "addKey": "添加 Key",
       "confirm": "确认",
       "delete": "删除",
+      "edit": "编辑",
       "testConnection": "测试连接",
       "moreActions": "更多操作",
       "editModel": "更改模型",
@@ -190,6 +191,7 @@
       "fast": "快速",
       "custom": {
         "title": "添加自定义接入点",
+        "editTitle": "编辑接入点",
         "wire": "协议类型",
         "wires": {
           "openai-chat": "OpenAI Chat",
@@ -199,10 +201,12 @@
         "name": "名称",
         "baseUrl": "接入地址",
         "apiKey": "API Key",
+        "apiKeyEditPlaceholder": "留空则保留 {{mask}}",
         "defaultModel": "默认模型",
         "test": "测试连接",
         "testOk": "正常 — 共 {{count}} 个模型",
-        "save": "保存并继续"
+        "save": "保存并继续",
+        "saveEdit": "保存修改"
       },
       "import": {
         "action": "导入",
@@ -389,8 +393,13 @@
       "tryFreeSubtitle": "使用 OpenRouter 免费额度 — 粘贴一个 OpenRouter Key，然后选 openrouter/free 或输入任意模型 ID。",
       "useKey": "使用我的 API Key",
       "useKeySubtitle": "支持 Anthropic、OpenAI 或 OpenRouter，自动识别 Key 前缀。",
-      "useOllama": "使用本地模型（已检测到 Ollama）",
-      "useOllamaSubtitle": "将在 v0.2 中推出 — Ollama 集成已列入路线图。",
+      "useOllama": "使用本地模型（Ollama）",
+      "useOllamaSubtitle": "完全本地运行，零 API 费用。需要已安装并启动 Ollama。",
+      "useOllamaDetected": "已检测到 Ollama — 本地共 {{count}} 个模型可用。",
+      "useOllamaNotRunning": "未在 localhost:11434 检测到 Ollama，请先安装或启动后重试。",
+      "useOllamaProbing": "正在检测本地 Ollama 实例…",
+      "useOllamaRetry": "重新检测",
+      "useOllamaInstall": "安装 Ollama ↗",
       "whereToGetKey": "在哪里获取 Key"
     },
     "paste": {

--- a/packages/providers/src/validate.test.ts
+++ b/packages/providers/src/validate.test.ts
@@ -21,6 +21,23 @@ describe('pingProvider', () => {
     await expect(pingProvider('anthropic', '')).rejects.toBeInstanceOf(CodesignError);
   });
 
+  // Keyless builtins (local Ollama) explicitly opt out of API keys via
+  // `requiresApiKey: false`. The empty-key guard must recognize that flag —
+  // otherwise Ollama onboarding/validation fails before ever hitting the
+  // network (bot review on PR #135).
+  it('does not throw when key is empty for a keyless builtin (ollama)', async () => {
+    mockFetch(async (url) => {
+      expect(url).toBe('http://localhost:11434/v1/models');
+      return new Response(JSON.stringify({ data: [{ id: 'llama3.2' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const res = await pingProvider('ollama', '');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.modelCount).toBe(1);
+  });
+
   it('returns ok with model count for Anthropic 200', async () => {
     mockFetch(async (url, init) => {
       expect(url).toBe('https://api.anthropic.com/v1/models');

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -56,6 +56,16 @@ function endpoint(provider: SupportedOnboardingProvider, baseUrl?: string): Prov
         headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
       };
     }
+    case 'ollama': {
+      // Local Ollama — OpenAI-compat endpoint at /v1. No auth header; the
+      // caller (renderer) may still pass a non-empty apiKey as a sentinel
+      // that we harmlessly drop here.
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'http://localhost:11434';
+      return {
+        url: `${root}/v1/models`,
+        headers: () => ({}),
+      };
+    }
   }
 }
 

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -1,4 +1,5 @@
 import {
+  BUILTIN_PROVIDERS,
   CodesignError,
   ERROR_CODES,
   type SupportedOnboardingProvider,
@@ -96,11 +97,16 @@ export async function pingProvider(
 ): Promise<ValidateResult> {
   if (!isSupportedOnboardingProvider(provider)) {
     throw new CodesignError(
-      `Provider "${provider}" is not supported in v0.1. Supported: anthropic, openai, openrouter.`,
+      `Provider "${provider}" is not supported in v0.1. Supported: anthropic, openai, openrouter, ollama.`,
       ERROR_CODES.PROVIDER_NOT_SUPPORTED,
     );
   }
-  if (!apiKey || apiKey.trim().length === 0) {
+  // Keyless builtins (local Ollama) legitimately validate with an empty key;
+  // all other providers must have one. Keeping the empty-check means a
+  // user who forgets to paste their Anthropic/OpenAI key still gets a fast
+  // PROVIDER_AUTH_MISSING instead of a confusing 401 from the network.
+  const isKeyless = BUILTIN_PROVIDERS[provider].requiresApiKey === false;
+  if (!isKeyless && (!apiKey || apiKey.trim().length === 0)) {
     throw new CodesignError('API key is empty', ERROR_CODES.PROVIDER_AUTH_MISSING);
   }
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -16,8 +16,18 @@ const ProviderIdEnum = z.enum([
   'vercel-ai-gateway',
 ]);
 
-export const SUPPORTED_ONBOARDING_PROVIDERS = ['anthropic', 'openai', 'openrouter'] as const;
+export const SUPPORTED_ONBOARDING_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'openrouter',
+  'ollama',
+] as const;
 export type SupportedOnboardingProvider = (typeof SUPPORTED_ONBOARDING_PROVIDERS)[number];
+
+/** Default Ollama local endpoint. Users override via Settings if they run
+ *  Ollama on a different host/port. */
+export const OLLAMA_DEFAULT_BASE_URL = 'http://localhost:11434/v1';
+export const OLLAMA_DEFAULT_MODEL = 'llama3.2';
 
 // ── Wire types (v3) ──────────────────────────────────────────────────────────
 
@@ -124,6 +134,15 @@ export const BUILTIN_PROVIDERS: Readonly<Record<SupportedOnboardingProvider, Pro
     wire: 'openai-chat',
     baseUrl: 'https://openrouter.ai/api/v1',
     defaultModel: 'anthropic/claude-sonnet-4.6',
+  },
+  ollama: {
+    id: 'ollama',
+    name: 'Ollama (local)',
+    builtin: true,
+    wire: 'openai-chat',
+    baseUrl: OLLAMA_DEFAULT_BASE_URL,
+    defaultModel: OLLAMA_DEFAULT_MODEL,
+    requiresApiKey: false,
   },
 } as const;
 
@@ -308,6 +327,13 @@ export const PROVIDER_SHORTLIST: Record<SupportedOnboardingProvider, ProviderSho
     keyHelpUrl: 'https://openrouter.ai/keys',
     primary: ['anthropic/claude-sonnet-4.6', 'openai/gpt-4o'],
     defaultPrimary: 'anthropic/claude-sonnet-4.6',
+  },
+  ollama: {
+    provider: 'ollama',
+    label: 'Ollama (local)',
+    keyHelpUrl: 'https://ollama.com/download',
+    primary: [OLLAMA_DEFAULT_MODEL, 'llama3.1', 'qwen2.5'],
+    defaultPrimary: OLLAMA_DEFAULT_MODEL,
   },
 };
 


### PR DESCRIPTION
## Summary

- **Ollama as a builtin provider.** `requiresApiKey: false` on `ProviderEntry` lets any provider (builtin or custom) declare itself keyless; `isKeylessProviderAllowed` now honors it. `extractModelIds` falls back to the `{name}` shape so Ollama's `/api/tags` parses cleanly even when the user pastes the raw `localhost:11434` baseUrl. New \`ollama:v1:probe\` IPC does a 2s liveness check so the renderer can distinguish \"running\" / \"not installed\" / \"unreachable\" without racing the 10s /models timeout.
- **Custom + builtin providers gain an Edit action.** `AddCustomProviderModal` now accepts an `editTarget` prop that pre-fills every field and routes save through `updateProvider`. Secret rotation is tri-state: omit the `apiKey` field to keep the current key, empty string to clear, non-empty to rotate. Builtin rows open the same editor but with `baseUrl`/`wire` locked — users can still update the API key and default model without deleting+re-adding.
- Addresses the 0.1.3 gap where a stale key or moved endpoint meant nuking the provider entry and redoing everything.

## Notable tradeoffs

- `toProviderRows` always surfaces keyless builtins (Ollama) even without a `cfg.providers` entry, so fresh v3 installs see the Ollama card immediately. Keys that require onboarding (Anthropic/OpenAI/OpenRouter) still only appear after the user imports them.
- `updateProvider` falls back to `BUILTIN_PROVIDERS[id]` when an entry is missing — needed so builtin edits work on brand-new configs.
- No user-visible onboarding flow change beyond the Ollama card. The welcome-screen probe-and-retry UX will land in a follow-up alongside the "Ollama not running" detection copy (i18n keys already in place).

## Test plan

- [x] `pnpm typecheck` green (all 10 packages)
- [x] `pnpm lint` clean
- [x] `pnpm test` → 602 desktop + 147 shared, all pass (5 new cases covering Ollama `/api/tags` parsing + `requiresApiKey: false` keyless path)
- [ ] Manual: Settings → custom provider → pencil → edit label/baseUrl/model → save reloads row
- [ ] Manual: Settings → builtin Anthropic → pencil → only API key + default model editable, baseUrl greyed out
- [ ] Manual: Settings shows Ollama row out-of-the-box with no config; `ollama:v1:probe` returns `{ok:true,models:[...]}` when Ollama is running; handles refused gracefully when it isn't

## Compatibility, upgradeability, no bloat, elegance

- **Compatibility** ✅ — additive schema field (`requiresApiKey`), no migration required; `migrateLegacyToV3` picks up Ollama via the existing `SUPPORTED_ONBOARDING_PROVIDERS` loop.
- **Upgradeability** ✅ — `updateProvider`'s new `apiKey` field is optional and tri-state; old callers unchanged.
- **No bloat** ✅ — reuses `AddCustomProviderModal` for both create and edit flows (no sibling component); ~420 net added lines across 13 files.
- **Elegance** ✅ — keyless is one boolean; edit is one prop; Ollama slots into the existing provider registry instead of getting a bespoke code path.