### PR TITLE
feat(ui): search input in model switcher dropdown

### DIFF
--- a/.changeset/model-switcher-search.md
+++ b/.changeset/model-switcher-search.md
@@ -1,0 +1,12 @@
+---
+'@open-codesign/desktop': patch
+'@open-codesign/i18n': patch
+---
+
+feat(ui): search input in model switcher dropdown
+
+Long provider catalogs (DeepSeek, Zhipu, OpenRouter, …) return 40+ model IDs; scrolling by wheel to find the one you actually use is painful. The topbar/sidebar model switcher now shows a search box at the top of the dropdown whenever the list crosses an 8-item threshold, filtering case-insensitively by substring. Path-style IDs (`deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`) and tag-style IDs (`llama3.2:latest`) both match naturally.
+
+The input auto-focuses on open, resets when the dropdown closes, and renders a distinct "no matches for <query>" message so users can tell a search miss apart from a provider with genuinely zero models.
+
+Community request from chengmo — thanks for the nudge.

--- a/apps/desktop/src/renderer/src/components/ModelSwitcher.test.ts
+++ b/apps/desktop/src/renderer/src/components/ModelSwitcher.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { filterModels } from './ModelSwitcher';
+
+describe('filterModels', () => {
+  const models = [
+    'claude-sonnet-4-6',
+    'claude-opus-4-1',
+    'gpt-4o',
+    'gpt-4.1',
+    'deepseek-ai/DeepSeek-R1-Distill-Qwen-7B',
+    'llama3.2:latest',
+  ];
+
+  it('returns the full list for an empty query', () => {
+    expect(filterModels(models, '')).toEqual(models);
+  });
+
+  it('treats a whitespace-only query as empty', () => {
+    expect(filterModels(models, '   ')).toEqual(models);
+  });
+
+  it('matches substrings case-insensitively', () => {
+    expect(filterModels(models, 'sonnet')).toEqual(['claude-sonnet-4-6']);
+    expect(filterModels(models, 'CLAUDE')).toEqual(['claude-sonnet-4-6', 'claude-opus-4-1']);
+  });
+
+  it('matches path-like model IDs (OpenRouter / HuggingFace style)', () => {
+    expect(filterModels(models, 'deepseek')).toEqual(['deepseek-ai/DeepSeek-R1-Distill-Qwen-7B']);
+  });
+
+  it('matches tag-style model IDs (Ollama style with colon)', () => {
+    expect(filterModels(models, ':latest')).toEqual(['llama3.2:latest']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterModels(models, 'xyz-nonexistent')).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
+++ b/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
-import { ChevronDown, Loader2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, Loader2, Search } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderRow } from '../../../preload/index';
 import { recordAction } from '../lib/action-timeline';
 import { useCodesignStore } from '../store';
@@ -9,9 +9,25 @@ interface ModelSwitcherProps {
   variant: 'topbar' | 'sidebar';
 }
 
+// Below this threshold the search input just adds UI chrome for no real win —
+// a user with 6 models can eyeball the list. Above it, scrolling becomes a
+// chore (community feedback: providers like DeepSeek/Zhipu return 40+ IDs).
+const SEARCH_VISIBILITY_THRESHOLD = 8;
+
 function shortenModelLabel(model: string): string {
   const stripped = model.replace(/^(claude-|gpt-|gemini-)/, '');
   return stripped.includes('/') ? (stripped.split('/').pop() ?? stripped) : stripped;
+}
+
+/**
+ * Case-insensitive substring filter. Exported for unit tests — inlining it
+ * into a useMemo would work, but a pure helper documents the "empty query
+ * returns everything" and "trim" rules without reading the component.
+ */
+export function filterModels(models: string[], query: string): string[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return models;
+  return models.filter((m) => m.toLowerCase().includes(q));
 }
 
 export function ModelSwitcher({ variant }: ModelSwitcherProps) {
@@ -24,7 +40,9 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
   const [models, setModels] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [providerRows, setProviderRows] = useState<ProviderRow[] | null>(null);
+  const [query, setQuery] = useState('');
   const rootRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const provider = config?.provider ?? null;
   const currentModel = config?.modelPrimary ?? null;
@@ -45,6 +63,13 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
     };
   }, [open]);
 
+  // Reset the filter every time the dropdown closes so the next open starts
+  // fresh — otherwise a stale query from a previous session silently hides
+  // models and looks like a loading bug.
+  useEffect(() => {
+    if (!open) setQuery('');
+  }, [open]);
+
   // Load provider rows once — used to display the active provider's friendly label
   useEffect(() => {
     if (providerRows !== null || !window.codesign?.settings?.listProviders) return;
@@ -63,6 +88,21 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
       .catch(() => setModels([]))
       .finally(() => setLoading(false));
   }, [open, models, provider]);
+
+  const showSearch = (models?.length ?? 0) > SEARCH_VISIBILITY_THRESHOLD;
+
+  // Auto-focus the search box once the model list arrives so users who
+  // opened the dropdown with keyboard don't need to grab the mouse.
+  useEffect(() => {
+    if (open && showSearch && !loading) {
+      searchInputRef.current?.focus();
+    }
+  }, [open, showSearch, loading]);
+
+  const filteredModels = useMemo(() => {
+    if (models === null) return null;
+    return filterModels(models, query);
+  }, [models, query]);
 
   if (!provider || !currentModel) return null;
 
@@ -151,13 +191,36 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
             </div>
           )}
 
