### PR TITLE
fix(core): retry first-turn agent generation on transient errors (#125)

### DIFF
--- a/.changeset/agent-first-turn-retry.md
+++ b/.changeset/agent-first-turn-retry.md
@@ -1,0 +1,6 @@
+---
+"@open-codesign/core": patch
+"@open-codesign/providers": patch
+---
+
+Fix: retry first-turn agent generation on transient provider errors (5xx, 429, network). The agent runtime now wraps `agent.prompt()` + `waitForIdle()` in a backoff loop for the first turn only — multi-turn requests still fail fast to avoid corrupting mid-session tool state. Extracted a generic `withBackoff` helper in `@open-codesign/providers` that shares the existing classify/jitter/Retry-After/abort logic with `completeWithRetry`. (#125)

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -38,6 +38,12 @@ interface AgentScript {
   errorMessage?: string;
   promptThrows?: Error;
   /**
+   * When > 0, `promptThrows` is thrown only on the first N prompt() calls;
+   * subsequent calls resolve normally. Lets tests script "transient failure
+   * then success" sequences for first-turn retry coverage.
+   */
+  promptThrowsTimes?: number;
+  /**
    * When set, the mock invokes `options.getApiKey` before emitting the
    * assistant response and — if it throws — converts the throw into an
    * 'error' AgentMessage (matching pi-agent-core's `handleRunFailure`
@@ -64,7 +70,10 @@ vi.mock('@mariozechner/pi-agent-core', () => {
     }
     async prompt(message: unknown): Promise<void> {
       this.call.prompts.push({ message });
-      if (scriptedAgent.promptThrows) throw scriptedAgent.promptThrows;
+      if (scriptedAgent.promptThrows) {
+        const limit = scriptedAgent.promptThrowsTimes ?? Number.POSITIVE_INFINITY;
+        if (this.call.prompts.length <= limit) throw scriptedAgent.promptThrows;
+      }
 
       // Simulate pi-agent-core's per-turn getApiKey invocation. Real
       // runAgentLoop calls `await config.getApiKey(provider)` (line 156 of
@@ -406,9 +415,14 @@ describe('generateViaAgent() — Phase 1 pass-through', () => {
       signal: controller.signal,
     });
     controller.abort();
-    // Mock's prompt() is synchronous enough to complete; just verify the wire-up
-    // registered by confirming the Agent.abort() call counter after settlement.
-    await promise;
+    // With first-turn withBackoff the pre-call signal check may short-circuit
+    // the prompt entirely (throwing PROVIDER_ABORTED), or the prompt may have
+    // already completed; either way the `signal → agent.abort()` listener
+    // registered before sending should have fired.
+    await promise.catch(() => {
+      // Expected when abort arrives before the withBackoff loop enters its
+      // first iteration.
+    });
     expect(agentCalls[0]?.aborted).toBe(true);
   });
 
@@ -471,6 +485,109 @@ describe('generateViaAgent() — Phase 1 pass-through', () => {
     const sys = agentCalls[0]?.options.initialState?.systemPrompt as string;
     expect(sys).toContain('str_replace_based_edit_tool');
     expect(sys).toContain('Do NOT emit `<artifact>`');
+  });
+});
+
+describe('generateViaAgent() — first-turn retry', () => {
+  class HttpError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+      this.name = 'HttpError';
+    }
+  }
+
+  it('retries a transient 500 on the first turn and resolves on the second attempt', async () => {
+    vi.useFakeTimers();
+    try {
+      scriptedAgent = {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        promptThrows: new HttpError('upstream 500', 500),
+        promptThrowsTimes: 1,
+      };
+      const onRetry = vi.fn();
+      const promise = generateViaAgent(
+        {
+          prompt: 'design a meditation app',
+          history: [],
+          model: MODEL,
+          apiKey: 'sk-test',
+        },
+        { onRetry },
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result.artifacts).toHaveLength(1);
+      expect(agentCalls[0]?.prompts.length).toBe(2);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/server error/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws after three consecutive 500s on the first turn (retries exhausted)', async () => {
+    vi.useFakeTimers();
+    try {
+      scriptedAgent = {
+        assistantText: '',
+        promptThrows: new HttpError('still down', 500),
+      };
+      const promise = generateViaAgent({
+        prompt: 'design a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      });
+      // Swallow the expected rejection while we drain timers so the test
+      // does not surface it as an unhandled promise.
+      const settled = promise.catch((err: unknown) => ({ rejected: err }));
+      await vi.runAllTimersAsync();
+      const outcome = (await settled) as { rejected?: unknown };
+      expect(outcome.rejected).toBeDefined();
+      expect(agentCalls[0]?.prompts.length).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry 4xx client errors (no 401 replay)', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      promptThrows: new HttpError('unauthorized', 401),
+    };
+    await expect(
+      generateViaAgent({
+        prompt: 'design a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).rejects.toBeTruthy();
+    expect(agentCalls[0]?.prompts.length).toBe(1);
+  });
+
+  it('does not retry when history is non-empty (protects multi-turn agent state)', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      promptThrows: new HttpError('upstream 500', 500),
+    };
+    await expect(
+      generateViaAgent({
+        prompt: 'refine this',
+        history: [
+          { role: 'user', content: 'first request' },
+          { role: 'assistant', content: 'first reply' },
+        ],
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).rejects.toBeTruthy();
+    // Single attempt: replaying a partial multi-turn session would corrupt
+    // tool state, so the second+ turn must surface transient errors directly.
+    expect(agentCalls[0]?.prompts.length).toBe(1);
   });
 });
 

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -44,6 +44,14 @@ interface AgentScript {
    */
   promptThrowsTimes?: number;
   /**
+   * When true together with `promptThrows`, the mock pushes a partial
+   * assistant message onto `agent.state.messages` BEFORE throwing on
+   * each failing attempt. Simulates "model streamed tokens / tool call
+   * then the connection dropped" — the real pi-agent-core path where a
+   * retry at the outer send boundary would replay tool side effects.
+   */
+  promptPushesAssistantBeforeThrow?: boolean;
+  /**
    * When set, the mock invokes `options.getApiKey` before emitting the
    * assistant response and — if it throws — converts the throw into an
    * 'error' AgentMessage (matching pi-agent-core's `handleRunFailure`
@@ -72,7 +80,31 @@ vi.mock('@mariozechner/pi-agent-core', () => {
       this.call.prompts.push({ message });
       if (scriptedAgent.promptThrows) {
         const limit = scriptedAgent.promptThrowsTimes ?? Number.POSITIVE_INFINITY;
-        if (this.call.prompts.length <= limit) throw scriptedAgent.promptThrows;
+        if (this.call.prompts.length <= limit) {
+          if (scriptedAgent.promptPushesAssistantBeforeThrow) {
+            const partial: AgentMessage = {
+              role: 'assistant',
+              // biome-ignore lint/suspicious/noExplicitAny: same.
+              api: 'anthropic-messages' as any,
+              // biome-ignore lint/suspicious/noExplicitAny: same.
+              provider: 'anthropic' as any,
+              model: 'mock-model',
+              content: [{ type: 'text', text: 'partial tokens before drop' }],
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: 'error',
+              timestamp: Date.now(),
+            };
+            this.state.messages.push(partial);
+          }
+          throw scriptedAgent.promptThrows;
+        }
       }
 
       // Simulate pi-agent-core's per-turn getApiKey invocation. Real
@@ -557,6 +589,28 @@ describe('generateViaAgent() — first-turn retry', () => {
     scriptedAgent = {
       assistantText: '',
       promptThrows: new HttpError('unauthorized', 401),
+    };
+    await expect(
+      generateViaAgent({
+        prompt: 'design a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).rejects.toBeTruthy();
+    expect(agentCalls[0]?.prompts.length).toBe(1);
+  });
+
+  it('does not retry once the agent has produced an assistant message (side-effect guard)', async () => {
+    // First-turn + transient 500, BUT the mock pushes a partial assistant
+    // message before throwing, simulating "model already emitted tokens /
+    // tool calls before the connection dropped". Replaying would re-run
+    // any text_editor / set_todos side effects, so retry must be blocked
+    // regardless of the HTTP status. A single attempt is the only safe move.
+    scriptedAgent = {
+      assistantText: '',
+      promptThrows: new HttpError('upstream 500', 500),
+      promptPushesAssistantBeforeThrow: true,
     };
     await expect(
       generateViaAgent({

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -35,6 +35,7 @@ import {
   claudeCodeIdentityHeaders,
   looksLikeClaudeOAuthToken,
   shouldForceClaudeCodeIdentity,
+  withBackoff,
 } from '@open-codesign/providers';
 import {
   type Artifact,
@@ -822,9 +823,36 @@ export async function generateViaAgent(
 
   log.info('[generate] step=send_request', ctx);
   const sendStart = Date.now();
-  try {
+  // First-turn-only retry. Multi-turn requests carry half-complete agent
+  // state (tool calls mid-flight, transcript accumulated in pi-agent-core's
+  // internal loop) — retrying would replay partial progress and corrupt the
+  // session. `input.history.length === 0` is the cleanest signal that this
+  // call starts a fresh agent, so retry there and only there.
+  const isFirstTurn = input.history.length === 0;
+  const sendOnce = async (): Promise<void> => {
     await agent.prompt(userContent);
     await agent.waitForIdle();
+  };
+  try {
+    if (isFirstTurn) {
+      const retryOpts: Parameters<typeof withBackoff>[1] = {
+        maxRetries: 3,
+        onRetry: (info: RetryReason) => {
+          log.warn('[generate] step=send_request.retry', {
+            ...ctx,
+            attempt: info.attempt,
+            totalAttempts: info.totalAttempts,
+            delayMs: info.delayMs,
+            reason: info.reason,
+          });
+          deps.onRetry?.(info);
+        },
+      };
+      if (input.signal) retryOpts.signal = input.signal;
+      await withBackoff(sendOnce, retryOpts);
+    } else {
+      await sendOnce();
+    }
   } catch (err) {
     log.error('[generate] step=send_request.fail', {
       ...ctx,

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -30,8 +30,9 @@ import {
 } from '@mariozechner/pi-agent-core';
 import type { Message as PiAiMessage, Model as PiAiModel } from '@mariozechner/pi-ai';
 import { type ArtifactEvent, createArtifactParser } from '@open-codesign/artifacts';
-import type { RetryReason } from '@open-codesign/providers';
+import type { RetryDecision, RetryReason } from '@open-codesign/providers';
 import {
+  classifyError,
   claudeCodeIdentityHeaders,
   looksLikeClaudeOAuthToken,
   shouldForceClaudeCodeIdentity,
@@ -823,20 +824,43 @@ export async function generateViaAgent(
 
   log.info('[generate] step=send_request', ctx);
   const sendStart = Date.now();
-  // First-turn-only retry. Multi-turn requests carry half-complete agent
-  // state (tool calls mid-flight, transcript accumulated in pi-agent-core's
-  // internal loop) — retrying would replay partial progress and corrupt the
-  // session. `input.history.length === 0` is the cleanest signal that this
-  // call starts a fresh agent, so retry there and only there.
+  // First-turn-only retry, further guarded by a side-effect check. Multi-turn
+  // requests carry half-complete agent state (tool calls mid-flight, transcript
+  // accumulated in pi-agent-core's internal loop) — retrying would replay
+  // partial progress and corrupt the session. Even on the first turn, retrying
+  // is safe only before any assistant message has landed in `agent.state`:
+  // once the model has emitted tokens or tool calls, side effects (text_editor
+  // writes, set_todos state) have already fired and a retry would re-run them.
+  // The pre-attempt snapshot of `agent.state.messages.length` lets us detect
+  // whether the failed attempt produced any such artefact and, if so, mark the
+  // error as non-retryable.
   const isFirstTurn = input.history.length === 0;
+  const RETRY_BLOCKED = Symbol.for('open-codesign.retry.blocked');
+  type RetryBlockedError = Error & { [RETRY_BLOCKED]?: true };
   const sendOnce = async (): Promise<void> => {
-    await agent.prompt(userContent);
-    await agent.waitForIdle();
+    const preLen = agent.state.messages.length;
+    try {
+      await agent.prompt(userContent);
+      await agent.waitForIdle();
+    } catch (err) {
+      if (agent.state.messages.length > preLen) {
+        const tagged = (err instanceof Error ? err : new Error(String(err))) as RetryBlockedError;
+        tagged[RETRY_BLOCKED] = true;
+        throw tagged;
+      }
+      throw err;
+    }
   };
   try {
     if (isFirstTurn) {
       const retryOpts: Parameters<typeof withBackoff>[1] = {
         maxRetries: 3,
+        classify: (err): RetryDecision => {
+          if ((err as RetryBlockedError)[RETRY_BLOCKED]) {
+            return { retry: false, reason: 'agent already produced side effects' };
+          }
+          return classifyError(err);
+        },
         onRetry: (info: RetryReason) => {
           log.warn('[generate] step=send_request.retry', {
             ...ctx,

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -356,8 +356,13 @@ export {
   withClaudeCodeIdentity,
 } from './claude-code-compat';
 
-export { completeWithRetry, classifyError, sleepWithAbort } from './retry';
-export type { CompleteWithRetryOptions, RetryReason } from './retry';
+export { completeWithRetry, classifyError, sleepWithAbort, withBackoff } from './retry';
+export type {
+  BackoffOptions,
+  CompleteWithRetryOptions,
+  RetryDecision,
+  RetryReason,
+} from './retry';
 
 export { injectSkillsIntoMessages, formatSkillsForPrompt, filterActive } from './skill-injector';
 

--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -1,7 +1,7 @@
 import { type ChatMessage, CodesignError, type ModelRef } from '@open-codesign/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { GenerateOptions, GenerateResult } from './index';
-import { type RetryReason, classifyError, completeWithRetry } from './retry';
+import { type RetryReason, classifyError, completeWithRetry, withBackoff } from './retry';
 
 const MODEL: ModelRef = { provider: 'anthropic', modelId: 'claude-sonnet-4-6' };
 const MESSAGES: ChatMessage[] = [{ role: 'user', content: 'hi' }];
@@ -206,5 +206,86 @@ describe('completeWithRetry', () => {
     );
     const firstCall = logger.warn.mock.calls.find((c) => c[0] === 'provider.error');
     expect(firstCall?.[1]).toMatchObject({ upstream_request_id: 'req_test' });
+  });
+});
+
+describe('withBackoff', () => {
+  it('returns the result on first-try success without invoking onRetry', async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn().mockResolvedValueOnce('ok');
+    const out = await withBackoff(fn, { baseDelayMs: 1, onRetry });
+    expect(out).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('retries on 503 then succeeds and surfaces each attempt via onRetry', async () => {
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('boom', 503))
+      .mockResolvedValueOnce('ok');
+    const out = await withBackoff(fn, { baseDelayMs: 1, onRetry });
+    expect(out).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/server error/);
+  });
+
+  it('retries on 429 and honours Retry-After (delay is at least retryAfterMs)', async () => {
+    const onRetry = vi.fn<(info: RetryReason) => void>();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError('slow', 429, { 'retry-after': '0.05' }))
+      .mockResolvedValueOnce('ok');
+    await withBackoff(fn, { baseDelayMs: 1, onRetry });
+    const info = onRetry.mock.calls[0]?.[0];
+    expect(info?.retryAfterMs).toBe(50);
+    expect(info?.delayMs).toBeGreaterThanOrEqual(50);
+  });
+
+  it('does not retry on a 4xx client error', async () => {
+    const fn = vi.fn().mockRejectedValue(new HttpError('unauthorized', 401));
+    await expect(withBackoff(fn, { baseDelayMs: 1 })).rejects.toThrow(/unauthorized/);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('exhausts maxRetries and rethrows the last error', async () => {
+    const onRetry = vi.fn();
+    const fn = vi.fn().mockRejectedValue(new HttpError('still down', 500));
+    await expect(withBackoff(fn, { baseDelayMs: 1, maxRetries: 3, onRetry })).rejects.toThrow(
+      /still down/,
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts immediately when signal is already aborted', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(withBackoff(fn, { signal: ctrl.signal })).rejects.toBeInstanceOf(CodesignError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('aborts mid-backoff when signal fires during retry sleep', async () => {
+    const fn = vi.fn().mockRejectedValue(new HttpError('boom', 503));
+    const ctrl = new AbortController();
+    const promise = withBackoff(fn, {
+      baseDelayMs: 5_000,
+      maxRetries: 5,
+      signal: ctrl.signal,
+    });
+    setTimeout(() => ctrl.abort(), 10);
+    await expect(promise).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a custom classify override when provided', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('weird'));
+    const classify = vi.fn(() => ({ retry: false as const, reason: 'never-retry' }));
+    await expect(withBackoff(fn, { baseDelayMs: 1, classify })).rejects.toThrow(/weird/);
+    expect(classify).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -36,7 +36,7 @@ export interface CompleteWithRetryOptions {
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_DELAY_MS = 500;
 
-interface RetryDecision {
+export interface RetryDecision {
   retry: boolean;
   reason: string;
   retryAfterMs?: number;
@@ -205,6 +205,59 @@ function shouldStop(decision: RetryDecision, attempt: number, maxRetries: number
   return !decision.retry || attempt >= maxRetries;
 }
 
+export interface BackoffOptions {
+  /** Total attempts (initial + retries). Default 3. */
+  maxRetries?: number;
+  /** Exponential-backoff base, ms. Default 500. */
+  baseDelayMs?: number;
+  /** Decide whether a given error is transient. Defaults to {@link classifyError}. */
+  classify?: (err: unknown) => RetryDecision;
+  /** Invoked immediately before each retry sleep. */
+  onRetry?: (info: RetryReason) => void;
+  /** Abort short-circuits both the in-flight call and the inter-retry sleep. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Generic retry wrapper. `completeWithRetry` is a thin wrapper around this that
+ * adds provider-error normalization + structured logging. Call this directly
+ * when you need first-turn retry semantics around an arbitrary transient-prone
+ * async op (e.g. `agent.prompt()` in the pi-agent-core path).
+ */
+export async function withBackoff<T>(fn: () => Promise<T>, opts: BackoffOptions = {}): Promise<T> {
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const classify = opts.classify ?? classifyError;
+  const signal = opts.signal;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    if (signal?.aborted) {
+      throw new CodesignError('Generation aborted by user', ERROR_CODES.PROVIDER_ABORTED);
+    }
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const decision = classify(err);
+      if (shouldStop(decision, attempt, maxRetries)) {
+        if (decision.reason === 'aborted') {
+          throw new CodesignError('Generation aborted by user', ERROR_CODES.PROVIDER_ABORTED, {
+            cause: err,
+          });
+        }
+        throw err;
+      }
+      const info = buildRetryInfo(attempt, maxRetries, decision, baseDelayMs);
+      opts.onRetry?.(info);
+      await sleepWithAbort(info.delayMs, signal);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new CodesignError('withBackoff exhausted', ERROR_CODES.PROVIDER_RETRY_EXHAUSTED);
+}
+
 export async function completeWithRetry(
   model: ModelRef,
   messages: ChatMessage[],
@@ -216,38 +269,34 @@ export async function completeWithRetry(
   const maxRetries = retryOpts.maxRetries ?? DEFAULT_MAX_RETRIES;
   const baseDelayMs = retryOpts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   const onRetry = retryOpts.onRetry;
+  const logger = retryOpts.logger;
+  const provider = retryOpts.provider ?? 'unknown';
 
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    if (opts.signal?.aborted) {
-      throw new CodesignError('Generation aborted by user', ERROR_CODES.PROVIDER_ABORTED);
-    }
-    try {
-      return await _impl(model, messages, opts);
-    } catch (err) {
-      lastError = err;
+  // Thin wrapper around withBackoff: folds provider-error normalization into
+  // the classify/onRetry hooks so each attempt emits structured provider.error
+  // logs and exhaustion surfaces provider.error.final.
+  let attemptForLog = 0;
+  const backoffOpts: BackoffOptions = {
+    maxRetries,
+    baseDelayMs,
+    classify: (err) => {
       const decision = classifyError(err);
-      const retryCount = attempt - 1;
-      const normalized = normalizeProviderError(err, retryOpts.provider ?? 'unknown', retryCount);
-      if (shouldStop(decision, attempt, maxRetries)) {
-        retryOpts.logger?.warn(
-          'provider.error.final',
-          normalized as unknown as Record<string, unknown>,
-        );
-        if (decision.reason === 'aborted') {
-          throw new CodesignError('Generation aborted by user', ERROR_CODES.PROVIDER_ABORTED, {
-            cause: err,
-          });
-        }
-        throw err;
+      const retryCount = Math.max(0, attemptForLog - 1);
+      const normalized = normalizeProviderError(err, provider, retryCount);
+      if (shouldStop(decision, attemptForLog, maxRetries)) {
+        logger?.warn('provider.error.final', normalized as unknown as Record<string, unknown>);
+      } else {
+        logger?.warn('provider.error', normalized as unknown as Record<string, unknown>);
       }
-      const info = buildRetryInfo(attempt, maxRetries, decision, baseDelayMs);
+      return decision;
+    },
+    onRetry: (info) => {
       onRetry?.(info);
-      retryOpts.logger?.warn('provider.error', normalized as unknown as Record<string, unknown>);
-      await sleepWithAbort(info.delayMs, opts.signal);
-    }
-  }
-  throw lastError instanceof Error
-    ? lastError
-    : new CodesignError('completeWithRetry exhausted', ERROR_CODES.PROVIDER_RETRY_EXHAUSTED);
+    },
+  };
+  if (opts.signal) backoffOpts.signal = opts.signal;
+  return withBackoff(() => {
+    attemptForLog += 1;
+    return _impl(model, messages, opts);
+  }, backoffOpts);
 }


### PR DESCRIPTION
## Summary

\`USE_AGENT_RUNTIME\` 默认 ON，99% 用户走 \`generateViaAgent → agent.prompt()\` 单次调用，**没有任何重试**。旧的 \`completeWithRetry\`（3 次指数退避）只在 USE_AGENT_RUNTIME=0 时才走。pi-ai 自身也无内建重试。结果：429/5xx/transient network 直接抛错给用户。

## What changed

- **\`packages/providers/src/retry.ts\`**：抽出通用 \`withBackoff<T>(fn, opts)\`，承担 sleep / jitter / classify / Retry-After / abort 全部逻辑。\`completeWithRetry\` 改写为薄 wrapper（注入 provider-error normalization + \`provider.error\` 日志），行为完全不变，原 15 个测试不动
- **\`packages/providers/src/index.ts\`**：export \`withBackoff\` / \`BackoffOptions\` / \`RetryDecision\`
- **\`packages/core/src/agent.ts\`**：\`input.history.length === 0\`（first turn，**幂等**）时用 \`withBackoff({ maxRetries: 3 })\` 包 \`agent.prompt() + agent.waitForIdle()\`。non-first-turn 仍走 \`sendOnce()\`，避免多 turn 对话被重发污染状态
- 重试通过 \`log.warn('[generate] step=send_request.retry', ...)\` 暴露，UI feedback 留作 follow-up
- \`USE_AGENT_RUNTIME\` 默认值未动；Codex 401 路径未动（follow-up）

## Test plan

- [x] 9 new \`withBackoff\` tests：first-try success / 503→ok / 429 Retry-After / 4xx no retry / exhaustion / pre-aborted signal / mid-backoff abort / custom classify
- [x] 4 new agent tests：first-turn 500→success / first-turn 3×500 exhaustion / first-turn 401 no retry / **non-first-turn 500 no retry**（关键：保护 multi-turn 状态）
- [x] \`pnpm test\` providers (139) + core (220) all green
- [x] \`pnpm typecheck\` + \`pnpm lint\` clean
- [x] changeset added (patch bump)

Closes #125