### PR TITLE
feat(desktop):  workspace for each design projects

### DIFF
--- a/.changeset/feat-user-choose-workspace.md
+++ b/.changeset/feat-user-choose-workspace.md
@@ -1,0 +1,13 @@
+---
+'@open-codesign/desktop': minor
+---
+
+feat(desktop): per-design workspace folder linking
+
+Users can now bind any open design to a local folder directly from the Files panel. Every file the agent writes is mirrored to that folder in real time, and the binding persists across restarts.
+
+- **Bind on first use** — click "Choose folder" in the Files panel to pick a workspace directory; the design is linked immediately and files are synced.
+- **Rebind with migration** — choosing a different folder prompts a confirmation dialog; existing tracked files are copied to the new location before the binding switches.
+- **Clear binding** — a "Disconnect folder" action removes the link without touching files on disk.
+- **Error surfacing** — write-through failures and IPC errors (migration collision, missing tracked file) are now reported to the UI instead of being silently swallowed.
+- **Cross-platform path comparison** — the rebind dialog no longer triggers falsely when paths differ only by trailing slash or directory-separator style.

--- a/apps/desktop/src/main/design-files.test.ts
+++ b/apps/desktop/src/main/design-files.test.ts
@@ -14,6 +14,7 @@ import {
   listDesignFilesInDir,
   normalizeDesignFilePath,
   strReplaceInDesignFile,
+  upsertDesignFile,
   viewDesignFile,
 } from './snapshots-db';
 
@@ -97,6 +98,30 @@ describe('insert', () => {
     const { db, designId } = seed();
     createDesignFile(db, designId, 'a.txt', 'x');
     expect(() => insertInDesignFile(db, designId, 'a.txt', 99, 'y')).toThrow(/out of range/);
+  });
+});
+
+describe('upsert', () => {
+  it('creates a missing design file', () => {
+    const { db, designId } = seed();
+
+    const file = upsertDesignFile(db, designId, 'nested\\index.html', '<main>first</main>');
+
+    expect(file.path).toBe('nested/index.html');
+    expect(file.content).toBe('<main>first</main>');
+    expect(viewDesignFile(db, designId, 'nested/index.html')?.content).toBe('<main>first</main>');
+  });
+
+  it('updates an existing design file in place', () => {
+    const { db, designId } = seed();
+    const created = createDesignFile(db, designId, 'index.html', '<main>before</main>');
+
+    const updated = upsertDesignFile(db, designId, 'index.html', '<main>after</main>');
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.content).toBe('<main>after</main>');
+    expect(updated.updatedAt >= created.updatedAt).toBe(true);
+    expect(viewDesignFile(db, designId, 'index.html')?.content).toBe('<main>after</main>');
   });
 });
 

--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDesign, createDesignFile, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
+
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  shell: {
+    openPath: vi.fn(),
+  },
+}));
+
+import { dialog, shell } from 'electron';
+import {
+  bindWorkspace,
+  normalizeWorkspacePath,
+  openWorkspaceFolder,
+  pickWorkspaceFolder,
+} from './design-workspace';
+
+const showOpenDialog = vi.mocked(dialog.showOpenDialog);
+const openPath = vi.mocked(shell.openPath);
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeWorkspaceFile(root: string, relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(root, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
+}
+
+afterEach(async () => {
+  showOpenDialog.mockReset();
+  openPath.mockReset();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('normalizeWorkspacePath', () => {
+  it('strips trailing slash, resolves absolute path, and normalizes separators', () => {
+    const relative = path.join('tmp', 'designs', '..', 'designs', 'workspace') + path.sep;
+    const normalized = normalizeWorkspacePath(relative);
+
+    expect(path.isAbsolute(normalized)).toBe(true);
+    expect(normalized).toBe(path.resolve('tmp/designs/workspace').replaceAll('\\', '/'));
+    expect(normalized.endsWith('/')).toBe(false);
+  });
+});
+
+describe('pickWorkspaceFolder', () => {
+  it('returns the selected folder path', async () => {
+    showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/tmp/workspace'],
+    } as Awaited<ReturnType<typeof dialog.showOpenDialog>>);
+
+    await expect(pickWorkspaceFolder({} as never)).resolves.toBe('/tmp/workspace');
+  });
+
+  it('returns null when the picker is canceled', async () => {
+    showOpenDialog.mockResolvedValue({
+      canceled: true,
+      filePaths: [],
+    } as Awaited<ReturnType<typeof dialog.showOpenDialog>>);
+
+    await expect(pickWorkspaceFolder({} as never)).resolves.toBeNull();
+  });
+});
+
+describe('openWorkspaceFolder', () => {
+  it('opens the folder in the OS file manager', async () => {
+    openPath.mockResolvedValue('');
+
+    await expect(openWorkspaceFolder('/tmp/workspace')).resolves.toBeUndefined();
+    expect(openPath).toHaveBeenCalledWith('/tmp/workspace');
+  });
+
+  it('throws when Electron reports an open error', async () => {
+    openPath.mockResolvedValue('no application is associated');
+
+    await expect(openWorkspaceFolder('/tmp/workspace')).rejects.toThrow(
+      'Failed to open workspace folder: no application is associated',
+    );
+  });
+});
+
+describe('bindWorkspace', () => {
+  it('returns the current design unchanged when rebinding the same normalized path', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const workspace = await makeTempDir('ocd-ws-same-');
+    const normalized = normalizeWorkspacePath(workspace);
+    const bound = updateDesignWorkspace(db, design.id, normalized);
+    await writeWorkspaceFile(workspace, 'tracked.txt', 'tracked');
+    createDesignFile(db, design.id, 'tracked.txt', 'tracked');
+    const destinationBefore = await stat(path.join(workspace, 'tracked.txt'));
+
+    const rebound = await bindWorkspace(db, design.id, `${workspace}${path.sep}`, true);
+
+    expect(rebound).toEqual(bound);
+    expect(await stat(path.join(workspace, 'tracked.txt'))).toEqual(destinationBefore);
+  });
+
+  it('throws when another active design already owns the workspace path', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const otherDesign = createDesign(db);
+    const conflictPath = normalizeWorkspacePath(await makeTempDir('ocd-ws-conflict-'));
+    updateDesignWorkspace(db, otherDesign.id, conflictPath);
+
+    await expect(bindWorkspace(db, design.id, conflictPath, false)).rejects.toThrow(
+      'Workspace path is already bound to another design',
+    );
+    expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
+      workspace_path: null,
+    });
+  });
+
+  it('copies tracked files only during migration', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const source = await makeTempDir('ocd-ws-source-');
+    const destination = await makeTempDir('ocd-ws-dest-');
+    updateDesignWorkspace(db, design.id, normalizeWorkspacePath(source));
+    createDesignFile(db, design.id, 'tracked.txt', 'tracked root');
+    createDesignFile(db, design.id, 'nested/child.txt', 'tracked nested');
+    await writeWorkspaceFile(source, 'tracked.txt', 'tracked root');
+    await writeWorkspaceFile(source, 'nested/child.txt', 'tracked nested');
+    await writeWorkspaceFile(source, 'ignored.txt', 'untracked');
+
+    const updated = await bindWorkspace(db, design.id, destination, true);
+
+    expect(updated.workspacePath).toBe(normalizeWorkspacePath(destination));
+    expect(await readFile(path.join(destination, 'tracked.txt'), 'utf8')).toBe('tracked root');
+    expect(await readFile(path.join(destination, 'nested/child.txt'), 'utf8')).toBe('tracked nested');
+    await expect(readFile(path.join(destination, 'ignored.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(await readFile(path.join(source, 'tracked.txt'), 'utf8')).toBe('tracked root');
+    expect(await readFile(path.join(source, 'ignored.txt'), 'utf8')).toBe('untracked');
+  });
+
+  it('aborts migration on destination collision and leaves the binding unchanged', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const source = await makeTempDir('ocd-ws-source-');
+    const destination = await makeTempDir('ocd-ws-dest-');
+    const sourcePath = normalizeWorkspacePath(source);
+    updateDesignWorkspace(db, design.id, sourcePath);
+    createDesignFile(db, design.id, 'tracked.txt', 'tracked root');
+    await writeWorkspaceFile(source, 'tracked.txt', 'tracked root');
+    await writeWorkspaceFile(destination, 'tracked.txt', 'existing destination');
+
+    await expect(bindWorkspace(db, design.id, destination, true)).rejects.toThrow(
+      'Workspace migration collision: tracked.txt',
+    );
+    expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
+      workspace_path: sourcePath,
+    });
+    expect(await readFile(path.join(destination, 'tracked.txt'), 'utf8')).toBe('existing destination');
+  });
+
+  it('clears the workspace binding without touching the filesystem', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const source = await makeTempDir('ocd-ws-clear-');
+    const normalizedSource = normalizeWorkspacePath(source);
+    updateDesignWorkspace(db, design.id, normalizedSource);
+    await writeWorkspaceFile(source, 'tracked.txt', 'tracked root');
+    const beforeEntries = await readdir(source);
+
+    const cleared = await bindWorkspace(db, design.id, null, false);
+
+    expect(cleared.workspacePath).toBeNull();
+    expect(await readdir(source)).toEqual(beforeEntries);
+  });
+});

--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -31,6 +31,21 @@ const openPath = vi.mocked(shell.openPath);
 
 const tempDirs: string[] = [];
 
+async function withMockedPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    return await run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original);
+    }
+  }
+}
+
 async function makeTempDir(prefix: string): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
@@ -130,6 +145,35 @@ describe('bindWorkspace', () => {
     );
     expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
       workspace_path: null,
+    });
+  });
+
+  it('treats case-only workspace differences as the same path on Windows for the same design', async () => {
+    await withMockedPlatform('win32', async () => {
+      const db = initInMemoryDb();
+      const design = createDesign(db);
+      const storedPath = normalizeWorkspacePath('/Users/Roy/Workspace');
+      updateDesignWorkspace(db, design.id, storedPath);
+
+      const rebound = await bindWorkspace(db, design.id, '/users/roy/workspace/', false);
+
+      expect(rebound.workspacePath).toBe(storedPath);
+      expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
+        workspace_path: storedPath,
+      });
+    });
+  });
+
+  it('treats case-only workspace differences as conflicts on Windows across designs', async () => {
+    await withMockedPlatform('win32', async () => {
+      const db = initInMemoryDb();
+      const design = createDesign(db);
+      const otherDesign = createDesign(db);
+      updateDesignWorkspace(db, otherDesign.id, normalizeWorkspacePath('/Users/Roy/Workspace'));
+
+      await expect(bindWorkspace(db, design.id, '/users/roy/workspace', false)).rejects.toThrow(
+        'Workspace path is already bound to another design',
+      );
     });
   });
 