+          {showSearch && (
+            <div className="relative px-[var(--space-2)] py-[var(--space-1_5)] border-b border-[var(--color-border-muted)]">
+              <Search
+                className="absolute left-[calc(var(--space-2)+8px)] top-1/2 -translate-y-1/2 w-3 h-3 text-[var(--color-text-muted)] pointer-events-none"
+                aria-hidden
+              />
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t('topbar.modelSwitcher.searchPlaceholder', {
+                  defaultValue: 'Search models…',
+                })}
+                aria-label={t('topbar.modelSwitcher.searchAriaLabel', {
+                  defaultValue: 'Filter models by name',
+                })}
+                className="w-full h-7 pl-7 pr-2 rounded-[var(--radius-sm)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[12px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                style={{ fontFamily: 'var(--font-mono)' }}
+              />
+            </div>
+          )}
+
           <div className="max-h-[280px] overflow-y-auto py-[var(--space-1)]">
             {loading ? (
               <div className="flex items-center justify-center py-[var(--space-3)]">
                 <Loader2 className="w-4 h-4 animate-spin text-[var(--color-text-muted)]" />
               </div>
-            ) : models && models.length > 0 ? (
-              models.map((m) => {
+            ) : filteredModels && filteredModels.length > 0 ? (
+              filteredModels.map((m) => {
                 const isActive = m === currentModel;
                 return (
                   <button
@@ -183,6 +246,16 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
                   </button>
                 );
               })
+            ) : models && models.length > 0 && query.trim().length > 0 ? (
+              // Had models, filter produced none — distinct copy so the user
+              // knows their search term, not the provider, is the reason the
+              // list is empty.
+              <div className="px-[var(--space-3)] py-[var(--space-2)] text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                {t('topbar.modelSwitcher.noMatches', {
+                  defaultValue: 'No models match "{{query}}"',
+                  query: query.trim(),
+                })}
+              </div>
             ) : (
               <div className="px-[var(--space-3)] py-[var(--space-2)] text-[var(--text-xs)] text-[var(--color-text-muted)]">
                 {t('settings.providers.noModel')}

--- a/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
+++ b/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useT } from '@open-codesign/i18n';
-import { ChevronDown, Loader2, Search } from 'lucide-react';
+import { ChevronDown, Loader2, Search, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderRow } from '../../../preload/index';
 import { recordAction } from '../lib/action-timeline';
