### PR TITLE
fix(desktop): preserve generation timeout reason and raise dropdown ceiling

### DIFF
--- a/.changeset/fix-generation-timeout-reason.md
+++ b/.changeset/fix-generation-timeout-reason.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/desktop": patch
+---
+
+Fix: preserve the generation-timeout reason so long runs no longer surface a bare "Request was aborted." Provider SDKs rewrite aborted fetches into a generic message that drops `signal.reason`; the generate IPC now re-surfaces the stashed `GENERATION_TIMEOUT` CodesignError (with configured seconds + Settings path) when the controller was aborted by our own timer. Settings → Advanced → Generation timeout also gains 10m / 20m / 30m / 1h / 2h choices so the default 1200s and longer full-PDP runs can actually be configured without the dropdown silently downgrading the stored value.

--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -1,6 +1,10 @@
 import { CancelGenerationPayloadV1, CodesignError } from '@open-codesign/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { armGenerationTimeout, cancelGenerationRequest } from './generation-ipc';
+import {
+  armGenerationTimeout,
+  cancelGenerationRequest,
+  extractGenerationTimeoutError,
+} from './generation-ipc';
 
 function makeController() {
   return { abort: vi.fn() } as unknown as AbortController;
@@ -180,5 +184,45 @@ describe('armGenerationTimeout', () => {
       armGenerationTimeout('gen-1', controller, async () => -1, logger),
     ).rejects.toMatchObject({ name: 'CodesignError', code: 'PREFERENCES_INVALID_TIMEOUT' });
     expect(controller.signal.aborted).toBe(false);
+  });
+});
+
+describe('extractGenerationTimeoutError', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the CodesignError stashed by armGenerationTimeout so the SDK-rewritten AbortError can be upgraded back to GENERATION_TIMEOUT', async () => {
+    const controller = new AbortController();
+    const logger = { warn: vi.fn() };
+
+    await armGenerationTimeout('gen-1', controller, async () => 3, logger);
+    vi.advanceTimersByTime(3000);
+
+    const recovered = extractGenerationTimeoutError(controller.signal);
+    expect(recovered).toBeInstanceOf(CodesignError);
+    expect(recovered?.code).toBe('GENERATION_TIMEOUT');
+    expect(recovered?.message).toContain('3s');
+    expect(recovered?.message).toContain('Settings');
+  });
+
+  it('returns null when the controller was aborted by a user-initiated cancel (no reason set)', () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(extractGenerationTimeoutError(controller.signal)).toBeNull();
+  });
+
+  it('returns null when the signal has not been aborted', () => {
+    const controller = new AbortController();
+    expect(extractGenerationTimeoutError(controller.signal)).toBeNull();
+  });
+
+  it('returns null when the abort reason is some other CodesignError (not a timeout)', () => {
+    const controller = new AbortController();
+    controller.abort(new CodesignError('something else', 'PROVIDER_ABORTED'));
+    expect(extractGenerationTimeoutError(controller.signal)).toBeNull();
   });
 });

--- a/apps/desktop/src/main/generation-ipc.ts
+++ b/apps/desktop/src/main/generation-ipc.ts
@@ -82,3 +82,21 @@ export async function armGenerationTimeout(
   }, ms);
   return () => clearTimeout(handle);
 }