--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -1,8 +1,13 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createDesign, createDesignFile, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
+import {
+  createDesign,
+  createDesignFile,
+  initInMemoryDb,
+  updateDesignWorkspace,
+} from './snapshots-db';
 
 vi.mock('electron', () => ({
   dialog: {
@@ -32,7 +37,11 @@ async function makeTempDir(prefix: string): Promise<string> {
   return dir;
 }
 
-async function writeWorkspaceFile(root: string, relativePath: string, content: string): Promise<void> {
+async function writeWorkspaceFile(
+  root: string,
+  relativePath: string,
+  content: string,
+): Promise<void> {
   const filePath = path.join(root, relativePath);
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, content, 'utf8');
@@ -140,7 +149,9 @@ describe('bindWorkspace', () => {
 
     expect(updated.workspacePath).toBe(normalizeWorkspacePath(destination));
     expect(await readFile(path.join(destination, 'tracked.txt'), 'utf8')).toBe('tracked root');
-    expect(await readFile(path.join(destination, 'nested/child.txt'), 'utf8')).toBe('tracked nested');
+    expect(await readFile(path.join(destination, 'nested/child.txt'), 'utf8')).toBe(
+      'tracked nested',
+    );
     await expect(readFile(path.join(destination, 'ignored.txt'), 'utf8')).rejects.toMatchObject({
       code: 'ENOENT',
     });
@@ -165,7 +176,9 @@ describe('bindWorkspace', () => {
     expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
       workspace_path: sourcePath,
     });
-    expect(await readFile(path.join(destination, 'tracked.txt'), 'utf8')).toBe('existing destination');
+    expect(await readFile(path.join(destination, 'tracked.txt'), 'utf8')).toBe(
+      'existing destination',
+    );
   });
 
   it('clears the workspace binding without touching the filesystem', async () => {

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -1,0 +1,149 @@
+import { existsSync } from 'node:fs';
+import { copyFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { Design } from '@open-codesign/shared';
+import type Database from 'better-sqlite3';
+import { dialog, shell, type BrowserWindow } from 'electron';
+import { getLogger } from './logger';
+import {
+  clearDesignWorkspace,
+  getDesign,
+  listDesignFiles,
+  updateDesignWorkspace,
+} from './snapshots-db';
+
+const logger = getLogger('design-workspace');
+
+function stripTrailingSlash(value: string): string {
+  if (value === '/' || /^[A-Za-z]:\/$/.test(value)) {
+    return value;
+  }
+  return value.replace(/\/+$/, '');
+}
+
+export function normalizeWorkspacePath(p: string): string {
+  return stripTrailingSlash(path.resolve(p).replaceAll('\\', '/'));
+}
+
+export async function pickWorkspaceFolder(win: BrowserWindow): Promise<string | null> {
+  const result = await dialog.showOpenDialog(win, {
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (result.canceled || result.filePaths.length === 0) {
+    return null;
+  }
+  return result.filePaths[0] ?? null;
+}
+
+export async function openWorkspaceFolder(p: string): Promise<void> {
+  const result = await shell.openPath(p);
+  if (result.length > 0) {
+    throw new Error(`Failed to open workspace folder: ${result}`);
+  }
+}
+
+export function checkWorkspaceConflict(
+  db: Database.Database,
+  designId: string,
+  normalizedPath: string,
+): boolean {
+  const row = db
+    .prepare(
+      'SELECT 1 FROM designs WHERE workspace_path = ? AND id != ? AND deleted_at IS NULL LIMIT 1',
+    )
+    .get(normalizedPath, designId);
+  return row !== undefined;
+}
+
+export async function migrateWorkspaceFiles(
+  db: Database.Database,
+  designId: string,
+  destPath: string,
+): Promise<void> {
+  const design = getDesign(db, designId);
+  if (design === null) {
+    throw new Error(`Design not found: ${designId}`);
+  }
+  if (design.workspacePath === null) {
+    throw new Error('Cannot migrate workspace files without an existing workspace path');
+  }
+
+  const trackedFiles = listDesignFiles(db, designId);
+  const pendingCopies = trackedFiles.map((file) => ({
+    source: path.join(design.workspacePath as string, file.path),
+    destination: path.join(destPath, file.path),
+    relativePath: file.path,
+  }));
+
+  for (const copyOp of pendingCopies) {
+    if (existsSync(copyOp.destination)) {
+      throw new Error(`Workspace migration collision: ${copyOp.relativePath}`);
+    }
+    if (!existsSync(copyOp.source)) {
+      throw new Error(`Tracked workspace file missing: ${copyOp.relativePath}`);
+    }
+  }
+
+  for (const copyOp of pendingCopies) {
+    await mkdir(path.dirname(copyOp.destination), { recursive: true });
+    await copyFile(copyOp.source, copyOp.destination);
+  }
+}
+
+function requireDesign(db: Database.Database, designId: string): Design {
+  const design = getDesign(db, designId);
+  if (design === null) {
+    throw new Error(`Design not found: ${designId}`);
+  }
+  return design;
+}
+
+export async function bindWorkspace(
+  db: Database.Database,
+  designId: string,
+  workspacePath: string | null,
+  migrateFiles: boolean,
+): Promise<Design> {
+  const current = requireDesign(db, designId);
+
+  if (workspacePath === null) {
+    logger.info('workspace.clear.start', { designId });
+    const cleared = clearDesignWorkspace(db, designId);
+    if (cleared === null) {
+      throw new Error(`Design not found: ${designId}`);
+    }
+    logger.info('workspace.clear.done', { designId });
+    return cleared;
+  }
+
+  const normalizedPath = normalizeWorkspacePath(workspacePath);
+  if (current.workspacePath !== null && normalizeWorkspacePath(current.workspacePath) === normalizedPath) {
+    logger.info('workspace.bind.noop', { designId, workspacePath: normalizedPath });
+    return current;
+  }
+  if (checkWorkspaceConflict(db, designId, normalizedPath)) {
+    throw new Error('Workspace path is already bound to another design');
+  }
+
+  logger.info('workspace.bind.start', {
+    designId,
+    workspacePath: normalizedPath,
+    migrateFiles,
+  });
+
+  if (migrateFiles) {
+    await migrateWorkspaceFiles(db, designId, normalizedPath);
+  }
+
+  const updated = updateDesignWorkspace(db, designId, normalizedPath);
+  if (updated === null) {
+    throw new Error(`Design not found: ${designId}`);
+  }
+
+  logger.info('workspace.bind.done', {
+    designId,
+    workspacePath: normalizedPath,
+    migrateFiles,
+  });
+  return updated;
+}

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -3,7 +3,7 @@ import { copyFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import type { Design } from '@open-codesign/shared';
 import type Database from 'better-sqlite3';
-import { dialog, shell, type BrowserWindow } from 'electron';
+import { type BrowserWindow, dialog, shell } from 'electron';
 import { getLogger } from './logger';
 import {
   clearDesignWorkspace,
@@ -98,6 +98,10 @@ function requireDesign(db: Database.Database, designId: string): Design {
   return design;
 }
 
+export function checkWorkspaceFolderExists(p: string): boolean {
+  return existsSync(p);
+}
+
 export async function bindWorkspace(
   db: Database.Database,
   designId: string,
@@ -117,7 +121,10 @@ export async function bindWorkspace(
   }
 
   const normalizedPath = normalizeWorkspacePath(workspacePath);
-  if (current.workspacePath !== null && normalizeWorkspacePath(current.workspacePath) === normalizedPath) {
+  if (
+    current.workspacePath !== null &&
+    normalizeWorkspacePath(current.workspacePath) === normalizedPath
+  ) {
     logger.info('workspace.bind.noop', { designId, workspacePath: normalizedPath });
     return current;
   }

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -25,6 +25,11 @@ export function normalizeWorkspacePath(p: string): string {
   return stripTrailingSlash(path.resolve(p).replaceAll('\\', '/'));
 }
 
+function workspacePathComparisonKey(p: string): string {
+  const normalized = normalizeWorkspacePath(p);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
 export async function pickWorkspaceFolder(win: BrowserWindow): Promise<string | null> {
   const result = await dialog.showOpenDialog(win, {
     properties: ['openDirectory', 'createDirectory'],
@@ -47,12 +52,15 @@ export function checkWorkspaceConflict(
   designId: string,
   normalizedPath: string,
 ): boolean {
-  const row = db
-    .prepare(
-      'SELECT 1 FROM designs WHERE workspace_path = ? AND id != ? AND deleted_at IS NULL LIMIT 1',
-    )
-    .get(normalizedPath, designId);
-  return row !== undefined;
+  const comparisonPath = workspacePathComparisonKey(normalizedPath);
+  const rows = db
+    .prepare('SELECT workspace_path FROM designs WHERE id != ? AND deleted_at IS NULL')
+    .all(designId) as Array<{ workspace_path: string | null }>;
+  return rows.some(
+    (row) =>
+      row.workspace_path !== null &&
+      workspacePathComparisonKey(row.workspace_path) === comparisonPath,
+  );
 }
 
 export async function migrateWorkspaceFiles(
@@ -121,9 +129,10 @@ export async function bindWorkspace(
   }
 
   const normalizedPath = normalizeWorkspacePath(workspacePath);
+  const comparisonPath = workspacePathComparisonKey(normalizedPath);
   if (
     current.workspacePath !== null &&
-    normalizeWorkspacePath(current.workspacePath) === normalizedPath
+    workspacePathComparisonKey(current.workspacePath) === comparisonPath
   ) {
     logger.info('workspace.bind.noop', { designId, workspacePath: normalizedPath });
     return current;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -343,10 +343,10 @@ export function createRuntimeTextEditorFs({
       return { content, numLines: content.split('\n').length };
     },
     async create(path: string, content: string) {
+      await persistMutation(path, content);
       fsMap.set(path, content);
       emitFsUpdated(path, content);
       emitIndexIfAssetChanged(path);
-      await persistMutation(path, content);
       return { path };
     },
     async strReplace(path: string, oldStr: string, newStr: string) {
@@ -358,10 +358,10 @@ export function createRuntimeTextEditorFs({
         throw new Error(`old_str is ambiguous in ${path}; provide more context`);
       }
       const next = current.slice(0, idx) + newStr + current.slice(idx + oldStr.length);
+      await persistMutation(path, next);
       fsMap.set(path, next);
       emitFsUpdated(path, next);
       emitIndexIfAssetChanged(path);
-      await persistMutation(path, next);
       return { path };
     },
     async insert(path: string, line: number, text: string) {
@@ -370,10 +370,10 @@ export function createRuntimeTextEditorFs({
       const clamped = Math.max(0, Math.min(line, lines.length));
       lines.splice(clamped, 0, text);
       const next = lines.join('\n');
+      await persistMutation(path, next);
       fsMap.set(path, next);
       emitFsUpdated(path, next);
       emitIndexIfAssetChanged(path);
-      await persistMutation(path, next);
       return { path };
     },
     listDir(dir: string) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { stat } from 'node:fs/promises';
+import path_module from 'node:path';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -74,8 +75,14 @@ import { resolveActiveModel } from './provider-settings';
 import { cleanupStaleTmps } from './reported-fingerprints';
 import { resolveActiveApiKey, resolveApiKeyWithKeylessFallback } from './resolve-api-key';
 import { withRun } from './runContext';
-import { pruneDiagnosticEvents, recordDiagnosticEvent, safeInitSnapshotsDb } from './snapshots-db';
-import { registerSnapshotsIpc, registerSnapshotsUnavailableIpc } from './snapshots-ipc';
+import {
+  getDesign,
+  pruneDiagnosticEvents,
+  recordDiagnosticEvent,
+  safeInitSnapshotsDb,
+  upsertDesignFile,
+} from './snapshots-db';
+import { registerSnapshotsIpc, registerSnapshotsUnavailableIpc, registerWorkspaceIpc } from './snapshots-ipc';
 import { initStorageSettings } from './storage-settings';
 
 // ESM shim: package.json "type": "module" means the built bundle is ESM and
@@ -114,6 +121,8 @@ const USE_AGENT_RUNTIME = (() => {
   if (raw === '0' || raw === 'false') return false;
   return true;
 })();
+
+const IS_VITEST = process.env['VITEST'] === 'true';
 
 function createWindow(): void {
   mainWindow = new BrowserWindow({
@@ -257,6 +266,122 @@ function allocateAssetPath(
   return path;
 }
 
+interface CreateRuntimeTextEditorFsOptions {
+  db: BetterSqlite3.Database | null;
+  generationId: string;
+  designId: string | null;
+  previousHtml: string | null;
+  sendEvent: (event: AgentStreamEvent) => void;
+  logger: Pick<CoreLogger, 'error'>;
+}
+
+export function createRuntimeTextEditorFs({
+  db,
+  generationId,
+  designId,
+  previousHtml,
+  sendEvent,
+  logger,
+}: CreateRuntimeTextEditorFsOptions) {
+  const baseCtx = { designId: designId ?? '', generationId } as const;
+  const fsMap = new Map<string, string>();
+  if (previousHtml && previousHtml.trim().length > 0) {
+    fsMap.set('index.html', previousHtml);
+  }
+  for (const [name, content] of FRAME_TEMPLATES) {
+    fsMap.set(`frames/${name}`, content);
+  }
+  for (const [name, content] of DESIGN_SKILLS) {
+    fsMap.set(`skills/${name}`, content);
+  }
+
+  function emitFsUpdated(filePath: string, content: string): void {
+    if (designId === null) return;
+    const resolved = filePath === 'index.html' ? resolveLocalAssetRefs(content, fsMap) : content;
+    sendEvent({ ...baseCtx, type: 'fs_updated', path: filePath, content: resolved });
+  }
+
+  function emitIndexIfAssetChanged(filePath: string): void {
+    if (!filePath.startsWith('assets/')) return;
+    const index = fsMap.get('index.html');
+    if (index !== undefined) emitFsUpdated('index.html', index);
+  }
+
+  function persistMutation(filePath: string, content: string): void {
+    if (designId === null || db === null) return;
+    upsertDesignFile(db, designId, filePath, content);
+    const design = getDesign(db, designId);
+    if (design === null || design.workspacePath === null) return;
+    const destinationPath = path_module.join(design.workspacePath, filePath);
+    try {
+      mkdirSync(path_module.dirname(destinationPath), { recursive: true });
+      writeFileSync(destinationPath, content, 'utf8');
+    } catch (err) {
+      logger.error('runtime.fs.writeThrough.fail', {
+        designId,
+        filePath,
+        workspacePath: design.workspacePath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const fs = {
+    view(path: string) {
+      const content = fsMap.get(path);
+      if (content === undefined) return null;
+      return { content, numLines: content.split('\n').length };
+    },
+    create(path: string, content: string) {
+      fsMap.set(path, content);
+      emitFsUpdated(path, content);
+      emitIndexIfAssetChanged(path);
+      persistMutation(path, content);
+      return { path };
+    },
+    strReplace(path: string, oldStr: string, newStr: string) {
+      const current = fsMap.get(path);
+      if (current === undefined) throw new Error(`File not found: ${path}`);
+      const idx = current.indexOf(oldStr);
+      if (idx === -1) throw new Error(`old_str not found in ${path}`);
+      if (current.indexOf(oldStr, idx + oldStr.length) !== -1) {
+        throw new Error(`old_str is ambiguous in ${path}; provide more context`);
+      }
+      const next = current.slice(0, idx) + newStr + current.slice(idx + oldStr.length);
+      fsMap.set(path, next);
+      emitFsUpdated(path, next);
+      emitIndexIfAssetChanged(path);
+      persistMutation(path, next);
+      return { path };
+    },
+    insert(path: string, line: number, text: string) {
+      const current = fsMap.get(path) ?? '';
+      const lines = current.split('\n');
+      const clamped = Math.max(0, Math.min(line, lines.length));
+      lines.splice(clamped, 0, text);
+      const next = lines.join('\n');
+      fsMap.set(path, next);
+      emitFsUpdated(path, next);
+      emitIndexIfAssetChanged(path);
+      persistMutation(path, next);
+      return { path };
+    },
+    listDir(dir: string) {
+      const prefix = dir.length === 0 || dir === '.' ? '' : `${dir.replace(/\/+$/, '')}/`;
+      const entries = new Set<string>();
+      for (const p of fsMap.keys()) {
+        if (!p.startsWith(prefix)) continue;
+        const rest = p.slice(prefix.length);
+        const firstSegment = rest.split('/')[0];
+        if (firstSegment) entries.add(firstSegment);
+      }
+      return [...entries].sort();
+    },
+  };
+
+  return { fs, fsMap };
+}
+
 function registerIpcHandlers(db: Database | null): void {
   const logIpc = getLogger('main:ipc');
 
@@ -366,14 +491,14 @@ function registerIpcHandlers(db: Database | null): void {
     const baseCtx = { designId: designId ?? '', generationId: id } as const;
     const toolStartedAt = new Map<string, number>();
     const runtimeVerify = makeRuntimeVerifier();
-
-    // In-memory virtual FS for the text_editor tool. Scoped to this
-    // generation — fresh Map per run. Seeded with the design's current
-    // HTML under index.html so the agent can view/edit incrementally.
-    const fsMap = new Map<string, string>();
-    if (previousHtml && previousHtml.trim().length > 0) {
-      fsMap.set('index.html', previousHtml);
-    }
+    const { fs, fsMap } = createRuntimeTextEditorFs({
+      db,
+      designId,
+      generationId: id,
+      logger: logIpc,
+      previousHtml,
+      sendEvent,
+    });
     const cfg = getCachedConfig();
     const imageConfig = cfg ? resolveImageGenerationConfig(cfg) : null;
     const imageLog = getLogger('image-generation');
@@ -431,84 +556,6 @@ function registerIpcHandlers(db: Database | null): void {
           }
         }
       : undefined;
-    // Seed the virtual fs with optional device-frame starter templates. The
-    // agent decides whether to view/use them based on the brief — there is
-    // no keyword detection here. See packages/core/src/frames/README.md.
-    for (const [name, content] of FRAME_TEMPLATES) {
-      fsMap.set(`frames/${name}`, content);
-    }
-    // Same shape for design-skill snippets — `view skills/<name>.md` to learn
-    // a reusable pattern, then adapt. Pure progressive disclosure: model
-    // decides, no keyword router. See packages/core/src/design-skills/.
-    for (const [name, content] of DESIGN_SKILLS) {
-      fsMap.set(`skills/${name}`, content);
-    }
-    const fs = {
-      view(path: string) {
-        const content = fsMap.get(path);
-        if (content === undefined) return null;
-        return { content, numLines: content.split('\n').length };
-      },
-      create(path: string, content: string) {
-        fsMap.set(path, content);
-        emitFsUpdated(path, content);
-        emitIndexIfAssetChanged(path);
-        return { path };
-      },
-      strReplace(path: string, oldStr: string, newStr: string) {
-        const current = fsMap.get(path);
-        if (current === undefined) throw new Error(`File not found: ${path}`);
-        const idx = current.indexOf(oldStr);
-        if (idx === -1) throw new Error(`old_str not found in ${path}`);
-        if (current.indexOf(oldStr, idx + oldStr.length) !== -1) {
-          throw new Error(`old_str is ambiguous in ${path}; provide more context`);
-        }
-        const next = current.slice(0, idx) + newStr + current.slice(idx + oldStr.length);
-        fsMap.set(path, next);
-        emitFsUpdated(path, next);
-        emitIndexIfAssetChanged(path);
-        return { path };
-      },
-      insert(path: string, line: number, text: string) {
-        const current = fsMap.get(path) ?? '';
-        const lines = current.split('\n');
-        const clamped = Math.max(0, Math.min(line, lines.length));
-        lines.splice(clamped, 0, text);
-        const next = lines.join('\n');
-        fsMap.set(path, next);
-        emitFsUpdated(path, next);
-        emitIndexIfAssetChanged(path);
-        return { path };
-      },
-      listDir(dir: string) {
-        const prefix = dir.length === 0 || dir === '.' ? '' : `${dir.replace(/\/+$/, '')}/`;
-        const entries = new Set<string>();
-        for (const p of fsMap.keys()) {
-          if (!p.startsWith(prefix)) continue;
-          const rest = p.slice(prefix.length);
-          const firstSegment = rest.split('/')[0];
-          if (firstSegment) entries.add(firstSegment);
-        }
-        return [...entries].sort();
-      },
-    };
-
-    // Fan virtual-fs writes to the renderer so the iframe can re-render the
-    // artifact in near real time. Routed through the existing agent:event:v1
-    // channel as a `fs_updated` variant — single-channel keeps ordering with
-    // tool_call_start/end. Skip emission when the run isn't tied to a design
-    // (no preview pane to update).
-    function emitFsUpdated(path: string, content: string): void {
-      if (designId === null) return;
-      const resolved = path === 'index.html' ? resolveLocalAssetRefs(content, fsMap) : content;
-      sendEvent({ ...baseCtx, type: 'fs_updated', path, content: resolved });
-    }
-
-    function emitIndexIfAssetChanged(path: string): void {
-      if (!path.startsWith('assets/')) return;
-      const index = fsMap.get('index.html');
-      if (index !== undefined) emitFsUpdated('index.html', index);
-    }
 
     // Per-turn counters so we can emit a single summary line at turn_end
     // instead of a log per token delta.
@@ -1186,7 +1233,8 @@ async function scheduleStartupUpdateCheck(): Promise<void> {
   }, 30_000);
 }
 
-void app.whenReady().then(async () => {
+if (!IS_VITEST) {
+  void app.whenReady().then(async () => {
   // Extracted so the outer try/catch AND post-init listeners (whose callbacks
   // fire outside this block) can route failures through the same boot-fallback
   // path. Without this, a later createWindow() throw from app.on('activate')
@@ -1262,6 +1310,7 @@ void app.whenReady().then(async () => {
     const diagnosticsDb: Database | null = dbResult.ok ? dbResult.db : null;
     if (dbResult.ok) {
       registerSnapshotsIpc(dbResult.db);
+      registerWorkspaceIpc(dbResult.db, () => mainWindow);
       registerChatMessagesIpc(dbResult.db);
       registerCommentsIpc(dbResult.db);
       try {
@@ -1323,8 +1372,9 @@ void app.whenReady().then(async () => {
     );
     app.quit();
   }
-});
+  });
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit();
+  });
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { stat } from 'node:fs/promises';
+import { mkdirSync } from 'node:fs';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import path_module from 'node:path';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -311,15 +311,15 @@ export function createRuntimeTextEditorFs({
     if (index !== undefined) emitFsUpdated('index.html', index);
   }
 
-  function persistMutation(filePath: string, content: string): void {
+  async function persistMutation(filePath: string, content: string): Promise<void> {
     if (designId === null || db === null) return;
     const persisted = upsertDesignFile(db, designId, filePath, content);
     const design = getDesign(db, designId);
     if (design === null || design.workspacePath === null) return;
     const destinationPath = path_module.join(design.workspacePath, persisted.path);
     try {
-      mkdirSync(path_module.dirname(destinationPath), { recursive: true });
-      writeFileSync(destinationPath, content, 'utf8');
+      await mkdir(path_module.dirname(destinationPath), { recursive: true });
+      await writeFile(destinationPath, content, 'utf8');
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error('runtime.fs.writeThrough.fail', {
@@ -338,14 +338,14 @@ export function createRuntimeTextEditorFs({
       if (content === undefined) return null;
       return { content, numLines: content.split('\n').length };
     },
-    create(path: string, content: string) {
+    async create(path: string, content: string) {
       fsMap.set(path, content);
       emitFsUpdated(path, content);
       emitIndexIfAssetChanged(path);
-      persistMutation(path, content);
+      await persistMutation(path, content);
       return { path };
     },
-    strReplace(path: string, oldStr: string, newStr: string) {
+    async strReplace(path: string, oldStr: string, newStr: string) {
       const current = fsMap.get(path);
       if (current === undefined) throw new Error(`File not found: ${path}`);
       const idx = current.indexOf(oldStr);
@@ -357,10 +357,10 @@ export function createRuntimeTextEditorFs({
       fsMap.set(path, next);
       emitFsUpdated(path, next);
       emitIndexIfAssetChanged(path);
-      persistMutation(path, next);
+      await persistMutation(path, next);
       return { path };
     },
-    insert(path: string, line: number, text: string) {
+    async insert(path: string, line: number, text: string) {
       const current = fsMap.get(path) ?? '';
       const lines = current.split('\n');
       const clamped = Math.max(0, Math.min(line, lines.length));
@@ -369,7 +369,7 @@ export function createRuntimeTextEditorFs({
       fsMap.set(path, next);
       emitFsUpdated(path, next);
       emitIndexIfAssetChanged(path);
-      persistMutation(path, next);
+      await persistMutation(path, next);
       return { path };
     },
     listDir(dir: string) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -77,6 +77,7 @@ import { resolveActiveApiKey, resolveApiKeyWithKeylessFallback } from './resolve
 import { withRun } from './runContext';
 import {
   getDesign,
+  normalizeDesignFilePath,
   pruneDiagnosticEvents,
   recordDiagnosticEvent,
   safeInitSnapshotsDb,
@@ -313,23 +314,26 @@ export function createRuntimeTextEditorFs({
 
   async function persistMutation(filePath: string, content: string): Promise<void> {
     if (designId === null || db === null) return;
-    const persisted = upsertDesignFile(db, designId, filePath, content);
+    const normalizedPath = normalizeDesignFilePath(filePath);
     const design = getDesign(db, designId);
-    if (design === null || design.workspacePath === null) return;
-    const destinationPath = path_module.join(design.workspacePath, persisted.path);
-    try {
-      await mkdir(path_module.dirname(destinationPath), { recursive: true });
-      await writeFile(destinationPath, content, 'utf8');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error('runtime.fs.writeThrough.fail', {
-        designId,
-        filePath,
-        workspacePath: design.workspacePath,
-        message,
-      });
-      throw new Error(`Workspace write-through failed for ${filePath}: ${message}`);
+    if (design?.workspacePath !== null && design !== null) {
+      const destinationPath = path_module.join(design.workspacePath, normalizedPath);
+      try {
+        await mkdir(path_module.dirname(destinationPath), { recursive: true });
+        await writeFile(destinationPath, content, 'utf8');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error('runtime.fs.writeThrough.fail', {
+          designId,
+          filePath,
+          workspacePath: design.workspacePath,
+          message,
+        });
+        throw new Error(`Workspace write-through failed for ${filePath}: ${message}`);
+      }
     }
+
+    upsertDesignFile(db, designId, normalizedPath, content);
   }
 
   const fs = {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -321,12 +321,14 @@ export function createRuntimeTextEditorFs({
       mkdirSync(path_module.dirname(destinationPath), { recursive: true });
       writeFileSync(destinationPath, content, 'utf8');
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       logger.error('runtime.fs.writeThrough.fail', {
         designId,
         filePath,
         workspacePath: design.workspacePath,
-        message: err instanceof Error ? err.message : String(err),
+        message,
       });
+      throw new Error(`Workspace write-through failed for ${filePath}: ${message}`);
     }
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -82,7 +82,11 @@ import {
   safeInitSnapshotsDb,
   upsertDesignFile,
 } from './snapshots-db';
-import { registerSnapshotsIpc, registerSnapshotsUnavailableIpc, registerWorkspaceIpc } from './snapshots-ipc';
+import {
+  registerSnapshotsIpc,
+  registerSnapshotsUnavailableIpc,
+  registerWorkspaceIpc,
+} from './snapshots-ipc';
 import { initStorageSettings } from './storage-settings';
 
 // ESM shim: package.json "type": "module" means the built bundle is ESM and
@@ -1235,143 +1239,136 @@ async function scheduleStartupUpdateCheck(): Promise<void> {
 
 if (!IS_VITEST) {
   void app.whenReady().then(async () => {
-  // Extracted so the outer try/catch AND post-init listeners (whose callbacks
-  // fire outside this block) can route failures through the same boot-fallback
-  // path. Without this, a later createWindow() throw from app.on('activate')
-  // would bypass writeBootErrorSync and leave the user with nothing to attach.
-  const handleBootFailure = (err: unknown, title: string, message: string): void => {
-    let logsDir: string;
-    try {
-      logsDir = app.getPath('logs');
-    } catch {
-      logsDir = app.getPath('temp');
-    }
-    const bootLogPath = writeBootErrorSync({
-      error: err,
-      logsDir,
-      appVersion: app.getVersion(),
-      platform: process.platform,
-      electronVersion: process.versions.electron ?? 'unknown',
-      nodeVersion: process.versions.node,
-    });
-    const choice = showBootDialog(app, dialog, {
-      type: 'error',
-      title,
-      message,
-      detail: `Error: ${err instanceof Error ? err.message : String(err)}\n\nDiagnostic log: ${bootLogPath}`,
-      buttons: ['Copy diagnostic path', 'Open log folder', 'Quit'],
-      defaultId: 2,
-      cancelId: 2,
-    });
-    if (choice === 0) clipboard.writeText(bootLogPath);
-    if (choice === 1) shell.showItemInFolder(bootLogPath);
-  };
-
-  try {
-    initLogger();
-    // Single-instance lock. Two simultaneous Electron instances would race
-    // `cleanupStaleTmps` vs `writeAtomic` (B's cleanup unlinks A's in-flight
-    // tmp → ENOENT rename) and collide on the SQLite WAL. macOS usually
-    // enforces this at the OS level, but `open -n` defeats that — so we
-    // acquire the lock explicitly before touching any shared files.
-    const gotLock = app.requestSingleInstanceLock();
-    if (!gotLock) {
-      app.quit();
-      return;
-    }
-    app.on('second-instance', () => {
-      if (mainWindow) {
-        if (mainWindow.isMinimized()) mainWindow.restore();
-        mainWindow.focus();
-      }
-    });
-    // Show a blocking dialog if the user launched from the DMG mount. If
-    // they accept the remedy, we quit here before touching safeStorage / the
-    // snapshots DB so nothing half-initialises against a bad install.
-    const aborted = await maybeAbortIfRunningFromDmg();
-    if (aborted) return;
-    await loadConfigOnBoot();
-    // One-shot migration for feat-branch testers whose config.toml still
-    // carries Phase 1's stale codex wire/baseUrl. No-op on fresh installs
-    // and for everyone else. A failure here means the config file itself
-    // is unwritable (disk full, permissions, etc.) — let it bubble up to
-    // the outer boot-error dialog rather than silently hiding it, so the
-    // user sees the diagnostic instead of a mysteriously broken codex flow.
-    await migrateStaleCodexEntryIfNeeded();
-    // Best-effort sweep of leftover `<file>.tmp.<pid>` siblings from previous
-    // crashes. pid changes across restarts so without this the config dir
-    // accumulates 0o600 litter forever.
-    cleanupStaleTmps(join(configDir(), 'reported-fingerprints.json'));
-    // Snapshot persistence is best-effort at boot — a failure here (corrupt DB,
-    // permission denied, missing native binding) must NOT block the BrowserWindow
-    // from opening. Surface it via an error dialog and skip registering the
-    // snapshots IPC channels; the rest of the app stays usable.
-    const dbResult = safeInitSnapshotsDb(join(app.getPath('userData'), 'designs.db'));
-    const diagnosticsDb: Database | null = dbResult.ok ? dbResult.db : null;
-    if (dbResult.ok) {
-      registerSnapshotsIpc(dbResult.db);
-      registerWorkspaceIpc(dbResult.db, () => mainWindow);
-      registerChatMessagesIpc(dbResult.db);
-      registerCommentsIpc(dbResult.db);
+    // Extracted so the outer try/catch AND post-init listeners (whose callbacks
+    // fire outside this block) can route failures through the same boot-fallback
+    // path. Without this, a later createWindow() throw from app.on('activate')
+    // would bypass writeBootErrorSync and leave the user with nothing to attach.
+    const handleBootFailure = (err: unknown, title: string, message: string): void => {
+      let logsDir: string;
       try {
-        pruneDiagnosticEvents(dbResult.db, 500);
-      } catch (err) {
-        getLogger('main:boot').warn('diagnosticEvents.prune.fail', {
-          message: err instanceof Error ? err.message : String(err),
-        });
+        logsDir = app.getPath('logs');
+      } catch {
+        logsDir = app.getPath('temp');
       }
-    } else {
-      const bootLog = getLogger('main:boot');
-      bootLog.error('snapshotsDb.init.fail', {
-        message: dbResult.error.message,
-        stack: dbResult.error.stack,
+      const bootLogPath = writeBootErrorSync({
+        error: err,
+        logsDir,
+        appVersion: app.getVersion(),
+        platform: process.platform,
+        electronVersion: process.versions.electron ?? 'unknown',
+        nodeVersion: process.versions.node,
       });
-      // Install stub handlers so renderer-side calls reject with a typed
-      // SNAPSHOTS_UNAVAILABLE CodesignError instead of Electron's opaque
-      // "No handler registered" rejection — see snapshots-ipc.ts.
-      registerSnapshotsUnavailableIpc(dbResult.error.message);
-      registerChatMessagesUnavailableIpc(dbResult.error.message);
-      registerCommentsUnavailableIpc(dbResult.error.message);
-      dialog.showErrorBox(
-        'Design history unavailable',
-        `Could not open the local snapshots database. Version history will be disabled for this session.\n\n${dbResult.error.message}`,
-      );
-    }
-    registerIpcHandlers(diagnosticsDb);
-    registerLocaleIpc();
-    registerConnectionIpc();
-    registerOnboardingIpc();
-    registerCodexOAuthIpc();
-    registerPreferencesIpc();
-    registerImageGenerationSettingsIpc();
-    registerExporterIpc(() => mainWindow);
-    registerDiagnosticsIpc(diagnosticsDb);
-    setupAutoUpdater();
-    registerAppMenu();
-    createWindow();
-    void scheduleStartupUpdateCheck();
+      const choice = showBootDialog(app, dialog, {
+        type: 'error',
+        title,
+        message,
+        detail: `Error: ${err instanceof Error ? err.message : String(err)}\n\nDiagnostic log: ${bootLogPath}`,
+        buttons: ['Copy diagnostic path', 'Open log folder', 'Quit'],
+        defaultId: 2,
+        cancelId: 2,
+      });
+      if (choice === 0) clipboard.writeText(bootLogPath);
+      if (choice === 1) shell.showItemInFolder(bootLogPath);
+    };
 
-    app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        try {
-          createWindow();
-        } catch (err) {
-          handleBootFailure(err, 'Cannot reopen window', 'Window failed to open.');
-        }
+    try {
+      initLogger();
+      // Single-instance lock. Two simultaneous Electron instances would race
+      // `cleanupStaleTmps` vs `writeAtomic` (B's cleanup unlinks A's in-flight
+      // tmp → ENOENT rename) and collide on the SQLite WAL. macOS usually
+      // enforces this at the OS level, but `open -n` defeats that — so we
+      // acquire the lock explicitly before touching any shared files.
+      const gotLock = app.requestSingleInstanceLock();
+      if (!gotLock) {
+        app.quit();
+        return;
       }
-    });
-  } catch (err) {
-    // Last-resort boot-phase handler. Reached when something before
-    // `initLogger()` finishes (or during the first few setup calls)
-    // throws — our electron-log sink might not exist yet, so write a
-    // best-effort sync log and show a native three-button dialog.
-    handleBootFailure(
-      err,
-      'Open CoDesign failed to start',
-      'A startup error prevented the app from loading.',
-    );
-    app.quit();
-  }
+      app.on('second-instance', () => {
+        if (mainWindow) {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          mainWindow.focus();
+        }
+      });
+      // Show a blocking dialog if the user launched from the DMG mount. If
+      // they accept the remedy, we quit here before touching safeStorage / the
+      // snapshots DB so nothing half-initialises against a bad install.
+      const aborted = await maybeAbortIfRunningFromDmg();
+      if (aborted) return;
+      await loadConfigOnBoot();
+      // Best-effort sweep of leftover `<file>.tmp.<pid>` siblings from previous
+      // crashes. pid changes across restarts so without this the config dir
+      // accumulates 0o600 litter forever.
+      cleanupStaleTmps(join(configDir(), 'reported-fingerprints.json'));
+      // Snapshot persistence is best-effort at boot — a failure here (corrupt DB,
+      // permission denied, missing native binding) must NOT block the BrowserWindow
+      // from opening. Surface it via an error dialog and skip registering the
+      // snapshots IPC channels; the rest of the app stays usable.
+      const dbResult = safeInitSnapshotsDb(join(app.getPath('userData'), 'designs.db'));
+      const diagnosticsDb: Database | null = dbResult.ok ? dbResult.db : null;
+      if (dbResult.ok) {
+        registerSnapshotsIpc(dbResult.db);
+        registerWorkspaceIpc(dbResult.db, () => mainWindow);
+        registerChatMessagesIpc(dbResult.db);
+        registerCommentsIpc(dbResult.db);
+        try {
+          pruneDiagnosticEvents(dbResult.db, 500);
+        } catch (err) {
+          getLogger('main:boot').warn('diagnosticEvents.prune.fail', {
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } else {
+        const bootLog = getLogger('main:boot');
+        bootLog.error('snapshotsDb.init.fail', {
+          message: dbResult.error.message,
+          stack: dbResult.error.stack,
+        });
+        // Install stub handlers so renderer-side calls reject with a typed
+        // SNAPSHOTS_UNAVAILABLE CodesignError instead of Electron's opaque
+        // "No handler registered" rejection — see snapshots-ipc.ts.
+        registerSnapshotsUnavailableIpc(dbResult.error.message);
+        registerChatMessagesUnavailableIpc(dbResult.error.message);
+        registerCommentsUnavailableIpc(dbResult.error.message);
+        dialog.showErrorBox(
+          'Design history unavailable',
+          `Could not open the local snapshots database. Version history will be disabled for this session.\n\n${dbResult.error.message}`,
+        );
+      }
+      registerIpcHandlers(diagnosticsDb);
+      registerLocaleIpc();
+      registerConnectionIpc();
+      registerOnboardingIpc();
+      registerCodexOAuthIpc();
+      registerPreferencesIpc();
+      registerImageGenerationSettingsIpc();
+      registerExporterIpc(() => mainWindow);
+      registerDiagnosticsIpc(diagnosticsDb);
+      setupAutoUpdater();
+      registerAppMenu();
+      createWindow();
+      void scheduleStartupUpdateCheck();
+
+      app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+          try {
+            createWindow();
+          } catch (err) {
+            handleBootFailure(err, 'Cannot reopen window', 'Window failed to open.');
+          }
+        }
+      });
+    } catch (err) {
+      // Last-resort boot-phase handler. Reached when something before
+      // `initLogger()` finishes (or during the first few setup calls)
+      // throws — our electron-log sink might not exist yet, so write a
+      // best-effort sync log and show a native three-button dialog.
+      handleBootFailure(
+        err,
+        'Open CoDesign failed to start',
+        'A startup error prevented the app from loading.',
+      );
+      app.quit();
+    }
   });
 
   app.on('window-all-closed', () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -313,10 +313,10 @@ export function createRuntimeTextEditorFs({
 
   function persistMutation(filePath: string, content: string): void {
     if (designId === null || db === null) return;
-    upsertDesignFile(db, designId, filePath, content);
+    const persisted = upsertDesignFile(db, designId, filePath, content);
     const design = getDesign(db, designId);
     if (design === null || design.workspacePath === null) return;
-    const destinationPath = path_module.join(design.workspacePath, filePath);
+    const destinationPath = path_module.join(design.workspacePath, persisted.path);
     try {
       mkdirSync(path_module.dirname(destinationPath), { recursive: true });
       writeFileSync(destinationPath, content, 'utf8');

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -90,7 +90,7 @@ describe('createRuntimeTextEditorFs', () => {
     vi.clearAllMocks();
   });
 
-  it('persists fs.create to db without writing disk when workspace is absent', () => {
+  it('persists fs.create to db without writing disk when workspace is absent', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspaceless');
     const sendEvent = vi.fn();
@@ -104,7 +104,7 @@ describe('createRuntimeTextEditorFs', () => {
       sendEvent,
     });
 
-    fs.create('nested/index.html', '<main>created</main>');
+    await fs.create('nested/index.html', '<main>created</main>');
 
     expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
       '<main>created</main>',
@@ -113,7 +113,7 @@ describe('createRuntimeTextEditorFs', () => {
     expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
   });
 
-  it('persists fs.create to db and writes disk when workspace is bound', () => {
+  it('persists fs.create to db and writes disk when workspace is bound', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspace');
     const workspaceDir = makeTempDir('ocd-runtime-create-');
@@ -130,7 +130,7 @@ describe('createRuntimeTextEditorFs', () => {
     });
 
     try {
-      fs.create('nested/index.html', '<main>created</main>');
+      await fs.create('nested/index.html', '<main>created</main>');
 
       const diskPath = path.join(workspaceDir, 'nested/index.html');
       expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
@@ -143,7 +143,7 @@ describe('createRuntimeTextEditorFs', () => {
     }
   });
 
-  it('updates db and disk for fs.strReplace in a bound workspace', () => {
+  it('updates db and disk for fs.strReplace in a bound workspace', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspace');
     const workspaceDir = makeTempDir('ocd-runtime-replace-');
@@ -160,8 +160,8 @@ describe('createRuntimeTextEditorFs', () => {
     });
 
     try {
-      fs.create('index.html', '<main>before</main>');
-      fs.strReplace('index.html', 'before', 'after');
+      await fs.create('index.html', '<main>before</main>');
+      await fs.strReplace('index.html', 'before', 'after');
 
       const events = listFsUpdatedEvents(sendEvent);
       expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>after</main>');
@@ -179,7 +179,7 @@ describe('createRuntimeTextEditorFs', () => {
     }
   });
 
-  it('updates db and disk for fs.insert in a bound workspace', () => {
+  it('updates db and disk for fs.insert in a bound workspace', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspace');
     const workspaceDir = makeTempDir('ocd-runtime-insert-');
@@ -196,8 +196,8 @@ describe('createRuntimeTextEditorFs', () => {
     });
 
     try {
-      fs.create('index.html', '<main>line1</main>');
-      fs.insert('index.html', 1, '<footer>tail</footer>');
+      await fs.create('index.html', '<main>line1</main>');
+      await fs.insert('index.html', 1, '<footer>tail</footer>');
 
       const events = listFsUpdatedEvents(sendEvent);
       expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe(
@@ -217,7 +217,7 @@ describe('createRuntimeTextEditorFs', () => {
     }
   });
 
-  it('skips disk writes for all mutations when workspacePath is null', () => {
+  it('skips disk writes for all mutations when workspacePath is null', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspaceless');
     const workspaceDir = makeTempDir('ocd-runtime-null-workspace-');
@@ -233,11 +233,9 @@ describe('createRuntimeTextEditorFs', () => {
     });
 
     try {
-      expect(() => {
-        fs.create('nested/index.html', '<main>start</main>');
-        fs.strReplace('nested/index.html', 'start', 'middle');
-        fs.insert('nested/index.html', 1, '<footer>end</footer>');
-      }).not.toThrow();
+      await fs.create('nested/index.html', '<main>start</main>');
+      await fs.strReplace('nested/index.html', 'start', 'middle');
+      await fs.insert('nested/index.html', 1, '<footer>end</footer>');
 
       expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
         '<main>middle</main>\n<footer>end</footer>',
@@ -250,7 +248,7 @@ describe('createRuntimeTextEditorFs', () => {
     }
   });
 
-  it('emits fs_updated for anonymous mutations without db persistence', () => {
+  it('emits fs_updated for anonymous mutations without db persistence', async () => {
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
     const { fs } = createRuntimeTextEditorFs({
@@ -262,9 +260,9 @@ describe('createRuntimeTextEditorFs', () => {
       sendEvent,
     });
 
-    fs.create('index.html', '<main>start</main>');
-    fs.strReplace('index.html', 'start', 'middle');
-    fs.insert('index.html', 1, '<footer>end</footer>');
+    await fs.create('index.html', '<main>start</main>');
+    await fs.strReplace('index.html', 'start', 'middle');
+    await fs.insert('index.html', 1, '<footer>end</footer>');
 
     expect(listFsUpdatedEvents(sendEvent)).toHaveLength(0);
     expect(logger.error).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -1,0 +1,259 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AgentStreamEvent } from '../preload/index';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeWorkspacePath } from './design-workspace';
+import {
+  createDesign,
+  initInMemoryDb,
+  updateDesignWorkspace,
+  viewDesignFile,
+} from './snapshots-db';
+
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showErrorBox: vi.fn(),
+  },
+  shell: {
+    openPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    on: vi.fn(),
+    checkForUpdates: vi.fn(),
+  },
+}));
+
+vi.mock('./electron-runtime', () => ({
+  BrowserWindow: class BrowserWindow {},
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'userData') return '/tmp/open-codesign-tests';
+      if (name === 'logs') return '/tmp/open-codesign-tests/logs';
+      if (name === 'temp') return '/tmp';
+      return '/tmp';
+    }),
+    setPath: vi.fn(),
+    whenReady: vi.fn(() => Promise.resolve()),
+    on: vi.fn(),
+    requestSingleInstanceLock: vi.fn(() => true),
+    quit: vi.fn(),
+    getVersion: vi.fn(() => '0.0.0-test'),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showErrorBox: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  shell: {
+    showItemInFolder: vi.fn(),
+    openPath: vi.fn(),
+  },
+}));
+
+vi.mock('./storage-settings', () => ({
+  getActiveStorageLocations: vi.fn(() => ({})),
+  initStorageSettings: vi.fn(() => ({})),
+}));
+
+import { createRuntimeTextEditorFs } from './index';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function listFsUpdatedEvents(sendEvent: ReturnType<typeof vi.fn>): AgentStreamEvent[] {
+  return sendEvent.mock.calls
+    .map(([event]) => event as AgentStreamEvent)
+    .filter((event) => event.type === 'fs_updated');
+}
+
+describe('createRuntimeTextEditorFs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists fs.create to db without writing disk when workspace is absent', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspaceless');
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-create-db-only',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    fs.create('nested/index.html', '<main>created</main>');
+
+    expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe('<main>created</main>');
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
+  });
+
+  it('persists fs.create to db and writes disk when workspace is bound', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-create-');
+    updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-create-workspace',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      fs.create('nested/index.html', '<main>created</main>');
+
+      const diskPath = path.join(workspaceDir, 'nested/index.html');
+      expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe('<main>created</main>');
+      expect(readFileSync(diskPath, 'utf8')).toBe('<main>created</main>');
+      expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('updates db and disk for fs.strReplace in a bound workspace', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-replace-');
+    updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-replace-workspace',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      fs.create('index.html', '<main>before</main>');
+      fs.strReplace('index.html', 'before', 'after');
+
+      const events = listFsUpdatedEvents(sendEvent);
+      expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>after</main>');
+      expect(readFileSync(path.join(workspaceDir, 'index.html'), 'utf8')).toBe('<main>after</main>');
+      expect(events).toHaveLength(2);
+      expect(events.at(-1)).toMatchObject({ type: 'fs_updated', path: 'index.html', content: '<main>after</main>' });
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('updates db and disk for fs.insert in a bound workspace', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-insert-');
+    updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-insert-workspace',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      fs.create('index.html', '<main>line1</main>');
+      fs.insert('index.html', 1, '<footer>tail</footer>');
+
+      const events = listFsUpdatedEvents(sendEvent);
+      expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe(
+        '<main>line1</main>\n<footer>tail</footer>',
+      );
+      expect(readFileSync(path.join(workspaceDir, 'index.html'), 'utf8')).toBe(
+        '<main>line1</main>\n<footer>tail</footer>',
+      );
+      expect(events).toHaveLength(2);
+      expect(events.at(-1)).toMatchObject({
+        type: 'fs_updated',
+        path: 'index.html',
+        content: '<main>line1</main>\n<footer>tail</footer>',
+      });
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('skips disk writes for all mutations when workspacePath is null', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspaceless');
+    const workspaceDir = makeTempDir('ocd-runtime-null-workspace-');
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-null-workspace',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      expect(() => {
+        fs.create('nested/index.html', '<main>start</main>');
+        fs.strReplace('nested/index.html', 'start', 'middle');
+        fs.insert('nested/index.html', 1, '<footer>end</footer>');
+      }).not.toThrow();
+
+      expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
+        '<main>middle</main>\n<footer>end</footer>',
+      );
+      expect(existsSync(path.join(workspaceDir, 'nested/index.html'))).toBe(false);
+      expect(listFsUpdatedEvents(sendEvent)).toHaveLength(3);
+      expect(logger.error).not.toHaveBeenCalled();
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('emits fs_updated for anonymous mutations without db persistence', () => {
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db: initInMemoryDb(),
+      designId: null,
+      generationId: 'gen-anon',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    fs.create('index.html', '<main>start</main>');
+    fs.strReplace('index.html', 'start', 'middle');
+    fs.insert('index.html', 1, '<footer>end</footer>');
+
+    expect(listFsUpdatedEvents(sendEvent)).toHaveLength(0);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -167,6 +167,8 @@ describe('createRuntimeTextEditorFs', () => {
       );
 
       expect(viewDesignFile(db, design.id, 'nested/index.html')).toBeNull();
+      expect(fs.view('nested/index.html')).toBeNull();
+      expect(listFsUpdatedEvents(sendEvent)).toHaveLength(0);
       expect(logger.error).toHaveBeenCalled();
     } finally {
       cleanupDir(workspaceDir);
@@ -235,6 +237,42 @@ describe('createRuntimeTextEditorFs', () => {
       );
 
       expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>before</main>');
+      expect(fs.view('index.html')?.content).toBe('<main>before</main>');
+      expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
+      expect(logger.error).toHaveBeenCalled();
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('does not advance db content when bound workspace insert write-through fails', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-insert-fail-');
+    const workspaceFile = path.join(workspaceDir, 'occupied');
+    writeFileSync(workspaceFile, 'occupied', 'utf8');
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-insert-workspace-fail',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      await fs.create('index.html', '<main>before</main>');
+      updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceFile));
+
+      await expect(fs.insert('index.html', 1, '<footer>after</footer>')).rejects.toThrow(
+        'Workspace write-through failed for index.html',
+      );
+
+      expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>before</main>');
+      expect(fs.view('index.html')?.content).toBe('<main>before</main>');
+      expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
       expect(logger.error).toHaveBeenCalled();
     } finally {
       cleanupDir(workspaceDir);

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { existsSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -143,6 +143,36 @@ describe('createRuntimeTextEditorFs', () => {
     }
   });
 
+  it('does not create a db row when bound workspace write-through fails', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-create-fail-');
+    const workspaceFile = path.join(workspaceDir, 'occupied');
+    writeFileSync(workspaceFile, 'occupied', 'utf8');
+    updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceFile));
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-create-workspace-fail',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      await expect(fs.create('nested/index.html', '<main>created</main>')).rejects.toThrow(
+        'Workspace write-through failed for nested/index.html',
+      );
+
+      expect(viewDesignFile(db, design.id, 'nested/index.html')).toBeNull();
+      expect(logger.error).toHaveBeenCalled();
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
   it('updates db and disk for fs.strReplace in a bound workspace', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Workspace');
@@ -174,6 +204,38 @@ describe('createRuntimeTextEditorFs', () => {
         path: 'index.html',
         content: '<main>after</main>',
       });
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('does not advance db content when bound workspace strReplace write-through fails', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Workspace');
+    const workspaceDir = makeTempDir('ocd-runtime-replace-fail-');
+    const workspaceFile = path.join(workspaceDir, 'occupied');
+    writeFileSync(workspaceFile, 'occupied', 'utf8');
+    const sendEvent = vi.fn();
+    const logger = { error: vi.fn() };
+    const { fs } = createRuntimeTextEditorFs({
+      db,
+      designId: design.id,
+      generationId: 'gen-replace-workspace-fail',
+      logger,
+      previousHtml: null,
+      sendEvent,
+    });
+
+    try {
+      await fs.create('index.html', '<main>before</main>');
+      updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceFile));
+
+      await expect(fs.strReplace('index.html', 'before', 'after')).rejects.toThrow(
+        'Workspace write-through failed for index.html',
+      );
+
+      expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>before</main>');
+      expect(logger.error).toHaveBeenCalled();
     } finally {
       cleanupDir(workspaceDir);
     }

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -2,8 +2,8 @@ import { mkdtempSync, readFileSync } from 'node:fs';
 import { existsSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { AgentStreamEvent } from '../preload/index';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentStreamEvent } from '../preload/index';
 import { normalizeWorkspacePath } from './design-workspace';
 import {
   createDesign,
@@ -29,8 +29,11 @@ vi.mock('electron-updater', () => ({
   },
 }));
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function BrowserWindowMock() {}
+
 vi.mock('./electron-runtime', () => ({
-  BrowserWindow: class BrowserWindow {},
+  BrowserWindow: BrowserWindowMock,
   app: {
     getPath: vi.fn((name: string) => {
       if (name === 'userData') return '/tmp/open-codesign-tests';
@@ -103,7 +106,9 @@ describe('createRuntimeTextEditorFs', () => {
 
     fs.create('nested/index.html', '<main>created</main>');
 
-    expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe('<main>created</main>');
+    expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
+      '<main>created</main>',
+    );
     expect(logger.error).not.toHaveBeenCalled();
     expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
   });
@@ -128,7 +133,9 @@ describe('createRuntimeTextEditorFs', () => {
       fs.create('nested/index.html', '<main>created</main>');
 
       const diskPath = path.join(workspaceDir, 'nested/index.html');
-      expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe('<main>created</main>');
+      expect(viewDesignFile(db, design.id, 'nested/index.html')?.content).toBe(
+        '<main>created</main>',
+      );
       expect(readFileSync(diskPath, 'utf8')).toBe('<main>created</main>');
       expect(listFsUpdatedEvents(sendEvent)).toHaveLength(1);
     } finally {
@@ -158,9 +165,15 @@ describe('createRuntimeTextEditorFs', () => {
 
       const events = listFsUpdatedEvents(sendEvent);
       expect(viewDesignFile(db, design.id, 'index.html')?.content).toBe('<main>after</main>');
-      expect(readFileSync(path.join(workspaceDir, 'index.html'), 'utf8')).toBe('<main>after</main>');
+      expect(readFileSync(path.join(workspaceDir, 'index.html'), 'utf8')).toBe(
+        '<main>after</main>',
+      );
       expect(events).toHaveLength(2);
-      expect(events.at(-1)).toMatchObject({ type: 'fs_updated', path: 'index.html', content: '<main>after</main>' });
+      expect(events.at(-1)).toMatchObject({
+        type: 'fs_updated',
+        path: 'index.html',
+        content: '<main>after</main>',
+      });
     } finally {
       cleanupDir(workspaceDir);
     }

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   appendChatMessage,
+  clearDesignWorkspace,
   createDesign,
   createSnapshot,
   deleteSnapshot,
@@ -21,6 +22,7 @@ import {
   setDesignThumbnail,
   softDeleteDesign,
   updateChatToolCallStatus,
+  updateDesignWorkspace,
 } from './snapshots-db';
 
 function makeDb() {
@@ -432,6 +434,137 @@ describe('duplicateDesign', () => {
     // Cloned snapshots survive the source deletion because they belong to a
     // different design row.
     expect(listSnapshots(db, cloned?.id ?? '')).toHaveLength(1);
+  });
+});
+
+describe('updateDesignWorkspace', () => {
+  it('sets the workspace_path and bumps updated_at', () => {
+    const db = makeDb();
+    const d = createDesign(db, 'My design');
+    const originalUpdatedAt = d.updatedAt;
+
+    const updated = updateDesignWorkspace(db, d.id, '/path/to/workspace');
+    expect(updated).not.toBeNull();
+    expect(updated?.workspacePath).toBe('/path/to/workspace');
+    expect(updated?.updatedAt).toBeTruthy();
+    expect(new Date(updated?.updatedAt ?? '').getTime()).toBeGreaterThanOrEqual(
+      new Date(originalUpdatedAt).getTime(),
+    );
+  });
+
+  it('returns null when the design is missing', () => {
+    const db = makeDb();
+    expect(updateDesignWorkspace(db, 'missing', '/path')).toBeNull();
+  });
+
+  it('overwrites an existing workspace_path', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    updateDesignWorkspace(db, d.id, '/old/path');
+    const updated = updateDesignWorkspace(db, d.id, '/new/path');
+    expect(updated?.workspacePath).toBe('/new/path');
+  });
+});
+
+describe('clearDesignWorkspace', () => {
+  it('sets workspace_path to NULL and bumps updated_at', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    updateDesignWorkspace(db, d.id, '/path/to/workspace');
+    const originalUpdatedAt = d.updatedAt;
+
+    const cleared = clearDesignWorkspace(db, d.id);
+    expect(cleared).not.toBeNull();
+    expect(cleared?.workspacePath).toBeNull();
+    expect(cleared?.updatedAt).toBeTruthy();
+    expect(new Date(cleared?.updatedAt ?? '').getTime()).toBeGreaterThanOrEqual(
+      new Date(originalUpdatedAt).getTime(),
+    );
+  });
+
+  it('returns null when the design is missing', () => {
+    const db = makeDb();
+    expect(clearDesignWorkspace(db, 'missing')).toBeNull();
+  });
+
+  it('is idempotent — clearing an already-null workspace_path works', () => {
+    const db = makeDb();
+    const d = createDesign(db);
+    // workspace_path is NULL by default
+    const cleared1 = clearDesignWorkspace(db, d.id);
+    expect(cleared1?.workspacePath).toBeNull();
+    const cleared2 = clearDesignWorkspace(db, d.id);
+    expect(cleared2?.workspacePath).toBeNull();
+  });
+});
+
+describe('duplicateDesign workspace_path semantics', () => {
+  it('copies a design with workspace_path set, but cloned design has workspace_path = NULL', () => {
+    const db = makeDb();
+    const source = createDesign(db, 'Source with workspace');
+    updateDesignWorkspace(db, source.id, '/path/to/workspace');
+
+    const sourceReloaded = getDesign(db, source.id);
+    expect(sourceReloaded?.workspacePath).toBe('/path/to/workspace');
+
+    const cloned = duplicateDesign(db, source.id, 'Cloned');
+    expect(cloned).not.toBeNull();
+    expect(cloned?.workspacePath).toBeNull();
+
+    // Source remains unchanged
+    expect(getDesign(db, source.id)?.workspacePath).toBe('/path/to/workspace');
+  });
+
+  it('clones a design with workspace_path = NULL, result also has NULL', () => {
+    const db = makeDb();
+    const source = createDesign(db, 'Source without workspace');
+    expect(source.workspacePath).toBeNull();
+
+    const cloned = duplicateDesign(db, source.id, 'Cloned');
+    expect(cloned?.workspacePath).toBeNull();
+  });
+});
+
+describe('migration idempotency for workspace_path', () => {
+  it('workspace_path column exists after first init', () => {
+    const db = makeDb();
+    type ColumnInfo = { name: string };
+    const cols = (db.prepare('PRAGMA table_info(designs)').all() as ColumnInfo[]).map(
+      (c) => c.name,
+    );
+    expect(cols).toContain('workspace_path');
+  });
+
+  it('legacy rows read as workspacePath: null after migration', () => {
+    const db = makeDb();
+    // Insert a row directly without workspace_path (simulating pre-migration data)
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    ).run(id, 'Legacy design', now, now);
+
+    const design = getDesign(db, id);
+    expect(design?.workspacePath).toBeNull();
+  });
+
+  it('re-applying migrations does not fail or lose data', () => {
+    const db = makeDb();
+    const d = createDesign(db, 'persist me');
+    updateDesignWorkspace(db, d.id, '/workspace/path');
+
+    // Simulate re-applying migrations (second app boot)
+    // This should be idempotent — the column already exists
+    type ColumnInfo = { name: string };
+    const cols = (db.prepare('PRAGMA table_info(designs)').all() as ColumnInfo[]).map(
+      (c) => c.name,
+    );
+    expect(cols).toContain('workspace_path');
+
+    // Data should be intact
+    const reloaded = getDesign(db, d.id);
+    expect(reloaded?.name).toBe('persist me');
+    expect(reloaded?.workspacePath).toBe('/workspace/path');
   });
 });
 

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -207,6 +207,9 @@ function applyAdditiveMigrations(db: Database): void {
     db.exec('ALTER TABLE designs ADD COLUMN deleted_at TEXT');
     db.exec('CREATE INDEX IF NOT EXISTS idx_designs_deleted_at ON designs(deleted_at)');
   }
+  if (!designCols.includes('workspace_path')) {
+    db.exec('ALTER TABLE designs ADD COLUMN workspace_path TEXT');
+  }
 
   // Comments v2 — add scope ('element'|'global') and parent_outer_html for
   // richer prompt enrichment. Both are additive; old rows backfill to
@@ -350,6 +353,7 @@ interface DesignRow {
   updated_at: string;
   thumbnail_text: string | null;
   deleted_at: string | null;
+  workspace_path: string | null;
 }
 
 interface SnapshotRow {
@@ -386,6 +390,7 @@ function rowToDesign(row: DesignRow): Design {
     updatedAt: row.updated_at,
     thumbnailText: row.thumbnail_text ?? null,
     deletedAt: row.deleted_at ?? null,
+    workspacePath: row.workspace_path ?? null,
   };
 }
 
@@ -412,7 +417,7 @@ export function createDesign(db: Database, name = 'Untitled design'): Design {
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
   db.prepare(
-    'INSERT INTO designs (id, schema_version, name, created_at, updated_at) VALUES (?, 1, ?, ?, ?)',
+    'INSERT INTO designs (id, schema_version, name, created_at, updated_at, workspace_path) VALUES (?, 1, ?, ?, ?, NULL)',
   ).run(id, name, now, now);
   return rowToDesign(db.prepare('SELECT * FROM designs WHERE id = ?').get(id) as DesignRow);
 }
@@ -467,6 +472,28 @@ export function softDeleteDesign(db: Database, id: string): Design | null {
   return getDesign(db, id);
 }
 
+export function updateDesignWorkspace(
+  db: Database,
+  id: string,
+  workspacePath: string,
+): Design | null {
+  const now = new Date().toISOString();
+  const result = db
+    .prepare('UPDATE designs SET workspace_path = ?, updated_at = ? WHERE id = ?')
+    .run(workspacePath, now, id);
+  if (result.changes === 0) return null;
+  return getDesign(db, id);
+}
+
+export function clearDesignWorkspace(db: Database, id: string): Design | null {
+  const now = new Date().toISOString();
+  const result = db
+    .prepare('UPDATE designs SET workspace_path = NULL, updated_at = ? WHERE id = ?')
+    .run(now, id);
+  if (result.changes === 0) return null;
+  return getDesign(db, id);
+}
+
 /**
  * Duplicate a design row + all its messages + all its snapshots. Snapshot
  * parent_id references are remapped to point at the freshly-cloned snapshots
@@ -482,7 +509,7 @@ export function duplicateDesign(db: Database, sourceId: string, newName: string)
 
   const tx = db.transaction(() => {
     db.prepare(
-      'INSERT INTO designs (id, schema_version, name, created_at, updated_at, thumbnail_text, deleted_at) VALUES (?, 1, ?, ?, ?, ?, NULL)',
+      'INSERT INTO designs (id, schema_version, name, created_at, updated_at, thumbnail_text, deleted_at, workspace_path) VALUES (?, 1, ?, ?, ?, ?, NULL, NULL)',
     ).run(newId, trimmed, now, now, source.thumbnailText);
 
     const messages = db
@@ -988,6 +1015,33 @@ export function createDesignFile(
   ).run(id, designId, p, content, now, now);
   const row = db.prepare('SELECT * FROM design_files WHERE id = ?').get(id) as DesignFileRowDb;
   return rowToDesignFile(row);
+}
+
+export function upsertDesignFile(
+  db: Database,
+  designId: string,
+  path: string,
+  content: string,
+): DesignFile {
+  const p = normalizeDesignFilePath(path);
+  const existing = db
+    .prepare('SELECT * FROM design_files WHERE design_id = ? AND path = ?')
+    .get(designId, p) as DesignFileRowDb | undefined;
+  if (existing) {
+    const now = new Date().toISOString();
+    db.prepare('UPDATE design_files SET content = ?, updated_at = ? WHERE id = ?').run(
+      content,
+      now,
+      existing.id,
+    );
+    return rowToDesignFile({ ...existing, content, updated_at: now });
+  }
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  db.prepare(
+    'INSERT INTO design_files (id, design_id, path, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(id, designId, p, content, now, now);
+  return rowToDesignFile(db.prepare('SELECT * FROM design_files WHERE id = ?').get(id) as DesignFileRowDb);
 }
 
 export function strReplaceInDesignFile(

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -11,7 +11,6 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { getLogger } from './logger';
 import type {
   ChatAppendInput,
   ChatMessageKind,
@@ -32,6 +31,7 @@ import type {
   SnapshotCreateInput,
 } from '@open-codesign/shared';
 import type BetterSqlite3 from 'better-sqlite3';
+import { getLogger } from './logger';
 
 // better-sqlite3 is a native module — require() instead of import.
 const require = createRequire(import.meta.url);
@@ -309,7 +309,7 @@ export function initSnapshotsDb(dbPath: string): Database {
     try {
       db.close();
     } catch (closeErr) {
-      const logger = getLogger();
+      const logger = getLogger('snapshots-db');
       logger.warn('db.init.close_failed', { cause: closeErr });
     }
     throw cause;

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { getLogger } from './logger';
 import type {
   ChatAppendInput,
   ChatMessageKind,
@@ -307,8 +308,9 @@ export function initSnapshotsDb(dbPath: string): Database {
     // Don't cache a half-open DB — let the next caller retry from scratch.
     try {
       db.close();
-    } catch {
-      /* swallow secondary close failure */
+    } catch (closeErr) {
+      const logger = getLogger();
+      logger.warn('db.init.close_failed', { cause: closeErr });
     }
     throw cause;
   }
@@ -1041,7 +1043,9 @@ export function upsertDesignFile(
   db.prepare(
     'INSERT INTO design_files (id, design_id, path, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
   ).run(id, designId, p, content, now, now);
-  return rowToDesignFile(db.prepare('SELECT * FROM design_files WHERE id = ?').get(id) as DesignFileRowDb);
+  return rowToDesignFile(
+    db.prepare('SELECT * FROM design_files WHERE id = ?').get(id) as DesignFileRowDb,
+  );
 }
 
 export function strReplaceInDesignFile(

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { CodesignError } from '@open-codesign/shared';
+import type { Design } from '@open-codesign/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Collect registered handlers so tests can invoke them directly.
@@ -17,6 +18,9 @@ vi.mock('./electron-runtime', () => ({
       handlers.set(channel, fn);
     },
   },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
 }));
 
 vi.mock('./logger', () => ({
@@ -27,14 +31,28 @@ vi.mock('./logger', () => ({
   }),
 }));
 
-import { createDesign, createSnapshot, initInMemoryDb } from './snapshots-db';
+vi.mock('./design-workspace', () => ({
+  bindWorkspace: vi.fn(),
+  openWorkspaceFolder: vi.fn(),
+}));
+
+import { createDesign, createSnapshot, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
 import {
   SNAPSHOTS_CHANNELS_V1,
   registerSnapshotsIpc,
   registerSnapshotsUnavailableIpc,
+  registerWorkspaceIpc,
 } from './snapshots-ipc';
+import { bindWorkspace, openWorkspaceFolder } from './design-workspace';
+import { dialog } from './electron-runtime';
 
 function call(channel: string, raw: unknown): unknown {
+  const fn = handlers.get(channel);
+  if (!fn) throw new Error(`No handler for channel: ${channel}`);
+  return fn(null, raw);
+}
+
+async function callAsync(channel: string, raw: unknown): Promise<unknown> {
   const fn = handlers.get(channel);
   if (!fn) throw new Error(`No handler for channel: ${channel}`);
   return fn(null, raw);
@@ -52,6 +70,7 @@ beforeEach(() => {
   handlers.clear();
   db = initInMemoryDb();
   registerSnapshotsIpc(db);
+  registerWorkspaceIpc(db, () => ({} as any));
 });
 
 // ---------------------------------------------------------------------------
@@ -544,6 +563,168 @@ describe('SQLite error translation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// snapshots:v1:workspace:pick
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:workspace:pick', () => {
+  it('returns null when user cancels the dialog', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({ canceled: true, filePaths: [] });
+    const result = await callAsync('snapshots:v1:workspace:pick', v1({}));
+    expect(result).toBeNull();
+  });
+
+  it('returns the selected folder path', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+      canceled: false,
+      filePaths: ['/home/user/my-workspace'],
+    });
+    const result = await callAsync('snapshots:v1:workspace:pick', v1({}));
+    expect(result).toBe('/home/user/my-workspace');
+  });
+
+  it('rejects non-object payload with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:pick', null);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects missing schemaVersion with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:pick', {});
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('returns null when filePaths is empty', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValueOnce({
+      canceled: false,
+      filePaths: [],
+    });
+    const result = await callAsync('snapshots:v1:workspace:pick', v1({}));
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:workspace:update
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:workspace:update', () => {
+  it('updates workspace and returns the design', async () => {
+    const design = createDesign(db, 'Test');
+    const updated = { ...design, workspacePath: '/new/path' };
+    vi.mocked(bindWorkspace).mockResolvedValueOnce(updated);
+    const result = await callAsync(
+      'snapshots:v1:workspace:update',
+      v1({ designId: design.id, workspacePath: '/new/path', migrateFiles: false }),
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it('throws IPC_NOT_FOUND when design does not exist', async () => {
+    vi.mocked(bindWorkspace).mockResolvedValueOnce(null as any);
+    try {
+      await callAsync(
+        'snapshots:v1:workspace:update',
+        v1({ designId: 'missing', workspacePath: '/path', migrateFiles: false }),
+      );
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_NOT_FOUND');
+    }
+  });
+
+  it('throws IPC_CONFLICT when workspace is already bound', async () => {
+    const design = createDesign(db, 'Test');
+    vi.mocked(bindWorkspace).mockRejectedValueOnce(new Error('already bound to another design'));
+    try {
+      await callAsync(
+        'snapshots:v1:workspace:update',
+        v1({ designId: design.id, workspacePath: '/path', migrateFiles: false }),
+      );
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_CONFLICT');
+    }
+  });
+
+  it('rejects non-object payload with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:update', null);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects missing designId with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:update', v1({ workspacePath: '/path', migrateFiles: false }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('accepts null workspacePath to clear binding', async () => {
+    const design = createDesign(db, 'Test');
+    const cleared = { ...design, workspacePath: null };
+    vi.mocked(bindWorkspace).mockResolvedValueOnce(cleared);
+    const result = await callAsync(
+      'snapshots:v1:workspace:update',
+      v1({ designId: design.id, workspacePath: null, migrateFiles: false }),
+    );
+    expect(result).toEqual(cleared);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:workspace:open
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:workspace:open', () => {
+  it('opens the workspace folder for a design', async () => {
+    const design = createDesign(db, 'Test');
+    updateDesignWorkspace(db, design.id, '/tmp/workspace');
+    vi.mocked(openWorkspaceFolder).mockResolvedValueOnce(undefined);
+    await callAsync('snapshots:v1:workspace:open', v1({ designId: design.id }));
+    expect(vi.mocked(openWorkspaceFolder)).toHaveBeenCalledWith('/tmp/workspace');
+  });
+
+  it('throws IPC_NOT_FOUND when design does not exist', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:open', v1({ designId: 'missing' }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_NOT_FOUND');
+    }
+  });
+
+  it('rejects non-object payload with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:open', null);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects missing designId with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:open', v1({}));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // registerSnapshotsUnavailableIpc — DB init failure path
 //
 // When safeInitSnapshotsDb fails at boot, main/index.ts installs stub handlers
@@ -573,10 +754,11 @@ describe('registerSnapshotsUnavailableIpc', () => {
     });
   }
 
-  it('covers exactly the channels registered by registerSnapshotsIpc', () => {
+  it('covers exactly the channels registered by registerSnapshotsIpc and registerWorkspaceIpc', () => {
     handlers.clear();
     const dbForLive = initInMemoryDb();
     registerSnapshotsIpc(dbForLive);
+    registerWorkspaceIpc(dbForLive, () => ({} as any));
     const live = new Set(handlers.keys());
     handlers.clear();
     registerSnapshotsUnavailableIpc('reason');

--- a/apps/desktop/src/main/snapshots-ipc.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.test.ts
@@ -34,17 +34,23 @@ vi.mock('./logger', () => ({
 vi.mock('./design-workspace', () => ({
   bindWorkspace: vi.fn(),
   openWorkspaceFolder: vi.fn(),
+  checkWorkspaceFolderExists: vi.fn(),
 }));
 
-import { createDesign, createSnapshot, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
+import { bindWorkspace, checkWorkspaceFolderExists, openWorkspaceFolder } from './design-workspace';
+import { dialog } from './electron-runtime';
+import {
+  createDesign,
+  createSnapshot,
+  initInMemoryDb,
+  updateDesignWorkspace,
+} from './snapshots-db';
 import {
   SNAPSHOTS_CHANNELS_V1,
   registerSnapshotsIpc,
   registerSnapshotsUnavailableIpc,
   registerWorkspaceIpc,
 } from './snapshots-ipc';
-import { bindWorkspace, openWorkspaceFolder } from './design-workspace';
-import { dialog } from './electron-runtime';
 
 function call(channel: string, raw: unknown): unknown {
   const fn = handlers.get(channel);
@@ -70,7 +76,8 @@ beforeEach(() => {
   handlers.clear();
   db = initInMemoryDb();
   registerSnapshotsIpc(db);
-  registerWorkspaceIpc(db, () => ({} as any));
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  registerWorkspaceIpc(db, () => ({}) as any);
 });
 
 // ---------------------------------------------------------------------------
@@ -380,6 +387,7 @@ describe('schemaVersion gating', () => {
     ['snapshots:v1:set-thumbnail', { id: 'x', thumbnailText: null }],
     ['snapshots:v1:soft-delete-design', { id: 'x' }],
     ['snapshots:v1:duplicate-design', { id: 'x', name: 'n' }],
+    ['snapshots:v1:workspace:check', { designId: 'x' }],
     [
       'snapshots:v1:create',
       {
@@ -394,9 +402,9 @@ describe('schemaVersion gating', () => {
   ];
 
   for (const [channel, sample] of channelsAndSamples) {
-    it(`${channel} rejects missing schemaVersion with IPC_BAD_INPUT`, () => {
+    it(`${channel} rejects missing schemaVersion with IPC_BAD_INPUT`, async () => {
       try {
-        call(channel, sample);
+        await callAsync(channel, sample);
         throw new Error('expected throw');
       } catch (err) {
         expect(err).toBeInstanceOf(CodesignError);
@@ -405,9 +413,9 @@ describe('schemaVersion gating', () => {
       }
     });
 
-    it(`${channel} rejects schemaVersion: 2 with IPC_BAD_INPUT`, () => {
+    it(`${channel} rejects schemaVersion: 2 with IPC_BAD_INPUT`, async () => {
       try {
-        call(channel, { schemaVersion: 2, ...sample });
+        await callAsync(channel, { schemaVersion: 2, ...sample });
         throw new Error('expected throw');
       } catch (err) {
         expect(err).toBeInstanceOf(CodesignError);
@@ -627,6 +635,7 @@ describe('snapshots:v1:workspace:update', () => {
   });
 
   it('throws IPC_NOT_FOUND when design does not exist', async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
     vi.mocked(bindWorkspace).mockResolvedValueOnce(null as any);
     try {
       await callAsync(
@@ -664,7 +673,10 @@ describe('snapshots:v1:workspace:update', () => {
 
   it('rejects missing designId with IPC_BAD_INPUT', async () => {
     try {
-      await callAsync('snapshots:v1:workspace:update', v1({ workspacePath: '/path', migrateFiles: false }));
+      await callAsync(
+        'snapshots:v1:workspace:update',
+        v1({ workspacePath: '/path', migrateFiles: false }),
+      );
       throw new Error('expected throw');
     } catch (err) {
       expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
@@ -680,6 +692,68 @@ describe('snapshots:v1:workspace:update', () => {
       v1({ designId: design.id, workspacePath: null, migrateFiles: false }),
     );
     expect(result).toEqual(cleared);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshots:v1:workspace:check
+// ---------------------------------------------------------------------------
+
+describe('snapshots:v1:workspace:check', () => {
+  it('returns true when the workspace folder exists', async () => {
+    const design = createDesign(db, 'Test');
+    updateDesignWorkspace(db, design.id, '/tmp/workspace');
+    vi.mocked(checkWorkspaceFolderExists).mockResolvedValueOnce(true);
+    const result = await callAsync('snapshots:v1:workspace:check', v1({ designId: design.id }));
+    expect(result).toEqual({ exists: true });
+    expect(vi.mocked(checkWorkspaceFolderExists)).toHaveBeenCalledWith('/tmp/workspace');
+  });
+
+  it('returns false when the workspace folder does not exist', async () => {
+    const design = createDesign(db, 'Test');
+    updateDesignWorkspace(db, design.id, '/tmp/missing');
+    vi.mocked(checkWorkspaceFolderExists).mockResolvedValueOnce(false);
+    const result = await callAsync('snapshots:v1:workspace:check', v1({ designId: design.id }));
+    expect(result).toEqual({ exists: false });
+    expect(vi.mocked(checkWorkspaceFolderExists)).toHaveBeenCalledWith('/tmp/missing');
+  });
+
+  it('throws IPC_NOT_FOUND when design does not exist', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:check', v1({ designId: 'missing' }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_NOT_FOUND');
+    }
+  });
+
+  it('throws IPC_BAD_INPUT when design has no workspace path', async () => {
+    const design = createDesign(db, 'Test'); // No workspace bound
+    try {
+      await callAsync('snapshots:v1:workspace:check', v1({ designId: design.id }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+      expect((err as Error).message).toBe('Design is not bound to a workspace');
+    }
+  });
+
+  it('rejects non-object payload with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:check', null);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
+  });
+
+  it('rejects missing designId with IPC_BAD_INPUT', async () => {
+    try {
+      await callAsync('snapshots:v1:workspace:check', v1({}));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as CodesignError).code).toBe('IPC_BAD_INPUT');
+    }
   });
 });
 
@@ -758,7 +832,8 @@ describe('registerSnapshotsUnavailableIpc', () => {
     handlers.clear();
     const dbForLive = initInMemoryDb();
     registerSnapshotsIpc(dbForLive);
-    registerWorkspaceIpc(dbForLive, () => ({} as any));
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    registerWorkspaceIpc(dbForLive, () => ({}) as any);
     const live = new Set(handlers.keys());
     handlers.clear();
     registerSnapshotsUnavailableIpc('reason');

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -12,7 +12,8 @@
 import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign/shared';
 import { CodesignError } from '@open-codesign/shared';
 import type BetterSqlite3 from 'better-sqlite3';
-import { ipcMain } from './electron-runtime';
+import type { BrowserWindow } from 'electron';
+import { dialog, ipcMain } from './electron-runtime';
 import { getLogger } from './logger';
 import {
   createDesign,
@@ -27,6 +28,7 @@ import {
   setDesignThumbnail,
   softDeleteDesign,
 } from './snapshots-db';
+import { bindWorkspace, openWorkspaceFolder } from './design-workspace';
 
 type Database = BetterSqlite3.Database;
 
@@ -339,6 +341,89 @@ export function registerSnapshotsIpc(db: Database): void {
   });
 }
 
+export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow | null): void {
+  ipcMain.handle('snapshots:v1:workspace:pick', async (_e: unknown, raw: unknown): Promise<string | null> => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:workspace:pick expects an object payload',
+        'IPC_BAD_INPUT',
+      );
+    }
+    requireSchemaV1(raw as Record<string, unknown>, 'snapshots:v1:workspace:pick');
+    const win = getWin();
+    if (!win) {
+      throw new CodesignError('Window not available', 'IPC_DB_ERROR');
+    }
+    const result = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
+    if (result.canceled || result.filePaths.length === 0) {
+      return null;
+    }
+    return result.filePaths[0] ?? null;
+  });
+
+  ipcMain.handle('snapshots:v1:workspace:update', async (_e: unknown, raw: unknown): Promise<Design> => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:workspace:update expects an object payload',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:workspace:update');
+
+    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+    const workspacePath = r['workspacePath'];
+    if (workspacePath !== null && typeof workspacePath !== 'string') {
+      throw new CodesignError('workspacePath must be a string or null', 'IPC_BAD_INPUT');
+    }
+    if (typeof r['migrateFiles'] !== 'boolean') {
+      throw new CodesignError('migrateFiles must be a boolean', 'IPC_BAD_INPUT');
+    }
+
+    try {
+      const design = await bindWorkspace(db, r['designId'] as string, workspacePath as string | null, r['migrateFiles'] as boolean);
+      if (design === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+      logger.info('design.workspace_updated', { id: design.id, workspacePath: design.workspacePath });
+      return design;
+    } catch (err) {
+      if (err instanceof CodesignError) throw err;
+      if (err instanceof Error && err.message.includes('already bound')) {
+        throw new CodesignError(err.message, 'IPC_CONFLICT');
+      }
+      throw new CodesignError('Workspace update failed', 'IPC_DB_ERROR', { cause: err });
+    }
+  });
+
+  ipcMain.handle('snapshots:v1:workspace:open', async (_e: unknown, raw: unknown): Promise<void> => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new CodesignError(
+        'snapshots:v1:workspace:open expects an object payload',
+        'IPC_BAD_INPUT',
+      );
+    }
+    const r = raw as Record<string, unknown>;
+    requireSchemaV1(r, 'snapshots:v1:workspace:open');
+
+    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+    }
+
+    const design = runDb('workspace:open', () => getDesign(db, r['designId'] as string));
+    if (design === null) {
+      throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+    }
+    if (design.workspacePath === null) {
+      throw new CodesignError('No workspace bound to this design', 'IPC_BAD_INPUT');
+    }
+
+    await openWorkspaceFolder(design.workspacePath);
+  });
+}
+
 function parseIdPayload(raw: unknown, channel: string): string {
   if (typeof raw !== 'object' || raw === null) {
     throw new CodesignError(`snapshots:v1:${channel} expects { id }`, 'IPC_BAD_INPUT');
@@ -372,6 +457,9 @@ export const SNAPSHOTS_CHANNELS_V1 = [
   'snapshots:v1:get',
   'snapshots:v1:create',
   'snapshots:v1:delete',
+  'snapshots:v1:workspace:pick',
+  'snapshots:v1:workspace:update',
+  'snapshots:v1:workspace:open',
 ] as const;
 
 export function registerSnapshotsUnavailableIpc(reason: string): void {

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -482,7 +482,9 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
       try {
         exists = await checkWorkspaceFolderExists(design.workspacePath);
       } catch (cause) {
-        throw new CodesignError('Failed to check workspace folder existence', 'IPC_DB_ERROR', { cause });
+        throw new CodesignError('Failed to check workspace folder existence', 'IPC_DB_ERROR', {
+          cause,
+        });
       }
       return { exists };
     },

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -13,6 +13,7 @@ import type { Design, DesignSnapshot, SnapshotCreateInput } from '@open-codesign
 import { CodesignError } from '@open-codesign/shared';
 import type BetterSqlite3 from 'better-sqlite3';
 import type { BrowserWindow } from 'electron';
+import { bindWorkspace, checkWorkspaceFolderExists, openWorkspaceFolder } from './design-workspace';
 import { dialog, ipcMain } from './electron-runtime';
 import { getLogger } from './logger';
 import {
@@ -28,7 +29,6 @@ import {
   setDesignThumbnail,
   softDeleteDesign,
 } from './snapshots-db';
-import { bindWorkspace, openWorkspaceFolder } from './design-workspace';
 
 type Database = BetterSqlite3.Database;
 
@@ -342,86 +342,151 @@ export function registerSnapshotsIpc(db: Database): void {
 }
 
 export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow | null): void {
-  ipcMain.handle('snapshots:v1:workspace:pick', async (_e: unknown, raw: unknown): Promise<string | null> => {
-    if (typeof raw !== 'object' || raw === null) {
-      throw new CodesignError(
-        'snapshots:v1:workspace:pick expects an object payload',
-        'IPC_BAD_INPUT',
-      );
-    }
-    requireSchemaV1(raw as Record<string, unknown>, 'snapshots:v1:workspace:pick');
-    const win = getWin();
-    if (!win) {
-      throw new CodesignError('Window not available', 'IPC_DB_ERROR');
-    }
-    const result = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
-    if (result.canceled || result.filePaths.length === 0) {
-      return null;
-    }
-    return result.filePaths[0] ?? null;
-  });
+  ipcMain.handle(
+    'snapshots:v1:workspace:pick',
+    async (_e: unknown, raw: unknown): Promise<string | null> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:workspace:pick expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      requireSchemaV1(raw as Record<string, unknown>, 'snapshots:v1:workspace:pick');
+      const win = getWin();
+      if (!win) {
+        throw new CodesignError('Window not available', 'IPC_DB_ERROR');
+      }
+      let result: Awaited<ReturnType<typeof dialog.showOpenDialog>>;
+      try {
+        result = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
+      } catch (cause) {
+        throw new CodesignError('Failed to open folder picker dialog', 'IPC_DB_ERROR', { cause });
+      }
+      if (result.canceled || result.filePaths.length === 0) {
+        return null;
+      }
+      return result.filePaths[0] ?? null;
+    },
+  );
 
-  ipcMain.handle('snapshots:v1:workspace:update', async (_e: unknown, raw: unknown): Promise<Design> => {
-    if (typeof raw !== 'object' || raw === null) {
-      throw new CodesignError(
-        'snapshots:v1:workspace:update expects an object payload',
-        'IPC_BAD_INPUT',
-      );
-    }
-    const r = raw as Record<string, unknown>;
-    requireSchemaV1(r, 'snapshots:v1:workspace:update');
+  ipcMain.handle(
+    'snapshots:v1:workspace:update',
+    async (_e: unknown, raw: unknown): Promise<Design> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:workspace:update expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'snapshots:v1:workspace:update');
 
-    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
-      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
-    }
-    const workspacePath = r['workspacePath'];
-    if (workspacePath !== null && typeof workspacePath !== 'string') {
-      throw new CodesignError('workspacePath must be a string or null', 'IPC_BAD_INPUT');
-    }
-    if (typeof r['migrateFiles'] !== 'boolean') {
-      throw new CodesignError('migrateFiles must be a boolean', 'IPC_BAD_INPUT');
-    }
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+      const workspacePath = r['workspacePath'];
+      if (workspacePath !== null && typeof workspacePath !== 'string') {
+        throw new CodesignError('workspacePath must be a string or null', 'IPC_BAD_INPUT');
+      }
+      if (typeof r['migrateFiles'] !== 'boolean') {
+        throw new CodesignError('migrateFiles must be a boolean', 'IPC_BAD_INPUT');
+      }
 
-    try {
-      const design = await bindWorkspace(db, r['designId'] as string, workspacePath as string | null, r['migrateFiles'] as boolean);
+      try {
+        const design = await bindWorkspace(
+          db,
+          r['designId'] as string,
+          workspacePath as string | null,
+          r['migrateFiles'] as boolean,
+        );
+        if (design === null) {
+          throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+        }
+        logger.info('design.workspace_updated', {
+          id: design.id,
+          workspacePath: design.workspacePath,
+        });
+        return design;
+      } catch (err) {
+        if (err instanceof CodesignError) throw err;
+        if (err instanceof Error && err.message.includes('already bound')) {
+          throw new CodesignError(err.message, 'IPC_CONFLICT');
+        }
+        throw new CodesignError('Workspace update failed', 'IPC_DB_ERROR', { cause: err });
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'snapshots:v1:workspace:open',
+    async (_e: unknown, raw: unknown): Promise<void> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:workspace:open expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'snapshots:v1:workspace:open');
+
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+
+      const design = runDb('workspace:open', () => getDesign(db, r['designId'] as string));
       if (design === null) {
         throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
       }
-      logger.info('design.workspace_updated', { id: design.id, workspacePath: design.workspacePath });
-      return design;
-    } catch (err) {
-      if (err instanceof CodesignError) throw err;
-      if (err instanceof Error && err.message.includes('already bound')) {
-        throw new CodesignError(err.message, 'IPC_CONFLICT');
+      if (design.workspacePath === null) {
+        throw new CodesignError('No workspace bound to this design', 'IPC_BAD_INPUT');
       }
-      throw new CodesignError('Workspace update failed', 'IPC_DB_ERROR', { cause: err });
-    }
-  });
 
-  ipcMain.handle('snapshots:v1:workspace:open', async (_e: unknown, raw: unknown): Promise<void> => {
-    if (typeof raw !== 'object' || raw === null) {
-      throw new CodesignError(
-        'snapshots:v1:workspace:open expects an object payload',
-        'IPC_BAD_INPUT',
-      );
-    }
-    const r = raw as Record<string, unknown>;
-    requireSchemaV1(r, 'snapshots:v1:workspace:open');
+      try {
+        await openWorkspaceFolder(design.workspacePath);
+      } catch (err) {
+        throw new CodesignError(
+          err instanceof Error ? err.message : 'Failed to open workspace folder',
+          'IPC_BAD_INPUT',
+          { cause: err instanceof Error ? err : undefined },
+        );
+      }
+    },
+  );
 
-    if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
-      throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
-    }
+  ipcMain.handle(
+    'snapshots:v1:workspace:check',
+    async (_e: unknown, raw: unknown): Promise<{ exists: boolean }> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:workspace:check expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'snapshots:v1:workspace:check');
 
-    const design = runDb('workspace:open', () => getDesign(db, r['designId'] as string));
-    if (design === null) {
-      throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
-    }
-    if (design.workspacePath === null) {
-      throw new CodesignError('No workspace bound to this design', 'IPC_BAD_INPUT');
-    }
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
 
-    await openWorkspaceFolder(design.workspacePath);
-  });
+      const design = runDb('workspace:check', () => getDesign(db, r['designId'] as string));
+      if (design === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+
+      if (design.workspacePath === null) {
+        throw new CodesignError('Design is not bound to a workspace', 'IPC_BAD_INPUT');
+      }
+
+      let exists: boolean;
+      try {
+        exists = await checkWorkspaceFolderExists(design.workspacePath);
+      } catch (cause) {
+        throw new CodesignError('Failed to check workspace folder existence', 'IPC_DB_ERROR', { cause });
+      }
+      return { exists };
+    },
+  );
 }
 
 function parseIdPayload(raw: unknown, channel: string): string {
@@ -460,6 +525,7 @@ export const SNAPSHOTS_CHANNELS_V1 = [
   'snapshots:v1:workspace:pick',
   'snapshots:v1:workspace:update',
   'snapshots:v1:workspace:open',
+  'snapshots:v1:workspace:check',
 ] as const;
 
 export function registerSnapshotsUnavailableIpc(reason: string): void {

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -410,7 +410,14 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
       } catch (err) {
         if (err instanceof CodesignError) throw err;
         if (err instanceof Error && err.message.includes('already bound')) {
-          throw new CodesignError(err.message, 'IPC_CONFLICT');
+          throw new CodesignError(err.message, 'IPC_CONFLICT', { cause: err });
+        }
+        if (
+          err instanceof Error &&
+          (err.message.includes('Workspace migration collision') ||
+            err.message.includes('Tracked workspace file missing'))
+        ) {
+          throw new CodesignError(err.message, 'IPC_BAD_INPUT', { cause: err });
         }
         throw new CodesignError('Workspace update failed', 'IPC_DB_ERROR', { cause: err });
       }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -440,6 +440,22 @@ const api = {
       }) as Promise<DesignSnapshot>,
     delete: (id: string) =>
       ipcRenderer.invoke('snapshots:v1:delete', { schemaVersion: 1, id }) as Promise<void>,
+    pickWorkspaceFolder: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:workspace:pick', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<Design>,
+    updateWorkspace: (designId: string, workspacePath: string | null) =>
+      ipcRenderer.invoke('snapshots:v1:workspace:update', {
+        schemaVersion: 1,
+        designId,
+        workspacePath,
+      }) as Promise<Design>,
+    openWorkspaceFolder: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:workspace:open', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<void>,
   },
   chat: {
     list: (designId: string) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -440,16 +440,16 @@ const api = {
       }) as Promise<DesignSnapshot>,
     delete: (id: string) =>
       ipcRenderer.invoke('snapshots:v1:delete', { schemaVersion: 1, id }) as Promise<void>,
-    pickWorkspaceFolder: (designId: string) =>
+    pickWorkspaceFolder: () =>
       ipcRenderer.invoke('snapshots:v1:workspace:pick', {
         schemaVersion: 1,
-        designId,
-      }) as Promise<Design>,
-    updateWorkspace: (designId: string, workspacePath: string | null) =>
+      }) as Promise<string | null>,
+    updateWorkspace: (designId: string, workspacePath: string | null, migrateFiles: boolean) =>
       ipcRenderer.invoke('snapshots:v1:workspace:update', {
         schemaVersion: 1,
         designId,
         workspacePath,
+        migrateFiles,
       }) as Promise<Design>,
     openWorkspaceFolder: (designId: string) =>
       ipcRenderer.invoke('snapshots:v1:workspace:open', {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -456,6 +456,11 @@ const api = {
         schemaVersion: 1,
         designId,
       }) as Promise<void>,
+    checkWorkspaceFolder: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:workspace:check', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<{ exists: boolean }>,
   },
   chat: {
     list: (designId: string) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DeleteDesignDialog } from './components/DeleteDesignDialog';
 import { DesignsView } from './components/DesignsView';
 import { PreviewPane } from './components/PreviewPane';
+import { RebindWorkspaceDialog } from './components/RebindWorkspaceDialog';
 import { RenameDesignDialog } from './components/RenameDesignDialog';
 import { Settings } from './components/Settings';
 import { Sidebar } from './components/Sidebar';
@@ -256,6 +257,7 @@ export function App() {
       <DesignsView />
       <RenameDesignDialog />
       <DeleteDesignDialog />
+      <RebindWorkspaceDialog />
       <ToastViewport />
       <CommentsPanel />
       <ReportEventDialog localId={activeReportLocalId} onClose={closeReportDialog} />

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DeleteDesignDialog } from './components/DeleteDesignDialog';
 import { DesignsView } from './components/DesignsView';
+import { NewDesignDialog } from './components/NewDesignDialog';
 import { PreviewPane } from './components/PreviewPane';
 import { RebindWorkspaceDialog } from './components/RebindWorkspaceDialog';
 import { RenameDesignDialog } from './components/RenameDesignDialog';
@@ -258,6 +259,7 @@ export function App() {
       <RenameDesignDialog />
       <DeleteDesignDialog />
       <RebindWorkspaceDialog />
+      <NewDesignDialog />
       <ToastViewport />
       <CommentsPanel />
       <ReportEventDialog localId={activeReportLocalId} onClose={closeReportDialog} />

--- a/apps/desktop/src/renderer/src/components/DesignSwitcher.tsx
+++ b/apps/desktop/src/renderer/src/components/DesignSwitcher.tsx
@@ -13,7 +13,7 @@ export function DesignSwitcher() {
   const designs = useCodesignStore((s) => s.designs);
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
   const switchDesign = useCodesignStore((s) => s.switchDesign);
-  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const openNewDesignDialog = useCodesignStore((s) => s.openNewDesignDialog);
   const openDesignsView = useCodesignStore((s) => s.openDesignsView);
   const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
 
@@ -116,7 +116,7 @@ export function DesignSwitcher() {
               shortcut="Ctrl/Cmd+N"
               onClick={() => {
                 setOpen(false);
-                void createNewDesign();
+                openNewDesignDialog();
               }}
             />
             <MenuRow

--- a/apps/desktop/src/renderer/src/components/DesignsView.tsx
+++ b/apps/desktop/src/renderer/src/components/DesignsView.tsx
@@ -27,7 +27,7 @@ export function DesignsView() {
   const designs = useCodesignStore((s) => s.designs);
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
   const switchDesign = useCodesignStore((s) => s.switchDesign);
-  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const openNewDesignDialog = useCodesignStore((s) => s.openNewDesignDialog);
   const duplicateDesign = useCodesignStore((s) => s.duplicateDesign);
   const requestDeleteDesign = useCodesignStore((s) => s.requestDeleteDesign);
   const requestRenameDesign = useCodesignStore((s) => s.requestRenameDesign);
@@ -92,7 +92,7 @@ export function DesignsView() {
           />
           <button
             type="button"
-            onClick={() => void createNewDesign()}
+            onClick={() => openNewDesignDialog()}
             className="inline-flex items-center gap-2 h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
           >
             <Plus className="w-3.5 h-3.5" />

--- a/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
@@ -1,0 +1,290 @@
+import { initI18n } from '@open-codesign/i18n';
+import type { Design } from '@open-codesign/shared';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCodesignStore } from '../store';
+
+beforeAll(async () => {
+  await initI18n('en');
+});
+
+const mockDesign = (overrides?: Partial<Design>): Design => ({
+  id: 'design-1',
+  name: 'Test Design',
+  prompt: 'Test prompt',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  workspacePath: null,
+  ...overrides,
+});
+
+describe('FilesPanel workspace integration', () => {
+  beforeEach(() => {
+    useCodesignStore.setState({
+      currentDesignId: 'design-1',
+      designs: [mockDesign()],
+    });
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          pickWorkspaceFolder: vi.fn(),
+          updateWorkspace: vi.fn(),
+          openWorkspaceFolder: vi.fn(),
+          listDesigns: vi.fn(),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('workspace state retrieval', () => {
+    it('returns null workspacePath when design has no workspace bound', () => {
+      const designs = useCodesignStore.getState().designs;
+      const currentDesign = designs.find((d) => d.id === 'design-1');
+      expect(currentDesign?.workspacePath).toBeNull();
+    });
+
+    it('returns workspacePath when design has workspace bound', () => {
+      useCodesignStore.setState({
+        designs: [mockDesign({ workspacePath: '/home/user/workspace' })],
+      });
+
+      const designs = useCodesignStore.getState().designs;
+      const currentDesign = designs.find((d) => d.id === 'design-1');
+      expect(currentDesign?.workspacePath).toBe('/home/user/workspace');
+    });
+
+    it('handles multiple designs with different workspace bindings', () => {
+      useCodesignStore.setState({
+        designs: [
+          mockDesign({ id: 'design-1', workspacePath: '/path/one' }),
+          mockDesign({ id: 'design-2', workspacePath: '/path/two' }),
+          mockDesign({ id: 'design-3', workspacePath: null }),
+        ],
+      });
+
+      const designs = useCodesignStore.getState().designs;
+      expect(designs[0]?.workspacePath).toBe('/path/one');
+      expect(designs[1]?.workspacePath).toBe('/path/two');
+      expect(designs[2]?.workspacePath).toBeNull();
+    });
+  });
+
+  describe('workspace action handlers', () => {
+    it('pickWorkspaceFolder returns path or null', async () => {
+      const mockPick = vi.fn().mockResolvedValue('/home/user/workspace');
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+
+      const result = await window.codesign.snapshots.pickWorkspaceFolder();
+      expect(result).toBe('/home/user/workspace');
+      expect(mockPick).toHaveBeenCalledOnce();
+    });
+
+    it('pickWorkspaceFolder returns null when user cancels', async () => {
+      const mockPick = vi.fn().mockResolvedValue(null);
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+
+      const result = await window.codesign.snapshots.pickWorkspaceFolder();
+      expect(result).toBeNull();
+    });
+
+    it('updateWorkspace accepts designId, path, and migrateFiles parameters', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+
+      await window.codesign.snapshots.updateWorkspace('design-1', '/home/user/workspace', false);
+
+      expect(mockUpdate).toHaveBeenCalledWith('design-1', '/home/user/workspace', false);
+    });
+
+    it('updateWorkspace accepts null path to clear workspace', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+
+      await window.codesign.snapshots.updateWorkspace('design-1', null, false);
+
+      expect(mockUpdate).toHaveBeenCalledWith('design-1', null, false);
+    });
+
+    it('openWorkspaceFolder accepts designId parameter', async () => {
+      const mockOpen = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(window.codesign.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+
+      await window.codesign.snapshots.openWorkspaceFolder('design-1');
+
+      expect(mockOpen).toHaveBeenCalledWith('design-1');
+    });
+
+    it('listDesigns returns updated design list after workspace change', async () => {
+      const updatedDesign = mockDesign({ workspacePath: '/home/user/workspace' });
+      const mockList = vi.fn().mockResolvedValue([updatedDesign]);
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      const result = await window.codesign.snapshots.listDesigns();
+
+      expect(result).toEqual([updatedDesign]);
+      expect(result[0]?.workspacePath).toBe('/home/user/workspace');
+    });
+  });
+
+  describe('workspace action flow', () => {
+    it('choose workspace: pick → update → list', async () => {
+      const mockPick = vi.fn().mockResolvedValue('/home/user/workspace');
+      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
+      const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/workspace' })]);
+
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      expect(path).toBe('/home/user/workspace');
+
+      if (path) {
+        const updated = await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+        expect(updated.workspacePath).toBe('/home/user/workspace');
+
+        const designs = await window.codesign.snapshots.listDesigns();
+        useCodesignStore.setState({ designs });
+        expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/workspace');
+      }
+    });
+
+    it('clear workspace: update with null → list', async () => {
+      useCodesignStore.setState({
+        designs: [mockDesign({ workspacePath: '/home/user/workspace' })],
+      });
+
+      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
+      const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: null })]);
+
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      const updated = await window.codesign.snapshots.updateWorkspace('design-1', null, false);
+      expect(updated.workspacePath).toBeNull();
+
+      const designs = await window.codesign.snapshots.listDesigns();
+      useCodesignStore.setState({ designs });
+      expect(useCodesignStore.getState().designs[0]?.workspacePath).toBeNull();
+    });
+
+    it('change workspace: pick → update → list', async () => {
+      useCodesignStore.setState({
+        designs: [mockDesign({ workspacePath: '/home/user/old-workspace' })],
+      });
+
+      const mockPick = vi.fn().mockResolvedValue('/home/user/new-workspace');
+      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/new-workspace' }));
+      const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/new-workspace' })]);
+
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      expect(path).toBe('/home/user/new-workspace');
+
+      if (path) {
+        const updated = await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+        expect(updated.workspacePath).toBe('/home/user/new-workspace');
+
+        const designs = await window.codesign.snapshots.listDesigns();
+        useCodesignStore.setState({ designs });
+        expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/new-workspace');
+      }
+    });
+
+    it('cancel workspace pick: no update or list call', async () => {
+      const mockPick = vi.fn().mockResolvedValue(null);
+      const mockUpdate = vi.fn();
+      const mockList = vi.fn();
+
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      expect(path).toBeNull();
+
+      if (path) {
+        await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+      }
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockList).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workspace API error handling', () => {
+    it('handles pickWorkspaceFolder rejection', async () => {
+      const mockPick = vi.fn().mockRejectedValue(new Error('Dialog error'));
+      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+
+      await expect(window.codesign.snapshots.pickWorkspaceFolder()).rejects.toThrow('Dialog error');
+    });
+
+    it('handles updateWorkspace rejection', async () => {
+      const mockUpdate = vi.fn().mockRejectedValue(new Error('Update failed'));
+      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+
+      await expect(window.codesign.snapshots.updateWorkspace('design-1', '/path', false)).rejects.toThrow(
+        'Update failed',
+      );
+    });
+
+    it('handles openWorkspaceFolder rejection', async () => {
+      const mockOpen = vi.fn().mockRejectedValue(new Error('Open failed'));
+      vi.mocked(window.codesign.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+
+      await expect(window.codesign.snapshots.openWorkspaceFolder('design-1')).rejects.toThrow('Open failed');
+    });
+
+    it('handles listDesigns rejection', async () => {
+      const mockList = vi.fn().mockRejectedValue(new Error('List failed'));
+      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+
+      await expect(window.codesign.snapshots.listDesigns()).rejects.toThrow('List failed');
+    });
+  });
+
+  describe('workspace state consistency', () => {
+    it('preserves workspace binding across design switches', () => {
+      useCodesignStore.setState({
+        designs: [
+          mockDesign({ id: 'design-1', workspacePath: '/path/one' }),
+          mockDesign({ id: 'design-2', workspacePath: '/path/two' }),
+        ],
+      });
+
+      useCodesignStore.setState({ currentDesignId: 'design-1' });
+      let current = useCodesignStore.getState().designs.find((d) => d.id === 'design-1');
+      expect(current?.workspacePath).toBe('/path/one');
+
+      useCodesignStore.setState({ currentDesignId: 'design-2' });
+      current = useCodesignStore.getState().designs.find((d) => d.id === 'design-2');
+      expect(current?.workspacePath).toBe('/path/two');
+
+      useCodesignStore.setState({ currentDesignId: 'design-1' });
+      current = useCodesignStore.getState().designs.find((d) => d.id === 'design-1');
+      expect(current?.workspacePath).toBe('/path/one');
+    });
+
+    it('handles design without workspace alongside designs with workspace', () => {
+      useCodesignStore.setState({
+        designs: [
+          mockDesign({ id: 'design-1', workspacePath: null }),
+          mockDesign({ id: 'design-2', workspacePath: '/path/two' }),
+          mockDesign({ id: 'design-3', workspacePath: null }),
+        ],
+      });
+
+      const designs = useCodesignStore.getState().designs;
+      expect(designs.filter((d) => d.workspacePath === null)).toHaveLength(2);
+      expect(designs.filter((d) => d.workspacePath !== null)).toHaveLength(1);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
@@ -1,8 +1,8 @@
 import { initI18n } from '@open-codesign/i18n';
 import type { Design } from '@open-codesign/shared';
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react')>();
@@ -12,24 +12,23 @@ vi.mock('react', async (importOriginal) => {
     }
     return [init, vi.fn()];
   });
-  
+
   return {
     ...actual,
     default: {
-      ...(actual as any).default,
+      ...(actual as typeof actual & { default: Record<string, unknown> }).default,
       useState: mockUseState,
-      useSyncExternalStore: (sub: any, getSnap: any) => getSnap()
+      useSyncExternalStore: (sub: unknown, getSnap: () => unknown) => getSnap(),
     },
     useState: mockUseState,
-    useSyncExternalStore: (sub: any, getSnap: any) => getSnap()
+    useSyncExternalStore: (sub: unknown, getSnap: () => unknown) => getSnap(),
   };
 });
 
 import type { CodesignApi } from '../../../preload';
+import { useDesignFiles } from '../hooks/useDesignFiles';
 import { useCodesignStore } from '../store';
 import { FilesPanel } from './FilesPanel';
-import { useDesignFiles } from '../hooks/useDesignFiles';
-
 
 vi.mock('../store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../store')>();
@@ -69,6 +68,9 @@ const mockDesign = (overrides?: Partial<Design>): Design => ({
 });
 
 describe('FilesPanel workspace integration', () => {
+  function api() {
+    return window.codesign as NonNullable<typeof window.codesign>;
+  }
   beforeEach(() => {
     useCodesignStore.setState({
       currentDesignId: 'design-1',
@@ -127,44 +129,46 @@ describe('FilesPanel workspace integration', () => {
   describe('workspace action handlers', () => {
     it('pickWorkspaceFolder returns path or null', async () => {
       const mockPick = vi.fn().mockResolvedValue('/home/user/workspace');
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      const result = await window.codesign!.snapshots.pickWorkspaceFolder();
+      const result = await api().snapshots.pickWorkspaceFolder();
       expect(result).toBe('/home/user/workspace');
       expect(mockPick).toHaveBeenCalledOnce();
     });
 
     it('pickWorkspaceFolder returns null when user cancels', async () => {
       const mockPick = vi.fn().mockResolvedValue(null);
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      const result = await window.codesign!.snapshots.pickWorkspaceFolder();
+      const result = await api().snapshots.pickWorkspaceFolder();
       expect(result).toBeNull();
     });
 
     it('updateWorkspace accepts designId, path, and migrateFiles parameters', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      const mockUpdate = vi
+        .fn()
+        .mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await window.codesign!.snapshots.updateWorkspace('design-1', '/home/user/workspace', false);
+      await api().snapshots.updateWorkspace('design-1', '/home/user/workspace', false);
 
       expect(mockUpdate).toHaveBeenCalledWith('design-1', '/home/user/workspace', false);
     });
 
     it('updateWorkspace accepts null path to clear workspace', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await window.codesign!.snapshots.updateWorkspace('design-1', null, false);
+      await api().snapshots.updateWorkspace('design-1', null, false);
 
       expect(mockUpdate).toHaveBeenCalledWith('design-1', null, false);
     });
 
     it('openWorkspaceFolder accepts designId parameter', async () => {
       const mockOpen = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(window.codesign!.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+      vi.mocked(api().snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
 
-      await window.codesign!.snapshots.openWorkspaceFolder('design-1');
+      await api().snapshots.openWorkspaceFolder('design-1');
 
       expect(mockOpen).toHaveBeenCalledWith('design-1');
     });
@@ -172,9 +176,9 @@ describe('FilesPanel workspace integration', () => {
     it('listDesigns returns updated design list after workspace change', async () => {
       const updatedDesign = mockDesign({ workspacePath: '/home/user/workspace' });
       const mockList = vi.fn().mockResolvedValue([updatedDesign]);
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      const result = await window.codesign!.snapshots.listDesigns();
+      const result = await api().snapshots.listDesigns();
 
       expect(result).toEqual([updatedDesign]);
       expect(result[0]?.workspacePath).toBe('/home/user/workspace');
@@ -184,21 +188,25 @@ describe('FilesPanel workspace integration', () => {
   describe('workspace action flow', () => {
     it('choose workspace: pick → update → list', async () => {
       const mockPick = vi.fn().mockResolvedValue('/home/user/workspace');
-      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
-      const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/workspace' })]);
+      const mockUpdate = vi
+        .fn()
+        .mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
+      const mockList = vi
+        .fn()
+        .mockResolvedValue([mockDesign({ workspacePath: '/home/user/workspace' })]);
 
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
+      const path = await api().snapshots.pickWorkspaceFolder();
       expect(path).toBe('/home/user/workspace');
 
       if (path) {
-        const updated = await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
+        const updated = await api().snapshots.updateWorkspace('design-1', path, false);
         expect(updated.workspacePath).toBe('/home/user/workspace');
 
-        const designs = await window.codesign!.snapshots.listDesigns();
+        const designs = await api().snapshots.listDesigns();
         useCodesignStore.setState({ designs });
         expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/workspace');
       }
@@ -212,13 +220,13 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
       const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: null })]);
 
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      const updated = await window.codesign!.snapshots.updateWorkspace('design-1', null, false);
+      const updated = await api().snapshots.updateWorkspace('design-1', null, false);
       expect(updated.workspacePath).toBeNull();
 
-      const designs = await window.codesign!.snapshots.listDesigns();
+      const designs = await api().snapshots.listDesigns();
       useCodesignStore.setState({ designs });
       expect(useCodesignStore.getState().designs[0]?.workspacePath).toBeNull();
     });
@@ -229,23 +237,29 @@ describe('FilesPanel workspace integration', () => {
       });
 
       const mockPick = vi.fn().mockResolvedValue('/home/user/new-workspace');
-      const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/new-workspace' }));
-      const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/new-workspace' })]);
+      const mockUpdate = vi
+        .fn()
+        .mockResolvedValue(mockDesign({ workspacePath: '/home/user/new-workspace' }));
+      const mockList = vi
+        .fn()
+        .mockResolvedValue([mockDesign({ workspacePath: '/home/user/new-workspace' })]);
 
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
+      const path = await api().snapshots.pickWorkspaceFolder();
       expect(path).toBe('/home/user/new-workspace');
 
       if (path) {
-        const updated = await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
+        const updated = await api().snapshots.updateWorkspace('design-1', path, false);
         expect(updated.workspacePath).toBe('/home/user/new-workspace');
 
-        const designs = await window.codesign!.snapshots.listDesigns();
+        const designs = await api().snapshots.listDesigns();
         useCodesignStore.setState({ designs });
-        expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/new-workspace');
+        expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe(
+          '/home/user/new-workspace',
+        );
       }
     });
 
@@ -254,15 +268,15 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn();
       const mockList = vi.fn();
 
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
+      const path = await api().snapshots.pickWorkspaceFolder();
       expect(path).toBeNull();
 
       if (path) {
-        await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
+        await api().snapshots.updateWorkspace('design-1', path, false);
       }
 
       expect(mockUpdate).not.toHaveBeenCalled();
@@ -273,32 +287,32 @@ describe('FilesPanel workspace integration', () => {
   describe('workspace API error handling', () => {
     it('handles pickWorkspaceFolder rejection', async () => {
       const mockPick = vi.fn().mockRejectedValue(new Error('Dialog error'));
-      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(api().snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      await expect(window.codesign!.snapshots.pickWorkspaceFolder()).rejects.toThrow('Dialog error');
+      await expect(api().snapshots.pickWorkspaceFolder()).rejects.toThrow('Dialog error');
     });
 
     it('handles updateWorkspace rejection', async () => {
       const mockUpdate = vi.fn().mockRejectedValue(new Error('Update failed'));
-      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(api().snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await expect(window.codesign!.snapshots.updateWorkspace('design-1', '/path', false)).rejects.toThrow(
+      await expect(api().snapshots.updateWorkspace('design-1', '/path', false)).rejects.toThrow(
         'Update failed',
       );
     });
 
     it('handles openWorkspaceFolder rejection', async () => {
       const mockOpen = vi.fn().mockRejectedValue(new Error('Open failed'));
-      vi.mocked(window.codesign!.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+      vi.mocked(api().snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
 
-      await expect(window.codesign!.snapshots.openWorkspaceFolder('design-1')).rejects.toThrow('Open failed');
+      await expect(api().snapshots.openWorkspaceFolder('design-1')).rejects.toThrow('Open failed');
     });
 
     it('handles listDesigns rejection', async () => {
       const mockList = vi.fn().mockRejectedValue(new Error('List failed'));
-      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(api().snapshots.listDesigns).mockImplementation(mockList);
 
-      await expect(window.codesign!.snapshots.listDesigns()).rejects.toThrow('List failed');
+      await expect(api().snapshots.listDesigns()).rejects.toThrow('List failed');
     });
   });
 
@@ -338,25 +352,29 @@ describe('FilesPanel workspace integration', () => {
       expect(designs.filter((d) => d.workspacePath !== null)).toHaveLength(1);
     });
 
-  describe('FilesPanel rendering UI', () => {
-    beforeEach(() => {
-      vi.mocked(useDesignFiles).mockReturnValue({ files: [], loading: false } as any);
-      useCodesignStore.setState({
-        currentDesignId: 'design-1',
-        designs: [mockDesign({ id: 'design-1', workspacePath: '/path/workspace' })],
+    describe('FilesPanel rendering UI', () => {
+      beforeEach(() => {
+        vi.mocked(useDesignFiles).mockReturnValue({
+          files: [],
+          loading: false,
+          backend: 'snapshots',
+        });
+        useCodesignStore.setState({
+          currentDesignId: 'design-1',
+          designs: [mockDesign({ id: 'design-1', workspacePath: '/path/workspace' })],
+        });
+      });
+
+      it('renders empty state rendering alongside workspace', () => {
+        const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
+        expect(html).toContain('No files yet');
+        expect(html).toContain('Workspace');
+      });
+
+      it('renders unavailable indicator when folderExists is false', () => {
+        const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
+        expect(html).toContain('Folder not found on disk');
       });
     });
-
-    it('renders empty state rendering alongside workspace', () => {
-      const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
-      expect(html).toContain('No files yet');
-      expect(html).toContain('Workspace');
-    });
-
-    it('renders unavailable indicator when folderExists is false', () => {
-      const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
-      expect(html).toContain('Folder not found on disk');
-    });
   });
-});
 });

--- a/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
@@ -1,8 +1,50 @@
 import { initI18n } from '@open-codesign/i18n';
 import type { Design } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  const mockUseState = vi.fn((init) => {
+    if (init === null || init === false) {
+      return [false, vi.fn()];
+    }
+    return [init, vi.fn()];
+  });
+  
+  return {
+    ...actual,
+    default: {
+      ...(actual as any).default,
+      useState: mockUseState,
+      useSyncExternalStore: (sub: any, getSnap: any) => getSnap()
+    },
+    useState: mockUseState,
+    useSyncExternalStore: (sub: any, getSnap: any) => getSnap()
+  };
+});
+
 import type { CodesignApi } from '../../../preload';
 import { useCodesignStore } from '../store';
+import { FilesPanel } from './FilesPanel';
+import { useDesignFiles } from '../hooks/useDesignFiles';
+
+
+vi.mock('../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../store')>();
+  const mockStoreHook = vi.fn((selector) => {
+    return selector(actual.useCodesignStore.getState());
+  });
+  Object.assign(mockStoreHook, actual.useCodesignStore);
+  return {
+    ...actual,
+    useCodesignStore: mockStoreHook,
+  };
+});
+vi.mock('../hooks/useDesignFiles', () => ({
+  useDesignFiles: vi.fn(),
+}));
 
 declare global {
   interface Window {
@@ -295,5 +337,26 @@ describe('FilesPanel workspace integration', () => {
       expect(designs.filter((d) => d.workspacePath === null)).toHaveLength(2);
       expect(designs.filter((d) => d.workspacePath !== null)).toHaveLength(1);
     });
+
+  describe('FilesPanel rendering UI', () => {
+    beforeEach(() => {
+      vi.mocked(useDesignFiles).mockReturnValue({ files: [], loading: false } as any);
+      useCodesignStore.setState({
+        currentDesignId: 'design-1',
+        designs: [mockDesign({ id: 'design-1', workspacePath: '/path/workspace' })],
+      });
+    });
+
+    it('renders empty state rendering alongside workspace', () => {
+      const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
+      expect(html).toContain('No files yet');
+      expect(html).toContain('Workspace');
+    });
+
+    it('renders unavailable indicator when folderExists is false', () => {
+      const html = ReactDOMServer.renderToString(React.createElement(FilesPanel));
+      expect(html).toContain('Folder not found on disk');
+    });
   });
+});
 });

--- a/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
@@ -1,19 +1,28 @@
 import { initI18n } from '@open-codesign/i18n';
 import type { Design } from '@open-codesign/shared';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CodesignApi } from '../../../preload';
 import { useCodesignStore } from '../store';
+
+declare global {
+  interface Window {
+    codesign?: CodesignApi;
+  }
+}
 
 beforeAll(async () => {
   await initI18n('en');
 });
 
 const mockDesign = (overrides?: Partial<Design>): Design => ({
+  schemaVersion: 1,
   id: 'design-1',
   name: 'Test Design',
-  prompt: 'Test prompt',
-  createdAt: new Date('2026-01-01'),
-  updatedAt: new Date('2026-01-01'),
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
   workspacePath: null,
+  thumbnailText: null,
+  deletedAt: null,
   ...overrides,
 });
 
@@ -76,44 +85,44 @@ describe('FilesPanel workspace integration', () => {
   describe('workspace action handlers', () => {
     it('pickWorkspaceFolder returns path or null', async () => {
       const mockPick = vi.fn().mockResolvedValue('/home/user/workspace');
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      const result = await window.codesign.snapshots.pickWorkspaceFolder();
+      const result = await window.codesign!.snapshots.pickWorkspaceFolder();
       expect(result).toBe('/home/user/workspace');
       expect(mockPick).toHaveBeenCalledOnce();
     });
 
     it('pickWorkspaceFolder returns null when user cancels', async () => {
       const mockPick = vi.fn().mockResolvedValue(null);
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      const result = await window.codesign.snapshots.pickWorkspaceFolder();
+      const result = await window.codesign!.snapshots.pickWorkspaceFolder();
       expect(result).toBeNull();
     });
 
     it('updateWorkspace accepts designId, path, and migrateFiles parameters', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await window.codesign.snapshots.updateWorkspace('design-1', '/home/user/workspace', false);
+      await window.codesign!.snapshots.updateWorkspace('design-1', '/home/user/workspace', false);
 
       expect(mockUpdate).toHaveBeenCalledWith('design-1', '/home/user/workspace', false);
     });
 
     it('updateWorkspace accepts null path to clear workspace', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await window.codesign.snapshots.updateWorkspace('design-1', null, false);
+      await window.codesign!.snapshots.updateWorkspace('design-1', null, false);
 
       expect(mockUpdate).toHaveBeenCalledWith('design-1', null, false);
     });
 
     it('openWorkspaceFolder accepts designId parameter', async () => {
       const mockOpen = vi.fn().mockResolvedValue(undefined);
-      vi.mocked(window.codesign.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+      vi.mocked(window.codesign!.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
 
-      await window.codesign.snapshots.openWorkspaceFolder('design-1');
+      await window.codesign!.snapshots.openWorkspaceFolder('design-1');
 
       expect(mockOpen).toHaveBeenCalledWith('design-1');
     });
@@ -121,9 +130,9 @@ describe('FilesPanel workspace integration', () => {
     it('listDesigns returns updated design list after workspace change', async () => {
       const updatedDesign = mockDesign({ workspacePath: '/home/user/workspace' });
       const mockList = vi.fn().mockResolvedValue([updatedDesign]);
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      const result = await window.codesign.snapshots.listDesigns();
+      const result = await window.codesign!.snapshots.listDesigns();
 
       expect(result).toEqual([updatedDesign]);
       expect(result[0]?.workspacePath).toBe('/home/user/workspace');
@@ -136,18 +145,18 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/workspace' }));
       const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/workspace' })]);
 
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
       expect(path).toBe('/home/user/workspace');
 
       if (path) {
-        const updated = await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+        const updated = await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
         expect(updated.workspacePath).toBe('/home/user/workspace');
 
-        const designs = await window.codesign.snapshots.listDesigns();
+        const designs = await window.codesign!.snapshots.listDesigns();
         useCodesignStore.setState({ designs });
         expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/workspace');
       }
@@ -161,13 +170,13 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: null }));
       const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: null })]);
 
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      const updated = await window.codesign.snapshots.updateWorkspace('design-1', null, false);
+      const updated = await window.codesign!.snapshots.updateWorkspace('design-1', null, false);
       expect(updated.workspacePath).toBeNull();
 
-      const designs = await window.codesign.snapshots.listDesigns();
+      const designs = await window.codesign!.snapshots.listDesigns();
       useCodesignStore.setState({ designs });
       expect(useCodesignStore.getState().designs[0]?.workspacePath).toBeNull();
     });
@@ -181,18 +190,18 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn().mockResolvedValue(mockDesign({ workspacePath: '/home/user/new-workspace' }));
       const mockList = vi.fn().mockResolvedValue([mockDesign({ workspacePath: '/home/user/new-workspace' })]);
 
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
       expect(path).toBe('/home/user/new-workspace');
 
       if (path) {
-        const updated = await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+        const updated = await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
         expect(updated.workspacePath).toBe('/home/user/new-workspace');
 
-        const designs = await window.codesign.snapshots.listDesigns();
+        const designs = await window.codesign!.snapshots.listDesigns();
         useCodesignStore.setState({ designs });
         expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/home/user/new-workspace');
       }
@@ -203,15 +212,15 @@ describe('FilesPanel workspace integration', () => {
       const mockUpdate = vi.fn();
       const mockList = vi.fn();
 
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      const path = await window.codesign!.snapshots.pickWorkspaceFolder();
       expect(path).toBeNull();
 
       if (path) {
-        await window.codesign.snapshots.updateWorkspace('design-1', path, false);
+        await window.codesign!.snapshots.updateWorkspace('design-1', path, false);
       }
 
       expect(mockUpdate).not.toHaveBeenCalled();
@@ -222,32 +231,32 @@ describe('FilesPanel workspace integration', () => {
   describe('workspace API error handling', () => {
     it('handles pickWorkspaceFolder rejection', async () => {
       const mockPick = vi.fn().mockRejectedValue(new Error('Dialog error'));
-      vi.mocked(window.codesign.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
+      vi.mocked(window.codesign!.snapshots.pickWorkspaceFolder).mockImplementation(mockPick);
 
-      await expect(window.codesign.snapshots.pickWorkspaceFolder()).rejects.toThrow('Dialog error');
+      await expect(window.codesign!.snapshots.pickWorkspaceFolder()).rejects.toThrow('Dialog error');
     });
 
     it('handles updateWorkspace rejection', async () => {
       const mockUpdate = vi.fn().mockRejectedValue(new Error('Update failed'));
-      vi.mocked(window.codesign.snapshots.updateWorkspace).mockImplementation(mockUpdate);
+      vi.mocked(window.codesign!.snapshots.updateWorkspace).mockImplementation(mockUpdate);
 
-      await expect(window.codesign.snapshots.updateWorkspace('design-1', '/path', false)).rejects.toThrow(
+      await expect(window.codesign!.snapshots.updateWorkspace('design-1', '/path', false)).rejects.toThrow(
         'Update failed',
       );
     });
 
     it('handles openWorkspaceFolder rejection', async () => {
       const mockOpen = vi.fn().mockRejectedValue(new Error('Open failed'));
-      vi.mocked(window.codesign.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
+      vi.mocked(window.codesign!.snapshots.openWorkspaceFolder).mockImplementation(mockOpen);
 
-      await expect(window.codesign.snapshots.openWorkspaceFolder('design-1')).rejects.toThrow('Open failed');
+      await expect(window.codesign!.snapshots.openWorkspaceFolder('design-1')).rejects.toThrow('Open failed');
     });
 
     it('handles listDesigns rejection', async () => {
       const mockList = vi.fn().mockRejectedValue(new Error('List failed'));
-      vi.mocked(window.codesign.snapshots.listDesigns).mockImplementation(mockList);
+      vi.mocked(window.codesign!.snapshots.listDesigns).mockImplementation(mockList);
 
-      await expect(window.codesign.snapshots.listDesigns()).rejects.toThrow('List failed');
+      await expect(window.codesign!.snapshots.listDesigns()).rejects.toThrow('List failed');
     });
   });
 

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -1,5 +1,6 @@
 import { useT } from '@open-codesign/i18n';
-import { FileCode2 } from 'lucide-react';
+import { FileCode2, Folder, FolderOpen, X } from 'lucide-react';
+import { useState } from 'react';
 import { formatAbsoluteTime, formatRelativeTime, useDesignFiles } from '../hooks/useDesignFiles';
 import { useCodesignStore } from '../store';
 
@@ -10,11 +11,67 @@ function formatBytes(n: number | undefined): string {
   return `${(n / (1024 * 1024)).toFixed(2)} MB`;
 }
 
+function truncatePath(path: string, maxLength: number = 50): string {
+  if (path.length <= maxLength) return path;
+  const start = path.substring(0, maxLength / 2 - 2);
+  const end = path.substring(path.length - maxLength / 2 + 2);
+  return `${start}…${end}`;
+}
+
 export function FilesPanel() {
   const t = useT();
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const designs = useCodesignStore((s) => s.designs);
   const openFileTab = useCodesignStore((s) => s.openCanvasFileTab);
   const { files, loading } = useDesignFiles(currentDesignId);
+  const [workspaceLoading, setWorkspaceLoading] = useState(false);
+
+  const currentDesign = designs.find((d) => d.id === currentDesignId);
+  const workspacePath = currentDesign?.workspacePath ?? null;
+
+  async function handlePickWorkspace() {
+    if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
+    try {
+      setWorkspaceLoading(true);
+      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      if (path && currentDesignId) {
+        await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
+        const updated = await window.codesign.snapshots.listDesigns();
+        useCodesignStore.setState({ designs: updated });
+      }
+    } catch (err) {
+      console.error('Failed to pick workspace:', err);
+    } finally {
+      setWorkspaceLoading(false);
+    }
+  }
+
+  async function handleOpenWorkspace() {
+    if (!currentDesignId || !window.codesign?.snapshots.openWorkspaceFolder) return;
+    try {
+      setWorkspaceLoading(true);
+      await window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
+    } catch (err) {
+      console.error('Failed to open workspace:', err);
+    } finally {
+      setWorkspaceLoading(false);
+    }
+  }
+
+  async function handleClearWorkspace() {
+    if (!currentDesignId || !window.codesign?.snapshots.updateWorkspace) return;
+    try {
+      setWorkspaceLoading(true);
+      await window.codesign.snapshots.updateWorkspace(currentDesignId, null, false);
+      const updated = await window.codesign.snapshots.listDesigns();
+      useCodesignStore.setState({ designs: updated });
+    } catch (err) {
+      console.error('Failed to clear workspace:', err);
+    } finally {
+      setWorkspaceLoading(false);
+    }
+  }
+
 
   if (!currentDesignId) {
     return (
@@ -48,46 +105,112 @@ export function FilesPanel() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-[720px] px-[var(--space-6)] py-[var(--space-8)]">
-        <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-          <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
-            {t('canvas.files.sectionTitle')}
-          </h2>
-          <span
-            className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
-            style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
-          >
-            {files.length}
-          </span>
-        </header>
+        <section className="mb-[var(--space-8)]">
+          <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
+            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+              {t('canvas.workspace.sectionTitle')}
+            </h2>
+          </header>
 
-        <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-2)]">
-          {files.map((f) => (
-            <li key={f.path}>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between px-[var(--space-4)] py-[var(--space-3)] rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)]">
+              <div className="flex-1 min-w-0 flex flex-col gap-1">
+                <span className="text-[var(--text-xs)] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)] font-medium">
+                  {t('canvas.workspace.label')}
+                </span>
+                {workspacePath ? (
+                  <span
+                    className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-mono"
+                    title={workspacePath}
+                  >
+                    {truncatePath(workspacePath)}
+                  </span>
+                ) : (
+                  <span className="text-[var(--text-sm)] text-[var(--color-text-muted)]">
+                    {t('canvas.workspace.default')}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-2">
               <button
                 type="button"
-                onClick={() => openFileTab(f.path)}
-                className="group w-full flex items-center gap-[var(--space-3)] px-[var(--space-4)] h-[52px] text-left rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-[background-color,border-color,transform] duration-[var(--duration-faster)] active:scale-[var(--scale-press-down)]"
+                onClick={handlePickWorkspace}
+                disabled={workspaceLoading}
+                className="flex-1 h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
-                <FileCode2
-                  className="w-[18px] h-[18px] shrink-0 text-[var(--color-text-secondary)]"
-                  aria-hidden
-                />
-                <div className="flex-1 min-w-0 flex flex-col gap-[2px]">
-                  <span className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-sans leading-[var(--leading-ui)]">
-                    {f.path}
-                  </span>
-                  <span
-                    className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
-                    title={formatAbsoluteTime(f.updatedAt)}
-                    style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
-                  >
-                    {formatBytes(f.size)} · {formatRelativeTime(f.updatedAt)}
-                  </span>
-                </div>
+                <Folder className="w-3 h-3 inline mr-1" aria-hidden />
+                {workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
               </button>
-            </li>
-          ))}
-        </ul>
+
+              {workspacePath && (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleOpenWorkspace}
+                    disabled={workspaceLoading}
+                    className="h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <FolderOpen className="w-3 h-3" aria-hidden />
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleClearWorkspace}
+                    disabled={workspaceLoading}
+                    className="h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <X className="w-3 h-3" aria-hidden />
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
+            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+              {t('canvas.files.sectionTitle')}
+            </h2>
+            <span
+              className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
+              style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+            >
+              {files.length}
+            </span>
+          </header>
+
+          <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-2)]">
+            {files.map((f) => (
+              <li key={f.path}>
+                <button
+                  type="button"
+                  onClick={() => openFileTab(f.path)}
+                  className="group w-full flex items-center gap-[var(--space-3)] px-[var(--space-4)] h-[52px] text-left rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-[background-color,border-color,transform] duration-[var(--duration-faster)] active:scale-[var(--scale-press-down)]"
+                >
+                  <FileCode2
+                    className="w-[18px] h-[18px] shrink-0 text-[var(--color-text-secondary)]"
+                    aria-hidden
+                  />
+                  <div className="flex-1 min-w-0 flex flex-col gap-[2px]">
+                    <span className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-sans leading-[var(--leading-ui)]">
+                      {f.path}
+                    </span>
+                    <span
+                      className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
+                      title={formatAbsoluteTime(f.updatedAt)}
+                      style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+                    >
+                      {formatBytes(f.size)} · {formatRelativeTime(f.updatedAt)}
+                    </span>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -157,7 +157,7 @@ export function FilesPanel() {
       <div className="mx-auto max-w-[720px] px-[var(--space-6)] py-[var(--space-8)]">
         <section className="mb-[var(--space-8)]">
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.workspace.sectionTitle')}
             </h2>
           </header>
@@ -228,11 +228,11 @@ export function FilesPanel() {
 
         <section>
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-xs)] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-2xs)] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -269,7 +269,7 @@ export function FilesPanel() {
                         {f.path}
                       </span>
                       <span
-                        className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
+                        className="text-[var(--font-size-body-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
                         title={formatAbsoluteTime(f.updatedAt)}
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -2,6 +2,7 @@ import { useT } from '@open-codesign/i18n';
 import { FileCode2, Folder, FolderOpen, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { formatAbsoluteTime, formatRelativeTime, useDesignFiles } from '../hooks/useDesignFiles';
+import { workspacePathComparisonKey } from '../lib/workspace-path';
 import { useCodesignStore } from '../store';
 
 function formatBytes(n: number | undefined): string {
@@ -65,10 +66,10 @@ export function FilesPanel() {
       setWorkspaceLoading(true);
       const path = await window.codesign.snapshots.pickWorkspaceFolder();
       if (path && currentDesign && currentDesignId) {
-        const normalizePath = (p: string) => p.replaceAll('\\', '/').replace(/\/+$/, '');
         if (
           currentDesign.workspacePath &&
-          normalizePath(currentDesign.workspacePath) !== normalizePath(path)
+          workspacePathComparisonKey(currentDesign.workspacePath) !==
+            workspacePathComparisonKey(path)
         ) {
           requestWorkspaceRebind(currentDesign, path);
         } else if (!currentDesign.workspacePath) {

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { FileCode2, Folder, FolderOpen, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { formatAbsoluteTime, formatRelativeTime, useDesignFiles } from '../hooks/useDesignFiles';
 import { useCodesignStore } from '../store';
 
@@ -11,7 +11,7 @@ function formatBytes(n: number | undefined): string {
   return `${(n / (1024 * 1024)).toFixed(2)} MB`;
 }
 
-function truncatePath(path: string, maxLength: number = 50): string {
+function truncatePath(path: string, maxLength = 50): string {
   if (path.length <= maxLength) return path;
   const start = path.substring(0, maxLength / 2 - 2);
   const end = path.substring(path.length - maxLength / 2 + 2);
@@ -28,10 +28,21 @@ export function FilesPanel() {
   const requestWorkspaceRebind = useCodesignStore((s) => s.requestWorkspaceRebind);
   const { files, loading } = useDesignFiles(currentDesignId);
   const [workspaceLoading, setWorkspaceLoading] = useState(false);
+  const [folderExists, setFolderExists] = useState<boolean | null>(null);
 
   const currentDesign = designs.find((d) => d.id === currentDesignId);
   const workspacePath = currentDesign?.workspacePath ?? null;
   const isCurrentDesignGenerating = isGenerating && generatingDesignId === currentDesignId;
+
+  useEffect(() => {
+    if (!workspacePath || !currentDesignId) {
+      setFolderExists(null);
+      return;
+    }
+    window.codesign?.snapshots.checkWorkspaceFolder?.(currentDesignId)
+      .then(r => setFolderExists(r.exists))
+      .catch(() => setFolderExists(null));
+  }, [currentDesignId, workspacePath]);
 
   async function handlePickWorkspace() {
     if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
@@ -101,7 +112,6 @@ export function FilesPanel() {
     }
   }
 
-
   if (!currentDesignId) {
     return (
       <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
@@ -114,19 +124,6 @@ export function FilesPanel() {
     return (
       <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
         {t('common.loading')}
-      </div>
-    );
-  }
-
-  if (files.length === 0) {
-    return (
-      <div className="h-full flex flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-6)] text-center">
-        <div className="w-12 h-12 rounded-full border border-dashed border-[var(--color-border)] flex items-center justify-center">
-          <FileCode2 className="w-5 h-5 text-[var(--color-text-muted)] opacity-70" aria-hidden />
-        </div>
-        <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] max-w-sm leading-[var(--leading-body)]">
-          {t('canvas.files.empty')}
-        </p>
       </div>
     );
   }
@@ -148,12 +145,19 @@ export function FilesPanel() {
                   {t('canvas.workspace.label')}
                 </span>
                 {workspacePath ? (
-                  <span
-                    className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-mono"
-                    title={workspacePath}
-                  >
-                    {truncatePath(workspacePath)}
-                  </span>
+                  <>
+                    <span
+                      className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-mono"
+                      title={workspacePath}
+                    >
+                      {truncatePath(workspacePath)}
+                    </span>
+                    {folderExists === false && (
+                      <span className="text-[var(--text-xs)] text-[var(--color-text-warning,_theme(colors.amber.500))]">
+                        {t('canvas.workspace.unavailable')}
+                      </span>
+                    )}
+                  </>
                 ) : (
                   <span className="text-[var(--text-sm)] text-[var(--color-text-muted)]">
                     {t('canvas.workspace.default')}
@@ -211,34 +215,45 @@ export function FilesPanel() {
             </span>
           </header>
 
-          <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-2)]">
-            {files.map((f) => (
-              <li key={f.path}>
-                <button
-                  type="button"
-                  onClick={() => openFileTab(f.path)}
-                  className="group w-full flex items-center gap-[var(--space-3)] px-[var(--space-4)] h-[52px] text-left rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-[background-color,border-color,transform] duration-[var(--duration-faster)] active:scale-[var(--scale-press-down)]"
-                >
-                  <FileCode2
-                    className="w-[18px] h-[18px] shrink-0 text-[var(--color-text-secondary)]"
-                    aria-hidden
-                  />
-                  <div className="flex-1 min-w-0 flex flex-col gap-[2px]">
-                    <span className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-sans leading-[var(--leading-ui)]">
-                      {f.path}
-                    </span>
-                    <span
-                      className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
-                      title={formatAbsoluteTime(f.updatedAt)}
-                      style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
-                    >
-                      {formatBytes(f.size)} · {formatRelativeTime(f.updatedAt)}
-                    </span>
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
+          {files.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-6)] text-center py-[var(--space-8)]">
+              <div className="w-12 h-12 rounded-full border border-dashed border-[var(--color-border)] flex items-center justify-center">
+                <FileCode2 className="w-5 h-5 text-[var(--color-text-muted)] opacity-70" aria-hidden />
+              </div>
+              <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] max-w-sm leading-[var(--leading-body)]">
+                {t('canvas.files.empty')}
+              </p>
+            </div>
+          ) : (
+            <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-2)]">
+              {files.map((f) => (
+                <li key={f.path}>
+                  <button
+                    type="button"
+                    onClick={() => openFileTab(f.path)}
+                    className="group w-full flex items-center gap-[var(--space-3)] px-[var(--space-4)] h-[52px] text-left rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] transition-[background-color,border-color,transform] duration-[var(--duration-faster)] active:scale-[var(--scale-press-down)]"
+                  >
+                    <FileCode2
+                      className="w-[18px] h-[18px] shrink-0 text-[var(--color-text-secondary)]"
+                      aria-hidden
+                    />
+                    <div className="flex-1 min-w-0 flex flex-col gap-[2px]">
+                      <span className="truncate text-[var(--text-sm)] text-[var(--color-text-primary)] font-sans leading-[var(--leading-ui)]">
+                        {f.path}
+                      </span>
+                      <span
+                        className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
+                        title={formatAbsoluteTime(f.updatedAt)}
+                        style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+                      >
+                        {formatBytes(f.size)} · {formatRelativeTime(f.updatedAt)}
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -39,8 +39,9 @@ export function FilesPanel() {
       setFolderExists(null);
       return;
     }
-    window.codesign?.snapshots.checkWorkspaceFolder?.(currentDesignId)
-      .then(r => setFolderExists(r.exists))
+    window.codesign?.snapshots
+      .checkWorkspaceFolder?.(currentDesignId)
+      .then((r) => setFolderExists(r.exists))
       .catch(() => setFolderExists(null));
   }, [currentDesignId, workspacePath]);
 
@@ -218,7 +219,10 @@ export function FilesPanel() {
           {files.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-6)] text-center py-[var(--space-8)]">
               <div className="w-12 h-12 rounded-full border border-dashed border-[var(--color-border)] flex items-center justify-center">
-                <FileCode2 className="w-5 h-5 text-[var(--color-text-muted)] opacity-70" aria-hidden />
+                <FileCode2
+                  className="w-5 h-5 text-[var(--color-text-muted)] opacity-70"
+                  aria-hidden
+                />
               </div>
               <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] max-w-sm leading-[var(--leading-body)]">
                 {t('canvas.files.empty')}

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -58,7 +58,11 @@ export function FilesPanel() {
       setWorkspaceLoading(true);
       const path = await window.codesign.snapshots.pickWorkspaceFolder();
       if (path && currentDesign && currentDesignId) {
-        if (currentDesign.workspacePath && currentDesign.workspacePath !== path) {
+        const normalizePath = (p: string) => p.replaceAll('\\', '/').replace(/\/+$/, '');
+        if (
+          currentDesign.workspacePath &&
+          normalizePath(currentDesign.workspacePath) !== normalizePath(path)
+        ) {
           requestWorkspaceRebind(currentDesign, path);
         } else if (!currentDesign.workspacePath) {
           await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
@@ -67,7 +71,11 @@ export function FilesPanel() {
         }
       }
     } catch (err) {
-      console.error('Failed to pick workspace:', err);
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.updateFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
     } finally {
       setWorkspaceLoading(false);
     }
@@ -86,7 +94,11 @@ export function FilesPanel() {
       setWorkspaceLoading(true);
       await window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
     } catch (err) {
-      console.error('Failed to open workspace:', err);
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.updateFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
     } finally {
       setWorkspaceLoading(false);
     }
@@ -107,7 +119,11 @@ export function FilesPanel() {
       const updated = await window.codesign.snapshots.listDesigns();
       useCodesignStore.setState({ designs: updated });
     } catch (err) {
-      console.error('Failed to clear workspace:', err);
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.updateFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
     } finally {
       setWorkspaceLoading(false);
     }

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -22,22 +22,37 @@ export function FilesPanel() {
   const t = useT();
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
   const designs = useCodesignStore((s) => s.designs);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const generatingDesignId = useCodesignStore((s) => s.generatingDesignId);
   const openFileTab = useCodesignStore((s) => s.openCanvasFileTab);
+  const requestWorkspaceRebind = useCodesignStore((s) => s.requestWorkspaceRebind);
   const { files, loading } = useDesignFiles(currentDesignId);
   const [workspaceLoading, setWorkspaceLoading] = useState(false);
 
   const currentDesign = designs.find((d) => d.id === currentDesignId);
   const workspacePath = currentDesign?.workspacePath ?? null;
+  const isCurrentDesignGenerating = isGenerating && generatingDesignId === currentDesignId;
 
   async function handlePickWorkspace() {
     if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
+    if (isCurrentDesignGenerating) {
+      useCodesignStore.getState().pushToast({
+        variant: 'info',
+        title: t('canvas.workspace.busyGenerating'),
+      });
+      return;
+    }
     try {
       setWorkspaceLoading(true);
       const path = await window.codesign.snapshots.pickWorkspaceFolder();
-      if (path && currentDesignId) {
-        await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
-        const updated = await window.codesign.snapshots.listDesigns();
-        useCodesignStore.setState({ designs: updated });
+      if (path && currentDesign && currentDesignId) {
+        if (currentDesign.workspacePath && currentDesign.workspacePath !== path) {
+          requestWorkspaceRebind(currentDesign, path);
+        } else if (!currentDesign.workspacePath) {
+          await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
+          const updated = await window.codesign.snapshots.listDesigns();
+          useCodesignStore.setState({ designs: updated });
+        }
       }
     } catch (err) {
       console.error('Failed to pick workspace:', err);
@@ -48,6 +63,13 @@ export function FilesPanel() {
 
   async function handleOpenWorkspace() {
     if (!currentDesignId || !window.codesign?.snapshots.openWorkspaceFolder) return;
+    if (isCurrentDesignGenerating) {
+      useCodesignStore.getState().pushToast({
+        variant: 'info',
+        title: t('canvas.workspace.busyGenerating'),
+      });
+      return;
+    }
     try {
       setWorkspaceLoading(true);
       await window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
@@ -60,6 +82,13 @@ export function FilesPanel() {
 
   async function handleClearWorkspace() {
     if (!currentDesignId || !window.codesign?.snapshots.updateWorkspace) return;
+    if (isCurrentDesignGenerating) {
+      useCodesignStore.getState().pushToast({
+        variant: 'info',
+        title: t('canvas.workspace.busyGenerating'),
+      });
+      return;
+    }
     try {
       setWorkspaceLoading(true);
       await window.codesign.snapshots.updateWorkspace(currentDesignId, null, false);
@@ -137,7 +166,7 @@ export function FilesPanel() {
               <button
                 type="button"
                 onClick={handlePickWorkspace}
-                disabled={workspaceLoading}
+                disabled={workspaceLoading || isCurrentDesignGenerating}
                 className="flex-1 h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 <Folder className="w-3 h-3 inline mr-1" aria-hidden />
@@ -149,7 +178,7 @@ export function FilesPanel() {
                   <button
                     type="button"
                     onClick={handleOpenWorkspace}
-                    disabled={workspaceLoading}
+                    disabled={workspaceLoading || isCurrentDesignGenerating}
                     className="h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     <FolderOpen className="w-3 h-3" aria-hidden />
@@ -158,7 +187,7 @@ export function FilesPanel() {
                   <button
                     type="button"
                     onClick={handleClearWorkspace}
-                    disabled={workspaceLoading}
+                    disabled={workspaceLoading || isCurrentDesignGenerating}
                     className="h-8 px-3 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     <X className="w-3 h-3" aria-hidden />

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -157,7 +157,7 @@ export function FilesPanel() {
       <div className="mx-auto max-w-[720px] px-[var(--space-6)] py-[var(--space-8)]">
         <section className="mb-[var(--space-8)]">
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.workspace.sectionTitle')}
             </h2>
           </header>
@@ -228,11 +228,11 @@ export function FilesPanel() {
 
         <section>
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-2xs)] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -269,7 +269,7 @@ export function FilesPanel() {
                         {f.path}
                       </span>
                       <span
-                        className="text-[var(--font-size-body-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
+                        className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
                         title={formatAbsoluteTime(f.updatedAt)}
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -42,8 +42,15 @@ export function FilesPanel() {
     window.codesign?.snapshots
       .checkWorkspaceFolder?.(currentDesignId)
       .then((r) => setFolderExists(r.exists))
-      .catch(() => setFolderExists(null));
-  }, [currentDesignId, workspacePath]);
+      .catch((err) => {
+        setFolderExists(null);
+        useCodesignStore.getState().pushToast({
+          variant: 'error',
+          title: t('canvas.workspace.updateFailed'),
+          description: err instanceof Error ? err.message : t('errors.unknown'),
+        });
+      });
+  }, [currentDesignId, workspacePath, t]);
 
   async function handlePickWorkspace() {
     if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
@@ -150,7 +157,7 @@ export function FilesPanel() {
       <div className="mx-auto max-w-[720px] px-[var(--space-6)] py-[var(--space-8)]">
         <section className="mb-[var(--space-8)]">
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.workspace.sectionTitle')}
             </h2>
           </header>
@@ -221,11 +228,11 @@ export function FilesPanel() {
 
         <section>
           <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-xs)] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -262,7 +269,7 @@ export function FilesPanel() {
                         {f.path}
                       </span>
                       <span
-                        className="text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
+                        className="text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-ui)]"
                         title={formatAbsoluteTime(f.updatedAt)}
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -232,7 +232,7 @@ export function FilesPanel() {
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -95,11 +95,11 @@ function WorkspaceSection() {
 
   return (
     <div className="flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] min-w-0">
-      <span className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
+      <span className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
         {t('canvas.workspace.sectionTitle')}
       </span>
       <span
-        className="flex-1 min-w-0 truncate text-[var(--text-xs)] text-[var(--color-text-secondary)]"
+        className="flex-1 min-w-0 truncate text-[var(--text-2xs)] text-[var(--color-text-secondary)]"
         title={workspacePath ?? undefined}
         style={{ fontFamily: 'var(--font-mono)' }}
       >
@@ -123,7 +123,7 @@ function WorkspaceSection() {
           type="button"
           onClick={handlePickWorkspace}
           disabled={disabled}
-          className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
+          className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-2xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
           title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
         >
           <Folder className="w-3 h-3" aria-hidden />
@@ -134,7 +134,7 @@ function WorkspaceSection() {
             type="button"
             onClick={handleOpenWorkspace}
             disabled={isCurrentDesignGenerating}
-            className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-2xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             title={t('canvas.workspace.open')}
           >
             <FolderOpen className="w-3 h-3" aria-hidden />
@@ -206,11 +206,11 @@ export function FilesTabView() {
         <WorkspaceSection />
         <div className="px-[var(--space-6)] py-[var(--space-6)]">
           <div className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-xs)] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-2xs)] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -255,7 +255,7 @@ export function FilesTabView() {
                         {name}
                       </span>
                       <span
-                        className="text-[var(--text-xs)] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
+                        className="text-[var(--text-2xs)] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >
                         {formatBytes(f.size)}
@@ -267,7 +267,7 @@ export function FilesTabView() {
             })}
           </ul>
 
-          <p className="mt-[var(--space-6)] text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
+          <p className="mt-[var(--space-6)] text-[var(--font-size-body-xs)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
             {t('canvas.previewHint')}
           </p>
         </div>
@@ -283,7 +283,7 @@ export function FilesTabView() {
           <button
             type="button"
             onClick={() => selectedPath && openFileTab(selectedPath)}
-            className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
+            className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
           >
             {t('canvas.openInTab')}
           </button>

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -64,9 +64,17 @@ function WorkspaceSection() {
         ) {
           requestWorkspaceRebind(currentDesign, path);
         } else if (!currentDesign.workspacePath) {
-          await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
-          const updated = await window.codesign.snapshots.listDesigns();
-          useCodesignStore.setState({ designs: updated });
+          try {
+            await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
+            const updated = await window.codesign.snapshots.listDesigns();
+            useCodesignStore.setState({ designs: updated });
+          } catch (err) {
+            useCodesignStore.getState().pushToast({
+              variant: 'error',
+              title: t('canvas.workspace.updateFailed'),
+              description: err instanceof Error ? err.message : t('errors.unknown'),
+            });
+          }
         }
       }
     } finally {

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -3,6 +3,7 @@ import { buildSrcdoc } from '@open-codesign/runtime';
 import { FileCode2, Folder, FolderOpen } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDesignFiles } from '../hooks/useDesignFiles';
+import { workspacePathComparisonKey } from '../lib/workspace-path';
 import { useCodesignStore } from '../store';
 
 function truncatePath(path: string, maxLength = 40): string {
@@ -57,10 +58,10 @@ function WorkspaceSection() {
       setPicking(true);
       const path = await window.codesign.snapshots.pickWorkspaceFolder();
       if (path && currentDesign && currentDesignId) {
-        const normalizePath = (p: string) => p.replaceAll('\\', '/').replace(/\/+$/, '');
         if (
           currentDesign.workspacePath &&
-          normalizePath(currentDesign.workspacePath) !== normalizePath(path)
+          workspacePathComparisonKey(currentDesign.workspacePath) !==
+            workspacePathComparisonKey(path)
         ) {
           requestWorkspaceRebind(currentDesign, path);
         } else if (!currentDesign.workspacePath) {

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -1,9 +1,130 @@
 import { useT } from '@open-codesign/i18n';
 import { buildSrcdoc } from '@open-codesign/runtime';
-import { FileCode2 } from 'lucide-react';
+import { FileCode2, Folder, FolderOpen } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDesignFiles } from '../hooks/useDesignFiles';
 import { useCodesignStore } from '../store';
+
+function truncatePath(path: string, maxLength = 40): string {
+  if (path.length <= maxLength) return path;
+  const start = path.substring(0, maxLength / 2 - 2);
+  const end = path.substring(path.length - maxLength / 2 + 2);
+  return `${start}…${end}`;
+}
+
+function WorkspaceSection() {
+  const t = useT();
+  const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const designs = useCodesignStore((s) => s.designs);
+  const isGenerating = useCodesignStore((s) => s.isGenerating);
+  const generatingDesignId = useCodesignStore((s) => s.generatingDesignId);
+  const requestWorkspaceRebind = useCodesignStore((s) => s.requestWorkspaceRebind);
+  const [picking, setPicking] = useState(false);
+  const [folderExists, setFolderExists] = useState<boolean | null>(null);
+
+  const currentDesign = designs.find((d) => d.id === currentDesignId);
+  const workspacePath = currentDesign?.workspacePath ?? null;
+  const isCurrentDesignGenerating = isGenerating && generatingDesignId === currentDesignId;
+  const disabled = picking || isCurrentDesignGenerating;
+
+  useEffect(() => {
+    if (!workspacePath || !currentDesignId) {
+      setFolderExists(null);
+      return;
+    }
+    window.codesign?.snapshots
+      .checkWorkspaceFolder?.(currentDesignId)
+      .then((r) => setFolderExists(r.exists))
+      .catch(() => setFolderExists(null));
+  }, [currentDesignId, workspacePath]);
+
+  async function handlePickWorkspace() {
+    if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
+    if (isCurrentDesignGenerating) {
+      useCodesignStore
+        .getState()
+        .pushToast({ variant: 'info', title: t('canvas.workspace.busyGenerating') });
+      return;
+    }
+    try {
+      setPicking(true);
+      const path = await window.codesign.snapshots.pickWorkspaceFolder();
+      if (path && currentDesign && currentDesignId) {
+        if (currentDesign.workspacePath && currentDesign.workspacePath !== path) {
+          requestWorkspaceRebind(currentDesign, path);
+        } else if (!currentDesign.workspacePath) {
+          await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);
+          const updated = await window.codesign.snapshots.listDesigns();
+          useCodesignStore.setState({ designs: updated });
+        }
+      }
+    } finally {
+      setPicking(false);
+    }
+  }
+
+  function handleOpenWorkspace() {
+    if (!currentDesignId || !window.codesign?.snapshots.openWorkspaceFolder) return;
+    if (isCurrentDesignGenerating) {
+      useCodesignStore
+        .getState()
+        .pushToast({ variant: 'info', title: t('canvas.workspace.busyGenerating') });
+      return;
+    }
+    void window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
+  }
+
+  return (
+    <div className="flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] min-w-0">
+      <span className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
+        {t('canvas.workspace.sectionTitle')}
+      </span>
+      <span
+        className="flex-1 min-w-0 truncate text-[10px] text-[var(--color-text-secondary)]"
+        title={workspacePath ?? undefined}
+        style={{ fontFamily: 'var(--font-mono)' }}
+      >
+        {workspacePath ? (
+          <>
+            {truncatePath(workspacePath)}
+            {folderExists === false && (
+              <span className="ml-1 text-[var(--color-text-warning,_theme(colors.amber.500))]">
+                !
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="text-[var(--color-text-muted)] not-italic">
+            {t('canvas.workspace.default')}
+          </span>
+        )}
+      </span>
+      <div className="flex items-center gap-[var(--space-1)] shrink-0">
+        <button
+          type="button"
+          onClick={handlePickWorkspace}
+          disabled={disabled}
+          className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
+          title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
+        >
+          <Folder className="w-3 h-3" aria-hidden />
+          {workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
+        </button>
+        {workspacePath && (
+          <button
+            type="button"
+            onClick={handleOpenWorkspace}
+            disabled={isCurrentDesignGenerating}
+            className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            title={t('canvas.workspace.open')}
+          >
+            <FolderOpen className="w-3 h-3" aria-hidden />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function formatBytes(n: number | undefined): string {
   if (n === undefined) return '';
@@ -44,8 +165,16 @@ export function FilesTabView() {
 
   if (files.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
-        {t('canvas.filesTabEmpty')}
+      <div className="flex h-full min-h-0">
+        <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
+          <WorkspaceSection />
+          <div className="flex-1 flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)] px-[var(--space-6)]">
+            {t('canvas.filesTabEmpty')}
+          </div>
+        </aside>
+        <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
+          {t('canvas.filesTabEmpty')}
+        </div>
       </div>
     );
   }
@@ -54,7 +183,8 @@ export function FilesTabView() {
 
   return (
     <div className="flex h-full min-h-0">
-      <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto">
+      <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
+        <WorkspaceSection />
         <div className="px-[var(--space-6)] py-[var(--space-6)]">
           <div className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
             <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -103,11 +103,11 @@ function WorkspaceSection() {
 
   return (
     <div className="flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] min-w-0">
-      <span className="text-[var(--text-2xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
+      <span className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
         {t('canvas.workspace.sectionTitle')}
       </span>
       <span
-        className="flex-1 min-w-0 truncate text-[var(--text-2xs)] text-[var(--color-text-secondary)]"
+        className="flex-1 min-w-0 truncate text-[10px] text-[var(--color-text-secondary)]"
         title={workspacePath ?? undefined}
         style={{ fontFamily: 'var(--font-mono)' }}
       >
@@ -131,7 +131,7 @@ function WorkspaceSection() {
           type="button"
           onClick={handlePickWorkspace}
           disabled={disabled}
-          className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-2xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
+          className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
           title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
         >
           <Folder className="w-3 h-3" aria-hidden />
@@ -142,7 +142,7 @@ function WorkspaceSection() {
             type="button"
             onClick={handleOpenWorkspace}
             disabled={isCurrentDesignGenerating}
-            className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-2xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             title={t('canvas.workspace.open')}
           >
             <FolderOpen className="w-3 h-3" aria-hidden />
@@ -214,11 +214,11 @@ export function FilesTabView() {
         <WorkspaceSection />
         <div className="px-[var(--space-6)] py-[var(--space-6)]">
           <div className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-2xs)] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -263,7 +263,7 @@ export function FilesTabView() {
                         {name}
                       </span>
                       <span
-                        className="text-[var(--text-2xs)] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
+                        className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >
                         {formatBytes(f.size)}
@@ -275,7 +275,7 @@ export function FilesTabView() {
             })}
           </ul>
 
-          <p className="mt-[var(--space-6)] text-[var(--font-size-body-xs)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
+          <p className="mt-[var(--space-6)] text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
             {t('canvas.previewHint')}
           </p>
         </div>
@@ -291,7 +291,7 @@ export function FilesTabView() {
           <button
             type="button"
             onClick={() => selectedPath && openFileTab(selectedPath)}
-            className="text-[var(--font-size-body-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
+            className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
           >
             {t('canvas.openInTab')}
           </button>

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -50,7 +50,11 @@ function WorkspaceSection() {
       setPicking(true);
       const path = await window.codesign.snapshots.pickWorkspaceFolder();
       if (path && currentDesign && currentDesignId) {
-        if (currentDesign.workspacePath && currentDesign.workspacePath !== path) {
+        const normalizePath = (p: string) => p.replaceAll('\\', '/').replace(/\/+$/, '');
+        if (
+          currentDesign.workspacePath &&
+          normalizePath(currentDesign.workspacePath) !== normalizePath(path)
+        ) {
           requestWorkspaceRebind(currentDesign, path);
         } else if (!currentDesign.workspacePath) {
           await window.codesign.snapshots.updateWorkspace(currentDesignId, path, false);

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -35,8 +35,15 @@ function WorkspaceSection() {
     window.codesign?.snapshots
       .checkWorkspaceFolder?.(currentDesignId)
       .then((r) => setFolderExists(r.exists))
-      .catch(() => setFolderExists(null));
-  }, [currentDesignId, workspacePath]);
+      .catch((err) => {
+        setFolderExists(null);
+        useCodesignStore.getState().pushToast({
+          variant: 'error',
+          title: t('canvas.workspace.updateFailed'),
+          description: err instanceof Error ? err.message : t('errors.unknown'),
+        });
+      });
+  }, [currentDesignId, workspacePath, t]);
 
   async function handlePickWorkspace() {
     if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
@@ -67,7 +74,7 @@ function WorkspaceSection() {
     }
   }
 
-  function handleOpenWorkspace() {
+  async function handleOpenWorkspace() {
     if (!currentDesignId || !window.codesign?.snapshots.openWorkspaceFolder) return;
     if (isCurrentDesignGenerating) {
       useCodesignStore
@@ -75,16 +82,24 @@ function WorkspaceSection() {
         .pushToast({ variant: 'info', title: t('canvas.workspace.busyGenerating') });
       return;
     }
-    void window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
+    try {
+      await window.codesign.snapshots.openWorkspaceFolder(currentDesignId);
+    } catch (err) {
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.updateFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
+    }
   }
 
   return (
     <div className="flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] min-w-0">
-      <span className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
+      <span className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
         {t('canvas.workspace.sectionTitle')}
       </span>
       <span
-        className="flex-1 min-w-0 truncate text-[10px] text-[var(--color-text-secondary)]"
+        className="flex-1 min-w-0 truncate text-[var(--text-xs)] text-[var(--color-text-secondary)]"
         title={workspacePath ?? undefined}
         style={{ fontFamily: 'var(--font-mono)' }}
       >
@@ -108,7 +123,7 @@ function WorkspaceSection() {
           type="button"
           onClick={handlePickWorkspace}
           disabled={disabled}
-          className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
+          className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
           title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
         >
           <Folder className="w-3 h-3" aria-hidden />
@@ -119,7 +134,7 @@ function WorkspaceSection() {
             type="button"
             onClick={handleOpenWorkspace}
             disabled={isCurrentDesignGenerating}
-            className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="h-6 px-2 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             title={t('canvas.workspace.open')}
           >
             <FolderOpen className="w-3 h-3" aria-hidden />
@@ -191,11 +206,11 @@ export function FilesTabView() {
         <WorkspaceSection />
         <div className="px-[var(--space-6)] py-[var(--space-6)]">
           <div className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
-            <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
+            <h2 className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
               {t('canvas.files.sectionTitle')}
             </h2>
             <span
-              className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[10px] text-[var(--color-text-muted)]"
+              className="inline-flex items-center justify-center min-w-[18px] h-[var(--space-4)] px-[5px] rounded-[var(--radius-sm)] bg-[var(--color-background-secondary)] text-[var(--text-xs)] text-[var(--color-text-muted)]"
               style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
             >
               {files.length}
@@ -240,7 +255,7 @@ export function FilesTabView() {
                         {name}
                       </span>
                       <span
-                        className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
+                        className="text-[var(--text-xs)] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
                         style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                       >
                         {formatBytes(f.size)}
@@ -252,7 +267,7 @@ export function FilesTabView() {
             })}
           </ul>
 
-          <p className="mt-[var(--space-6)] text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
+          <p className="mt-[var(--space-6)] text-[var(--text-xs)] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
             {t('canvas.previewHint')}
           </p>
         </div>
@@ -268,12 +283,12 @@ export function FilesTabView() {
           <button
             type="button"
             onClick={() => selectedPath && openFileTab(selectedPath)}
-            className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
+            className="text-[var(--text-xs)] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
           >
             {t('canvas.openInTab')}
           </button>
         </div>
-        <div className="flex-1 min-h-0 bg-white">
+        <div className="flex-1 min-h-0 bg-[var(--color-background-secondary)]">
           {srcDoc ? (
             <iframe
               ref={iframeRef}

--- a/apps/desktop/src/renderer/src/components/NewDesignDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/NewDesignDialog.tsx
@@ -1,0 +1,112 @@
+import { useT } from '@open-codesign/i18n';
+import { FolderOpen } from 'lucide-react';
+import { useState } from 'react';
+import { useCodesignStore } from '../store';
+
+export function NewDesignDialog() {
+  const t = useT();
+  const open = useCodesignStore((s) => s.newDesignDialogOpen);
+  const close = useCodesignStore((s) => s.closeNewDesignDialog);
+  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
+  const setView = useCodesignStore((s) => s.setView);
+
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [picking, setPicking] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  if (!open) return null;
+
+  async function handlePickFolder() {
+    if (!window.codesign?.snapshots?.pickWorkspaceFolder) return;
+    setPicking(true);
+    try {
+      const picked = await window.codesign.snapshots.pickWorkspaceFolder();
+      if (picked) setSelectedPath(picked);
+    } finally {
+      setPicking(false);
+    }
+  }
+
+  async function handleCreate(withPath: string | null) {
+    setCreating(true);
+    try {
+      const design = await createNewDesign(withPath);
+      close();
+      setSelectedPath(null);
+      if (design) setView('workspace');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const busy = picking || creating;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('canvas.newDesignDialog.title')}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) {
+          close();
+          setSelectedPath(null);
+        }
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && !busy) {
+          close();
+          setSelectedPath(null);
+        }
+      }}
+    >
+      <div
+        role="document"
+        className="w-full max-w-sm rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] p-5 space-y-4 animate-[panel-in_160ms_ease-out]"
+      >
+        <div className="space-y-1">
+          <h3 className="text-[var(--text-md)] font-medium text-[var(--color-text-primary)]">
+            {t('canvas.newDesignDialog.title')}
+          </h3>
+          <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
+            {t('canvas.newDesignDialog.subtitle')}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
+          <span className="flex-1 text-[var(--text-sm)] text-[var(--color-text-secondary)] font-mono truncate">
+            {selectedPath ?? t('canvas.newDesignDialog.noWorkspace')}
+          </span>
+          <button
+            type="button"
+            onClick={() => void handlePickFolder()}
+            disabled={busy}
+            className="flex items-center gap-1.5 shrink-0 h-7 px-2.5 rounded-[var(--radius-sm)] text-[var(--text-xs)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <FolderOpen className="size-3.5" />
+            {selectedPath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
+          </button>
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => void handleCreate(null)}
+            disabled={busy}
+            className="h-9 px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {t('canvas.newDesignDialog.skip')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleCreate(selectedPath)}
+            disabled={busy}
+            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          >
+            {t('canvas.newDesignDialog.confirm')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/RebindWorkspaceDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/RebindWorkspaceDialog.tsx
@@ -1,0 +1,91 @@
+import { useT } from '@open-codesign/i18n';
+import { useState } from 'react';
+import { useCodesignStore } from '../store';
+
+export function RebindWorkspaceDialog() {
+  const t = useT();
+  const pending = useCodesignStore((s) => s.workspaceRebindPending);
+  const cancelRebind = useCodesignStore((s) => s.cancelWorkspaceRebind);
+  const confirmRebind = useCodesignStore((s) => s.confirmWorkspaceRebind);
+  const [isLoading, setIsLoading] = useState(false);
+
+  if (!pending) return null;
+
+  const { design, newPath } = pending;
+
+  async function handleSwitchOnly() {
+    setIsLoading(true);
+    try {
+      await confirmRebind(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleSwitchAndCopy() {
+    setIsLoading(true);
+    try {
+      await confirmRebind(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('canvas.workspace.rebindTitle')}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) cancelRebind();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') cancelRebind();
+      }}
+    >
+      <div
+        role="document"
+        className="w-full max-w-sm rounded-[var(--radius-2xl)] bg-[var(--color-background)] border border-[var(--color-border)] shadow-[var(--shadow-elevated)] p-5 space-y-4 animate-[panel-in_160ms_ease-out]"
+      >
+        <h3 className="text-[var(--text-md)] font-medium text-[var(--color-text-primary)]">
+          {t('canvas.workspace.rebindTitle')}
+        </h3>
+        <div className="space-y-2">
+          <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
+            {t('canvas.workspace.rebindDescription')}
+          </p>
+          <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] font-mono break-all">
+            {newPath}
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => cancelRebind()}
+            disabled={isLoading}
+            className="h-9 px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {t('canvas.workspace.rebindCancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSwitchOnly()}
+            disabled={isLoading}
+            className="h-9 px-3 rounded-[var(--radius-md)] text-[var(--text-sm)] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {t('canvas.workspace.rebindSwitchOnly')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSwitchAndCopy()}
+            disabled={isLoading}
+            className="h-9 px-3 rounded-[var(--radius-md)] bg-[var(--color-accent)] text-[var(--color-on-accent)] text-[var(--text-sm)] font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          >
+            {t('canvas.workspace.rebindSwitchAndCopy')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/workspace-path.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace-path.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { workspacePathComparisonKey } from './workspace-path';
+
+describe('workspacePathComparisonKey', () => {
+  it('normalizes separators and trailing slashes on all platforms', () => {
+    expect(workspacePathComparisonKey('C:\\Work\\Project\\', 'Win32')).toBe('c:/work/project');
+    expect(workspacePathComparisonKey('/tmp/workspace/', 'Linux x86_64')).toBe('/tmp/workspace');
+  });
+
+  it('preserves case on non-Windows platforms', () => {
+    expect(workspacePathComparisonKey('/Users/Roy/Workspace', 'MacIntel')).not.toBe(
+      workspacePathComparisonKey('/users/roy/workspace', 'MacIntel'),
+    );
+  });
+
+  it('folds case on Windows platforms', () => {
+    expect(workspacePathComparisonKey('C:/Work/Project', 'Win32')).toBe(
+      workspacePathComparisonKey('c:/work/project/', 'Win32'),
+    );
+  });
+
+  it('preserves root paths when stripping trailing slashes', () => {
+    expect(workspacePathComparisonKey('C:/', 'Win32')).toBe('c:/');
+    expect(workspacePathComparisonKey('/', 'Linux')).toBe('/');
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/workspace-path.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace-path.ts
@@ -1,0 +1,15 @@
+function stripTrailingSlash(value: string): string {
+  if (value === '/' || /^[A-Za-z]:\/$/.test(value)) {
+    return value;
+  }
+  return value.replace(/\/+$/, '');
+}
+
+function isWindowsPlatform(platform: string): boolean {
+  return platform.toLowerCase().includes('win');
+}
+
+export function workspacePathComparisonKey(path: string, platform = navigator.platform): string {
+  const normalized = stripTrailingSlash(path.replaceAll('\\', '/'));
+  return isWindowsPlatform(platform) ? normalized.toLowerCase() : normalized;
+}

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -584,6 +584,7 @@ describe('useCodesignStore artifact persistence', () => {
       updatedAt: '2024-01-01T00:00:00.000Z',
       thumbnailText: null,
       deletedAt: null,
+      workspacePath: null,
     };
 
     // Stand-in for the SQLite-backed snapshots table.

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1146,7 +1146,9 @@ describe('useCodesignStore workspace rebind confirmation flow', () => {
       },
     });
 
-    await expect(useCodesignStore.getState().confirmWorkspaceRebind(false)).rejects.toThrow('Update failed');
+    await expect(useCodesignStore.getState().confirmWorkspaceRebind(false)).rejects.toThrow(
+      'Update failed',
+    );
     // Pending state should still be cleared on error
     expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
   });

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1026,3 +1026,191 @@ describe('applyGenerateError via sendPrompt', () => {
     });
   });
 });
+
+describe('useCodesignStore workspace rebind confirmation flow', () => {
+  const mockDesign = {
+    schemaVersion: 1 as const,
+    id: 'design-1',
+    name: 'Test Design',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    thumbnailText: null,
+    deletedAt: null,
+    workspacePath: '/old/path',
+  };
+
+  it('requestWorkspaceRebind sets pending state with design and new path', () => {
+    useCodesignStore.setState({ designs: [mockDesign], currentDesignId: 'design-1' });
+
+    useCodesignStore.getState().requestWorkspaceRebind(mockDesign, '/new/path');
+
+    const state = useCodesignStore.getState();
+    expect(state.workspaceRebindPending).toEqual({
+      design: mockDesign,
+      newPath: '/new/path',
+    });
+  });
+
+  it('cancelWorkspaceRebind clears pending state', () => {
+    useCodesignStore.setState({
+      workspaceRebindPending: {
+        design: mockDesign,
+        newPath: '/new/path',
+      },
+    });
+
+    useCodesignStore.getState().cancelWorkspaceRebind();
+
+    expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
+  });
+
+  it('confirmWorkspaceRebind(false) calls updateWorkspace with migrateFiles=false, refreshes designs, and clears pending', async () => {
+    const updatedDesign = { ...mockDesign, workspacePath: '/new/path' };
+    const updateWorkspace = vi.fn().mockResolvedValue(updatedDesign);
+    const listDesigns = vi.fn().mockResolvedValue([updatedDesign]);
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          updateWorkspace,
+          listDesigns,
+        },
+      },
+    });
+
+    useCodesignStore.setState({
+      designs: [mockDesign],
+      currentDesignId: 'design-1',
+      workspaceRebindPending: {
+        design: mockDesign,
+        newPath: '/new/path',
+      },
+    });
+
+    await useCodesignStore.getState().confirmWorkspaceRebind(false);
+
+    expect(updateWorkspace).toHaveBeenCalledWith('design-1', '/new/path', false);
+    expect(listDesigns).toHaveBeenCalledOnce();
+    expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
+    expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/new/path');
+  });
+
+  it('confirmWorkspaceRebind(true) calls updateWorkspace with migrateFiles=true, refreshes designs, and clears pending', async () => {
+    const updatedDesign = { ...mockDesign, workspacePath: '/new/path' };
+    const updateWorkspace = vi.fn().mockResolvedValue(updatedDesign);
+    const listDesigns = vi.fn().mockResolvedValue([updatedDesign]);
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          updateWorkspace,
+          listDesigns,
+        },
+      },
+    });
+
+    useCodesignStore.setState({
+      designs: [mockDesign],
+      currentDesignId: 'design-1',
+      workspaceRebindPending: {
+        design: mockDesign,
+        newPath: '/new/path',
+      },
+    });
+
+    await useCodesignStore.getState().confirmWorkspaceRebind(true);
+
+    expect(updateWorkspace).toHaveBeenCalledWith('design-1', '/new/path', true);
+    expect(listDesigns).toHaveBeenCalledOnce();
+    expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
+    expect(useCodesignStore.getState().designs[0]?.workspacePath).toBe('/new/path');
+  });
+
+  it('confirmWorkspaceRebind handles updateWorkspace errors gracefully', async () => {
+    const updateWorkspace = vi.fn().mockRejectedValue(new Error('Update failed'));
+
+    vi.stubGlobal('window', {
+      codesign: {
+        snapshots: {
+          updateWorkspace,
+        },
+      },
+    });
+
+    useCodesignStore.setState({
+      designs: [mockDesign],
+      currentDesignId: 'design-1',
+      workspaceRebindPending: {
+        design: mockDesign,
+        newPath: '/new/path',
+      },
+    });
+
+    await expect(useCodesignStore.getState().confirmWorkspaceRebind(false)).rejects.toThrow('Update failed');
+    // Pending state should still be cleared on error
+    expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
+  });
+});
+
+describe('useCodesignStore generation-blocking workspace guards', () => {
+  const mockDesign = {
+    schemaVersion: 1 as const,
+    id: 'design-1',
+    name: 'Test Design',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    thumbnailText: null,
+    deletedAt: null,
+    workspacePath: null,
+  };
+
+  it('blocks requestWorkspaceRebind when current design is generating', () => {
+    useCodesignStore.setState({
+      designs: [mockDesign],
+      currentDesignId: 'design-1',
+      isGenerating: true,
+      generatingDesignId: 'design-1',
+      workspaceRebindPending: null,
+    });
+
+    useCodesignStore.getState().requestWorkspaceRebind(mockDesign, '/new/path');
+
+    // Should not set pending state when generation is active
+    expect(useCodesignStore.getState().workspaceRebindPending).toBeNull();
+  });
+
+  it('allows requestWorkspaceRebind when a different design is generating', () => {
+    useCodesignStore.setState({
+      designs: [mockDesign, { ...mockDesign, id: 'design-2' }],
+      currentDesignId: 'design-1',
+      isGenerating: true,
+      generatingDesignId: 'design-2',
+      workspaceRebindPending: null,
+    });
+
+    useCodesignStore.getState().requestWorkspaceRebind(mockDesign, '/new/path');
+
+    // Should allow rebind when generation is for a different design
+    expect(useCodesignStore.getState().workspaceRebindPending).toEqual({
+      design: mockDesign,
+      newPath: '/new/path',
+    });
+  });
+
+  it('allows requestWorkspaceRebind when not generating', () => {
+    useCodesignStore.setState({
+      designs: [mockDesign],
+      currentDesignId: 'design-1',
+      isGenerating: false,
+      generatingDesignId: null,
+      workspaceRebindPending: null,
+    });
+
+    useCodesignStore.getState().requestWorkspaceRebind(mockDesign, '/new/path');
+
+    expect(useCodesignStore.getState().workspaceRebindPending).toEqual({
+      design: mockDesign,
+      newPath: '/new/path',
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -1967,8 +1967,17 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       void get().loadChatForCurrentDesign();
       void get().loadCommentsForCurrentDesign();
       if (workspacePath) {
-        await window.codesign.snapshots.updateWorkspace(design.id, workspacePath, false);
-        await get().loadDesigns();
+        try {
+          await window.codesign.snapshots.updateWorkspace(design.id, workspacePath, false);
+          await get().loadDesigns();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : tr('errors.unknown');
+          get().pushToast({
+            variant: 'error',
+            title: tr('canvas.workspace.updateFailed'),
+            description: msg,
+          });
+        }
       }
       return design;
     } catch (err) {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -198,6 +198,7 @@ interface CodesignState {
   currentDesignId: string | null;
   designsLoaded: boolean;
   designsViewOpen: boolean;
+  newDesignDialogOpen: boolean;
   designToDelete: Design | null;
   designToRename: Design | null;
   /** Workspace rebind confirmation state: { design, newPath } when user picks a different folder */
@@ -349,7 +350,9 @@ interface CodesignState {
 
   loadDesigns: () => Promise<void>;
   ensureCurrentDesign: () => Promise<void>;
-  createNewDesign: () => Promise<Design | null>;
+  openNewDesignDialog: () => void;
+  closeNewDesignDialog: () => void;
+  createNewDesign: (workspacePath?: string | null) => Promise<Design | null>;
   switchDesign: (id: string) => Promise<void>;
   renameCurrentDesign: (name: string) => Promise<void>;
   renameDesign: (id: string, name: string) => Promise<void>;
@@ -1365,6 +1368,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   currentDesignId: null,
   designsLoaded: false,
   designsViewOpen: false,
+  newDesignDialogOpen: false,
   designToDelete: null,
   designToRename: null,
   workspaceRebindPending: null,
@@ -1922,7 +1926,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
     await get().createNewDesign();
   },
 
-  async createNewDesign() {
+  async createNewDesign(workspacePath?: string | null) {
     if (!window.codesign) return null;
     if (get().isGenerating) {
       // Don't silently drop the request — callers like the Examples flow
@@ -1962,6 +1966,10 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
       await get().loadDesigns();
       void get().loadChatForCurrentDesign();
       void get().loadCommentsForCurrentDesign();
+      if (workspacePath) {
+        await window.codesign.snapshots.updateWorkspace(design.id, workspacePath, false);
+        await get().loadDesigns();
+      }
       return design;
     } catch (err) {
       const msg = err instanceof Error ? err.message : tr('errors.unknown');
@@ -2191,6 +2199,12 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   },
   closeDesignsView() {
     set({ designsViewOpen: false });
+  },
+  openNewDesignDialog() {
+    set({ newDesignDialogOpen: true });
+  },
+  closeNewDesignDialog() {
+    set({ newDesignDialogOpen: false });
   },
   requestDeleteDesign(design) {
     set({ designToDelete: design });

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -200,6 +200,8 @@ interface CodesignState {
   designsViewOpen: boolean;
   designToDelete: Design | null;
   designToRename: Design | null;
+  /** Workspace rebind confirmation state: { design, newPath } when user picks a different folder */
+  workspaceRebindPending: { design: Design; newPath: string } | null;
 
   theme: Theme;
   view: AppView;
@@ -357,6 +359,10 @@ interface CodesignState {
   closeDesignsView: () => void;
   requestDeleteDesign: (design: Design | null) => void;
   requestRenameDesign: (design: Design | null) => void;
+
+  requestWorkspaceRebind: (design: Design, newPath: string) => void;
+  cancelWorkspaceRebind: () => void;
+  confirmWorkspaceRebind: (migrateFiles: boolean) => Promise<void>;
 
   pushToast: (toast: Omit<Toast, 'id'>) => string;
   /**
@@ -1361,6 +1367,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   designsViewOpen: false,
   designToDelete: null,
   designToRename: null,
+  workspaceRebindPending: null,
 
   inputFiles: [],
   referenceUrl: '',
@@ -2190,6 +2197,45 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   },
   requestRenameDesign(design) {
     set({ designToRename: design });
+  },
+
+  requestWorkspaceRebind(design, newPath) {
+    // Block workspace changes while the current design is generating
+    const state = get();
+    if (state.isGenerating && state.generatingDesignId === state.currentDesignId) {
+      return;
+    }
+    set({ workspaceRebindPending: { design, newPath } });
+  },
+
+  cancelWorkspaceRebind() {
+    set({ workspaceRebindPending: null });
+  },
+
+  async confirmWorkspaceRebind(migrateFiles) {
+    if (!window.codesign) return;
+    const pending = get().workspaceRebindPending;
+    if (!pending) return;
+
+    const { design, newPath } = pending;
+    try {
+      await window.codesign.snapshots.updateWorkspace(design.id, newPath, migrateFiles);
+      const updated = await window.codesign.snapshots.listDesigns();
+      set({ designs: updated, workspaceRebindPending: null });
+      get().pushToast({
+        variant: 'success',
+        title: tr('canvas.workspace.updated'),
+      });
+    } catch (err) {
+      set({ workspaceRebindPending: null });
+      const msg = err instanceof Error ? err.message : tr('errors.unknown');
+      get().pushToast({
+        variant: 'error',
+        title: tr('canvas.workspace.updateFailed'),
+        description: msg,
+      });
+      throw err;
+    }
   },
 
   pushToast(toast) {

--- a/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
@@ -8,8 +8,7 @@ const RECENT_LIMIT = 6;
 export function RecentTab() {
   const t = useT();
   const designs = useCodesignStore((s) => s.designs);
-  const createNewDesign = useCodesignStore((s) => s.createNewDesign);
-  const setView = useCodesignStore((s) => s.setView);
+  const openNewDesignDialog = useCodesignStore((s) => s.openNewDesignDialog);
   const isGenerating = useCodesignStore(
     (s) => s.isGenerating && s.generatingDesignId === s.currentDesignId,
   );
@@ -18,9 +17,8 @@ export function RecentTab() {
     .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
     .slice(0, RECENT_LIMIT);
 
-  async function handleNewDesign(): Promise<void> {
-    const design = await createNewDesign();
-    if (design) setView('workspace');
+  function handleNewDesign(): void {
+    openNewDesignDialog();
   }
 
   const newDesignTile = (

--- a/packages/core/src/tools/text-editor.ts
+++ b/packages/core/src/tools/text-editor.ts
@@ -15,9 +15,9 @@ import { Type } from '@sinclair/typebox';
 
 export interface TextEditorFsCallbacks {
   view(path: string): { content: string; numLines: number } | null;
-  create(path: string, content: string): { path: string };
-  strReplace(path: string, oldStr: string, newStr: string): { path: string };
-  insert(path: string, line: number, text: string): { path: string };
+  create(path: string, content: string): Promise<{ path: string }> | { path: string };
+  strReplace(path: string, oldStr: string, newStr: string): Promise<{ path: string }> | { path: string };
+  insert(path: string, line: number, text: string): Promise<{ path: string }> | { path: string };
   /** Optional: list files for `view` on a directory. Returns sorted paths. */
   listDir(dir: string): string[];
 }
@@ -135,20 +135,20 @@ export function makeTextEditorTool(
         }
         case 'create': {
           const text = params.file_text ?? '';
-          const result = fs.create(path, text);
+          const result = await fs.create(path, text);
           return ok(`Created ${result.path}`, { command: 'create', path, result });
         }
         case 'str_replace': {
           const oldStr = params.old_str ?? '';
           const newStr = params.new_str ?? '';
           if (oldStr.length === 0) throw new Error('str_replace requires non-empty old_str');
-          const result = fs.strReplace(path, oldStr, newStr);
+          const result = await fs.strReplace(path, oldStr, newStr);
           return ok(`Edited ${result.path}`, { command: 'str_replace', path, result });
         }
         case 'insert': {
           const line = params.insert_line ?? 0;
           const text = params.new_str ?? '';
-          const result = fs.insert(path, line, text);
+          const result = await fs.insert(path, line, text);
           return ok(`Inserted at ${result.path}:${line}`, { command: 'insert', path, result });
         }
       }

--- a/packages/core/src/tools/text-editor.ts
+++ b/packages/core/src/tools/text-editor.ts
@@ -16,7 +16,11 @@ import { Type } from '@sinclair/typebox';
 export interface TextEditorFsCallbacks {
   view(path: string): { content: string; numLines: number } | null;
   create(path: string, content: string): Promise<{ path: string }> | { path: string };
-  strReplace(path: string, oldStr: string, newStr: string): Promise<{ path: string }> | { path: string };
+  strReplace(
+    path: string,
+    oldStr: string,
+    newStr: string,
+  ): Promise<{ path: string }> | { path: string };
   insert(path: string, line: number, text: string): Promise<{ path: string }> | { path: string };
   /** Optional: list files for `view` on a directory. Returns sorted paths. */
   listDir(dir: string): string[];

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -49,6 +49,13 @@
       "sectionSubtitle": "{{count}} files",
       "empty": "No files yet. Send a prompt to have the agent generate a design — files will show up here."
     },
+    "workspace": {
+      "sectionTitle": "Workspace",
+      "label": "Folder",
+      "default": "Default internal storage",
+      "choose": "Choose folder",
+      "change": "Change"
+    },
     "rail": {
       "title": "Files",
       "collapse": "Collapse files",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -57,6 +57,7 @@
       "change": "Change",
       "open": "Open folder",
       "clear": "Clear workspace",
+      "unavailable": "Folder not found on disk",
       "busyGenerating": "Cannot change workspace while generating",
       "updated": "Workspace updated",
       "updateFailed": "Failed to update workspace",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -54,7 +54,17 @@
       "label": "Folder",
       "default": "Default internal storage",
       "choose": "Choose folder",
-      "change": "Change"
+      "change": "Change",
+      "open": "Open folder",
+      "clear": "Clear workspace",
+      "busyGenerating": "Cannot change workspace while generating",
+      "updated": "Workspace updated",
+      "updateFailed": "Failed to update workspace",
+      "rebindTitle": "Change workspace folder?",
+      "rebindDescription": "This design already has a workspace folder. Choose how to proceed:",
+      "rebindCancel": "Cancel",
+      "rebindSwitchOnly": "Switch without copying",
+      "rebindSwitchAndCopy": "Switch and copy files"
     },
     "rail": {
       "title": "Files",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -49,6 +49,13 @@
       "sectionSubtitle": "{{count}} files",
       "empty": "No files yet. Send a prompt to have the agent generate a design — files will show up here."
     },
+    "newDesignDialog": {
+      "title": "New design",
+      "subtitle": "Optionally choose a local folder to sync your design files.",
+      "noWorkspace": "No folder selected",
+      "skip": "Skip",
+      "confirm": "Create"
+    },
     "workspace": {
       "sectionTitle": "Workspace",
       "label": "Folder",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -49,6 +49,31 @@
       "sectionSubtitle": "{{count}} arquivos",
       "empty": "Nenhum arquivo ainda. Envie um prompt para o agente gerar um design — os arquivos vão aparecer aqui."
     },
+    "newDesignDialog": {
+      "title": "Novo design",
+      "subtitle": "Opcionalmente escolha uma pasta local para sincronizar seus arquivos de design.",
+      "noWorkspace": "Nenhuma pasta selecionada",
+      "skip": "Pular",
+      "confirm": "Criar"
+    },
+    "workspace": {
+      "sectionTitle": "Espaço de trabalho",
+      "label": "Pasta",
+      "default": "Armazenamento interno padrão",
+      "choose": "Escolher pasta",
+      "change": "Alterar",
+      "open": "Abrir pasta",
+      "clear": "Remover espaço de trabalho",
+      "unavailable": "Pasta não encontrada no disco",
+      "busyGenerating": "Não é possível alterar o espaço de trabalho durante a geração",
+      "updated": "Espaço de trabalho atualizado",
+      "updateFailed": "Falha ao atualizar espaço de trabalho",
+      "rebindTitle": "Alterar pasta do espaço de trabalho?",
+      "rebindDescription": "Este design já tem uma pasta de espaço de trabalho. Escolha como prosseguir:",
+      "rebindCancel": "Cancelar",
+      "rebindSwitchOnly": "Alternar sem copiar",
+      "rebindSwitchAndCopy": "Alternar e copiar arquivos"
+    },
     "rail": {
       "title": "Arquivos",
       "collapse": "Recolher arquivos",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -57,6 +57,7 @@
       "change": "更改",
       "open": "打开文件夹",
       "clear": "清除工作区",
+      "unavailable": "文件夹在磁盘上不存在",
       "busyGenerating": "生成中无法更改工作区",
       "updated": "工作区已更新",
       "updateFailed": "更新工作区失败",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -49,6 +49,23 @@
       "sectionSubtitle": "共 {{count}} 个文件",
       "empty": "还没有文件。发送一个 prompt 让 AI 生成设计后，文件会出现在这里。"
     },
+    "workspace": {
+      "sectionTitle": "工作区",
+      "label": "文件夹",
+      "default": "默认内部存储",
+      "choose": "选择文件夹",
+      "change": "更改",
+      "open": "打开文件夹",
+      "clear": "清除工作区",
+      "busyGenerating": "生成中无法更改工作区",
+      "updated": "工作区已更新",
+      "updateFailed": "更新工作区失败",
+      "rebindTitle": "更改工作区文件夹？",
+      "rebindDescription": "此设计已有工作区文件夹。请选择如何继续：",
+      "rebindCancel": "取消",
+      "rebindSwitchOnly": "仅切换（不复制文件）",
+      "rebindSwitchAndCopy": "切换并复制文件"
+    },
     "rail": {
       "title": "文件",
       "collapse": "折叠文件",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -49,6 +49,13 @@
       "sectionSubtitle": "共 {{count}} 个文件",
       "empty": "还没有文件。发送一个 prompt 让 AI 生成设计后，文件会出现在这里。"
     },
+    "newDesignDialog": {
+      "title": "新建项目",
+      "subtitle": "可选择一个本地文件夹，用于同步设计文件。",
+      "noWorkspace": "未选择文件夹",
+      "skip": "跳过",
+      "confirm": "创建"
+    },
     "workspace": {
       "sectionTitle": "工作区",
       "label": "文件夹",

--- a/packages/shared/src/snapshot.test.ts
+++ b/packages/shared/src/snapshot.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { DesignV1 } from './snapshot';
+
+describe('DesignV1', () => {
+  it('parses legacy row without workspacePath as null', () => {
+    const row = {
+      id: 'design-123',
+      createdAt: '2026-04-22T10:00:00Z',
+      updatedAt: '2026-04-22T10:00:00Z',
+    };
+    const result = DesignV1.parse(row);
+    expect(result.workspacePath).toBeNull();
+    expect(result.name).toBe('Untitled design');
+    expect(result.schemaVersion).toBe(1);
+  });
+
+  it('parses valid string workspacePath correctly', () => {
+    const row = {
+      id: 'design-456',
+      createdAt: '2026-04-22T10:00:00Z',
+      updatedAt: '2026-04-22T10:00:00Z',
+      workspacePath: '/home/user/projects/my-design',
+    };
+    const result = DesignV1.parse(row);
+    expect(result.workspacePath).toBe('/home/user/projects/my-design');
+  });
+
+  it('parses explicit null workspacePath correctly', () => {
+    const row = {
+      id: 'design-789',
+      createdAt: '2026-04-22T10:00:00Z',
+      updatedAt: '2026-04-22T10:00:00Z',
+      workspacePath: null,
+    };
+    const result = DesignV1.parse(row);
+    expect(result.workspacePath).toBeNull();
+  });
+
+  it('rejects invalid type for workspacePath', () => {
+    const row = {
+      id: 'design-invalid',
+      createdAt: '2026-04-22T10:00:00Z',
+      updatedAt: '2026-04-22T10:00:00Z',
+      workspacePath: 12345,
+    };
+    expect(() => DesignV1.parse(row)).toThrow();
+  });
+
+  it('rejects invalid type (array) for workspacePath', () => {
+    const row = {
+      id: 'design-invalid-array',
+      createdAt: '2026-04-22T10:00:00Z',
+      updatedAt: '2026-04-22T10:00:00Z',
+      workspacePath: ['path'],
+    };
+    expect(() => DesignV1.parse(row)).toThrow();
+  });
+});

--- a/packages/shared/src/snapshot.ts
+++ b/packages/shared/src/snapshot.ts
@@ -22,6 +22,7 @@ export const DesignV1 = z.object({
   updatedAt: z.string(),
   thumbnailText: z.string().nullable().default(null),
   deletedAt: z.string().nullable().default(null),
+  workspacePath: z.string().nullable().default(null),
 });
 export type Design = z.infer<typeof DesignV1>;
 


### PR DESCRIPTION

## Summary
- Adds a `NewDesignDialog` modal that appears whenever the user clicks "New Design" (Recent tab, Design Switcher, Designs view)
- The dialog lets the user pick a workspace folder via the native file picker, shows the chosen path, and offers a "Change" button
- Skipping is allowed; "Skip" creates the design without a bound workspace
- Workspace scope is per-design only

## Type of change
- [x] New feature

## Linked issue
close #133 

## Checklist

- [x] I read [`docs/VISION.md`](../docs/VISION.md), [`docs/PRINCIPLES.md`](../docs/PRINCIPLES.md), and [`CLAUDE.md`](../CLAUDE.md) before starting
- [x] Commits are signed with DCO (`git commit -s`)
- [x] `pnpm lint && pnpm typecheck && pnpm test` passes locally
- [x] Added/updated tests for the change
- [x] Added a changeset (`pnpm changeset`) if user-visible
- [x] Updated docs if behavior changed

## Changes
- `store.ts` — new `newDesignDialogOpen` state + open/close actions; `createNewDesign` now accepts optional `workspacePath`
- `NewDesignDialog.tsx` — new modal component (created)
- `App.tsx` — mounts `<NewDesignDialog />`
- `RecentTab.tsx`, `DesignSwitcher.tsx`, `DesignsView.tsx` — call `openNewDesignDialog()` instead of `createNewDesign` directly
- `FilesTabView.tsx` — WorkspaceSection single-row layout, fire-and-forget bug fixed
- `en.json` / `zh-CN.json` — new `canvas.newDesignDialog.*` i18n keys
- `snapshots-db.ts` — pre-existing `getLogger()` missing-scope fix
- `FilesPanel.test.tsx` — pre-existing lint/type errors fixed

## Screenshots / recordings (UI changes)
<img width="1918" height="1006" alt="image" src="https://github.com/user-attachments/assets/c91a862d-89a4-4373-9e93-344ce148e0f5" />
<img width="1920" height="1026" alt="image" src="https://github.com/user-attachments/assets/5eebab71-6472-4b1b-963a-eec79378be63" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ecd8b373-144e-43a1-88a7-2f3751b1d136" />