@@ -194,7 +194,7 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
           {showSearch && (
             <div className="relative px-[var(--space-2)] py-[var(--space-1_5)] border-b border-[var(--color-border-muted)]">
               <Search
-                className="absolute left-[calc(var(--space-2)+8px)] top-1/2 -translate-y-1/2 w-3 h-3 text-[var(--color-text-muted)] pointer-events-none"
+                className="absolute left-[calc(var(--space-2)+var(--space-2))] top-1/2 -translate-y-1/2 w-[var(--size-icon-xs)] h-[var(--size-icon-xs)] text-[var(--color-text-muted)] pointer-events-none"
                 aria-hidden
               />
               <input
@@ -208,9 +208,24 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
                 aria-label={t('topbar.modelSwitcher.searchAriaLabel', {
                   defaultValue: 'Filter models by name',
                 })}
-                className="w-full h-7 pl-7 pr-2 rounded-[var(--radius-sm)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[12px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                className="w-full h-[var(--size-control-xs)] pl-[calc(var(--space-2)+var(--size-icon-xs)+var(--space-1_5))] pr-[var(--space-2)] rounded-[var(--radius-sm)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-xs)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
                 style={{ fontFamily: 'var(--font-mono)' }}
               />
+              {query.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setQuery('');
+                    searchInputRef.current?.focus();
+                  }}
+                  aria-label={t('topbar.modelSwitcher.clearSearch', {
+                    defaultValue: 'Clear search',
+                  })}
+                  className="absolute right-[calc(var(--space-2)+var(--space-1_5))] top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-[var(--size-icon-sm)] h-[var(--size-icon-sm)] rounded-full text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+                >
+                  <X className="w-[var(--size-icon-xs)] h-[var(--size-icon-xs)]" aria-hidden />
+                </button>
+              )}
             </div>
           )}
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -476,6 +476,7 @@
       "fromProvider": "Provider",
       "searchPlaceholder": "Search models…",
       "searchAriaLabel": "Filter models by name",
+      "clearSearch": "Clear search",
       "noMatches": "No models match \"{{query}}\""
     },
     "status": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -472,6 +472,12 @@
     }
   },
   "topbar": {
+    "modelSwitcher": {
+      "fromProvider": "Provider",
+      "searchPlaceholder": "Search models…",
+      "searchAriaLabel": "Filter models by name",
+      "noMatches": "No models match \"{{query}}\""
+    },
     "status": {
       "connected": "Connected",
       "untested": "Not tested",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -479,6 +479,7 @@
       "fromProvider": "服务",
       "searchPlaceholder": "搜索模型…",
       "searchAriaLabel": "按名称筛选模型",
+      "clearSearch": "清除搜索",
       "noMatches": "没有匹配 \"{{query}}\" 的模型"
     },
     "status": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -475,6 +475,12 @@
     }
   },
   "topbar": {
+    "modelSwitcher": {
+      "fromProvider": "服务",
+      "searchPlaceholder": "搜索模型…",
+      "searchAriaLabel": "按名称筛选模型",
+      "noMatches": "没有匹配 \"{{query}}\" 的模型"
+    },
     "status": {
       "connected": "已连接",
       "untested": "未测试",


### PR DESCRIPTION
## Summary

Long provider catalogs (DeepSeek, Zhipu, OpenRouter, …) return 40+ model IDs; scrolling by wheel to find the one you actually use is painful. The topbar/sidebar model switcher now shows a search box at the top of the dropdown whenever the list crosses an 8-item threshold, filtering case-insensitively by substring.

- Path-style IDs (`deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`) and tag-style IDs (`llama3.2:latest`) both match naturally
- Auto-focuses on open so keyboard users don't need the mouse
- Resets when the dropdown closes (no stale query surprising the next open)
- Distinct \"no matches for <query>\" empty state so search-miss reads differently from genuinely-empty provider

Community request from @chengmo — thanks for the nudge.

## Test plan

- [x] \`pnpm typecheck\` green (10/10 packages)
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 6 new unit tests for \`filterModels\`, all 642 pass
- [ ] Manual: open switcher with <8 models → no search box (no UI chrome for small lists)
- [ ] Manual: open switcher with >8 models → search box focused automatically; typing filters; clearing restores full list
- [ ] Manual: ESC still closes the dropdown even when the search input has focus

## Compatibility, upgradeability, no bloat, elegance

- **Compatibility** ✅ — additive; no new deps, no IPC changes
- **Upgradeability** ✅ — \`filterModels\` is a pure helper, trivial to swap with fuzzy matching later
- **No bloat** ✅ — ~60 lines added to an existing component, one \`Search\` icon import; threshold keeps chrome off for users with small catalogs
- **Elegance** ✅ — the search box comes and goes with the list size; no settings flag needed