+
+/**
+ * Provider SDKs (Anthropic / OpenAI) catch an aborted fetch and rethrow their
+ * own generic `'Request was aborted.'` error, discarding `signal.reason`. When
+ * the caught error came from our own timeout abort, we want the richer message
+ * (with the configured seconds and the Settings path) to surface to the user.
+ *
+ * Returns the `CodesignError` we stashed on `signal.reason`, or `null` when the
+ * abort was caused by something else (user-initiated cancel, upstream error).
+ */
+export function extractGenerationTimeoutError(signal: AbortSignal): CodesignError | null {
+  if (!signal.aborted) return null;
+  const reason = signal.reason;
+  if (reason instanceof CodesignError && reason.code === ERROR_CODES.GENERATION_TIMEOUT) {
+    return reason;
+  }
+  return null;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,7 +43,11 @@ import { registerDiagnosticsIpc } from './diagnostics-ipc';
 import { makeRuntimeVerifier } from './done-verify';
 import { BrowserWindow, app, clipboard, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
-import { armGenerationTimeout, cancelGenerationRequest } from './generation-ipc';
+import {
+  armGenerationTimeout,
+  cancelGenerationRequest,
+  extractGenerationTimeoutError,
+} from './generation-ipc';
 import { maybeAbortIfRunningFromDmg } from './install-check';
 import { registerLocaleIpc } from './locale-ipc';
 import { getLogPath, getLogger, initLogger } from './logger';
@@ -737,6 +741,12 @@ function registerIpcHandlers(db: Database | null): void {
             errAsRec['upstream_wire'] = active.wire;
           }
         }
+        // The SDK catches our AbortController and rethrows a generic
+        // `'Request was aborted.'` that drops signal.reason. Prefer the
+        // CodesignError we stashed on the signal so the user sees the
+        // configured timeout + Settings path instead of an opaque message.
+        const timeoutErr = extractGenerationTimeoutError(controller.signal);
+        const rethrow = timeoutErr ?? err;
         logIpc.error('generate.fail', {
           generationId: id,
           ms: Date.now() - t0,
@@ -744,11 +754,11 @@ function registerIpcHandlers(db: Database | null): void {
           modelId: active.model.modelId,
           baseUrl: baseUrl ?? '<default>',
           status: upstreamStatus,
-          message: err instanceof Error ? err.message : String(err),
-          code: err instanceof CodesignError ? err.code : undefined,
+          message: rethrow instanceof Error ? rethrow.message : String(rethrow),
+          code: rethrow instanceof CodesignError ? rethrow.code : undefined,
         });
-        recordFinalError('generate', id, err);
-        throw err;
+        recordFinalError('generate', id, rethrow);
+        throw rethrow;
       } finally {
         clearTimeoutGuard();
         inFlight.delete(id);
@@ -846,17 +856,23 @@ function registerIpcHandlers(db: Database | null): void {
         });
         return result;
       } catch (err) {
+        // The SDK catches our AbortController and rethrows a generic
+        // `'Request was aborted.'` that drops signal.reason. Prefer the
+        // CodesignError we stashed on the signal so the user sees the
+        // configured timeout + Settings path instead of an opaque message.
+        const timeoutErr = extractGenerationTimeoutError(controller.signal);
+        const rethrow = timeoutErr ?? err;
         logIpc.error('generate.fail', {
           generationId: id,
           ms: Date.now() - t0,
           provider: active.model.provider,
           modelId: active.model.modelId,
           baseUrl: baseUrl ?? '<default>',
-          message: err instanceof Error ? err.message : String(err),
-          code: err instanceof CodesignError ? err.code : undefined,
+          message: rethrow instanceof Error ? rethrow.message : String(rethrow),
+          code: rethrow instanceof CodesignError ? rethrow.code : undefined,
         });
-        recordFinalError('generate', id, err);
-        throw err;
+        recordFinalError('generate', id, rethrow);
+        throw rethrow;
       } finally {
         clearTimeoutGuard();
         inFlight.delete(id);

--- a/apps/desktop/src/renderer/src/components/Settings.test.ts
+++ b/apps/desktop/src/renderer/src/components/Settings.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { applyLocaleChange, computeModelOptions } from './Settings';
+import {
+  TIMEOUT_OPTION_SECONDS,
+  applyLocaleChange,
+  computeModelOptions,
+  resolveTimeoutOptions,
+} from './Settings';
 
 vi.mock('@open-codesign/i18n', () => ({
   setLocale: vi.fn((locale: string) => Promise.resolve(locale)),
@@ -34,7 +39,6 @@ describe('applyLocaleChange', () => {
     expect(result).toBe('zh-CN');
   });
 });
-
 describe('computeModelOptions', () => {
   const suffix = '(active, not in provider list)';
 
@@ -86,5 +90,36 @@ describe('computeModelOptions', () => {
       { value: 'haiku', label: 'haiku' },
       { value: 'sonnet', label: 'sonnet' },
     ]);
+  });
+});
+
+describe('resolveTimeoutOptions', () => {
+  it('covers the default 1200s stored value and long-generation 30m / 1h / 2h choices so users can configure what they need without hitting the old 300s ceiling', () => {
+    expect(TIMEOUT_OPTION_SECONDS).toContain(1200);
+    expect(TIMEOUT_OPTION_SECONDS).toContain(1800);
+    expect(TIMEOUT_OPTION_SECONDS).toContain(3600);
+    expect(TIMEOUT_OPTION_SECONDS).toContain(7200);
+  });
+
+  it('returns the canonical options unchanged when the stored value is already present', () => {
+    const options = resolveTimeoutOptions(1200);
+    expect(options).toEqual([...TIMEOUT_OPTION_SECONDS]);
+  });
+
+  it("merges a stored value that is not in the canonical list and keeps the list sorted so the select shows the user's existing choice instead of silently downgrading on save", () => {
+    const options = resolveTimeoutOptions(900);
+    expect(options).toContain(900);
+    expect(options).toEqual([...options].sort((a, b) => a - b));
+    // Canonical entries are preserved.
+    for (const sec of TIMEOUT_OPTION_SECONDS) {
+      expect(options).toContain(sec);
+    }
+  });
+
+  it('ignores non-positive or non-finite stored values rather than injecting bogus options', () => {
+    expect(resolveTimeoutOptions(0)).toEqual([...TIMEOUT_OPTION_SECONDS]);
+    expect(resolveTimeoutOptions(-1)).toEqual([...TIMEOUT_OPTION_SECONDS]);
+    expect(resolveTimeoutOptions(Number.NaN)).toEqual([...TIMEOUT_OPTION_SECONDS]);
+    expect(resolveTimeoutOptions(Number.POSITIVE_INFINITY)).toEqual([...TIMEOUT_OPTION_SECONDS]);
   });
 });

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1644,6 +1644,29 @@ export function computeModelOptions(input: {
   return base;
 }
 
+/**
+ * Canonical timeout choices shown in Settings → Advanced. The default prefs
+ * value is 1200s (20 min); long generations (full PDP runs) need 30-60 min,
+ * so the dropdown tops out at 2h. The old 60-300s ceiling silently clamped
+ * the stored value when the UI couldn't represent it.
+ */
+export const TIMEOUT_OPTION_SECONDS = [60, 120, 180, 300, 600, 1200, 1800, 3600, 7200] as const;
+
+/**
+ * Returns the canonical timeout list with `currentSec` merged in when it is a
+ * positive finite value that isn't already present. Prevents the select from
+ * rendering with no selection when the user (or an earlier build) stored a
+ * custom value — and prevents a silent downgrade on the next save.
+ */
+export function resolveTimeoutOptions(currentSec: number): number[] {
+  const base: number[] = [...TIMEOUT_OPTION_SECONDS];
+  if (Number.isFinite(currentSec) && currentSec > 0 && !base.includes(currentSec)) {
+    base.push(currentSec);
+    base.sort((a, b) => a - b);
+  }
+  return base;
+}
+
 function AppearanceTab() {
   const t = useT();
   const theme = useCodesignStore((s) => s.theme);
@@ -2109,12 +2132,10 @@ function AdvancedTab() {
         <NativeSelect
           value={String(prefs.generationTimeoutSec)}
           onChange={(v) => void updatePref({ generationTimeoutSec: Number(v) })}
-          options={[
-            { value: '60', label: t('settings.advanced.timeoutSeconds', { value: 60 }) },
-            { value: '120', label: t('settings.advanced.timeoutSeconds', { value: 120 }) },
-            { value: '180', label: t('settings.advanced.timeoutSeconds', { value: 180 }) },
-            { value: '300', label: t('settings.advanced.timeoutSeconds', { value: 300 }) },
-          ]}
+          options={resolveTimeoutOptions(prefs.generationTimeoutSec).map((sec) => ({
+            value: String(sec),
+            label: t('settings.advanced.timeoutSeconds', { value: sec }),
+          }))}
         />
       </Row>
 


### PR DESCRIPTION
Fixes #164.

## Summary

- **Root cause of the opaque "Request was aborted." message.** When the generation timer fires, `armGenerationTimeout` calls `controller.abort(new CodesignError('Generation aborted after {n}s (Settings → Advanced → Generation timeout).', 'GENERATION_TIMEOUT'))`. But the Anthropic and OpenAI SDKs catch the aborted fetch and rethrow their own generic `'Request was aborted.'`, which drops `signal.reason`. The main-process `catch` then logged and re-threw that opaque error, so the user never saw the configured timeout or where to change it.
- **Fix at the catch boundary, not the SDK boundary.** New `extractGenerationTimeoutError(signal)` reads back the `CodesignError` we stashed. Both `codesign:v1:generate` and the legacy `codesign:generate` catch blocks now prefer it over the rewritten SDK error, so the log row and the renderer toast both carry `GENERATION_TIMEOUT` with the full message.
- **Settings dropdown ceiling raised.** The default preference is 1200s (20 min) but the UI only listed 60/120/180/300, so the select rendered blank and `updatePref` silently downgraded on save (covered in `project_bug_settings_timeout_dropdown` memory — this PR resolves that). Options now run 60s / 2m / 3m / 5m / 10m / 20m / 30m / 1h / 2h, and a stored value outside the list is injected so the user's existing choice is preserved.

## Changes

- `apps/desktop/src/main/generation-ipc.ts` — export `extractGenerationTimeoutError(signal)`.
- `apps/desktop/src/main/index.ts` — both generate catch blocks upgrade the SDK error back to `GENERATION_TIMEOUT` when our timer fired.
- `apps/desktop/src/renderer/src/components/Settings.tsx` — `TIMEOUT_OPTION_SECONDS` + `resolveTimeoutOptions(currentSec)` helper; dropdown maps from it.
- Tests: new `extractGenerationTimeoutError` suite (4 cases) + `resolveTimeoutOptions` suite (4 cases).
- Changeset: patch.

## PRINCIPLES §5b

- Compatibility: prefs schema unchanged, only the list of UI choices widened. Any stored timeout (including the legacy 1200) renders correctly.
- Upgradeability: `resolveTimeoutOptions` merges unknown stored values, so we can change the canonical list in the future without stranding user settings.
- No bloat: one new exported function per concern, no new deps.
- Elegance: fix is at the one place where the SDK's rewrite lands (the catch), not spread across every provider adapter.

## Test plan

- [x] `pnpm typecheck` — 10/10 tasks pass.
- [x] `pnpm --filter @open-codesign/desktop test -- --run` — 878/878 pass.
- [x] `pnpm lint` — clean.
- [x] Full pre-commit hook (turbo full test + lint) — clean.
- [ ] Manual: Settings → Advanced shows the new 30m/1h/2h choices; stored 1200s renders as "1200 s"; changing to 3600s and triggering a generation that exceeds the provider turn time shows the friendly GENERATION_TIMEOUT toast instead of "Request was aborted."

## Coordination

- Does not touch `retry.ts` or `remapProviderError` (out of scope, other PRs own those).
- Does not change `applyGenerateError` in the renderer store — the richer error code already flows through the normal error pipeline; a follow-up can add a "Open Settings" secondary action on the toast if desired.

😇