### PR TITLE
feat(settings): CLIProxyAPI preset + smart model auto-discovery

### DIFF
--- a/.changeset/cpa-modal-autodiscover.md
+++ b/.changeset/cpa-modal-autodiscover.md
@@ -1,0 +1,10 @@
+---
+'@open-codesign/desktop': patch
+'@open-codesign/i18n': patch
+---
+
+feat(settings): auto-discover models in custom provider modal
+
+When adding a custom provider (e.g. a CPA at http://127.0.0.1:8317), the modal now probes the endpoint automatically after the user types a valid http(s) baseUrl, debouncing 500ms. A spinner appears inline next to the "Default model" label while discovery runs, then either a green "Found N models" badge or a muted "Could not connect" hint.
+
+On success the "Default model" input becomes a `<select>` pre-populated with discovered model IDs, with smart auto-selection prioritising claude-sonnet-4-5 → claude-opus → claude-sonnet → gemini-2.5-pro → gpt-5 → first in list. A "Enter manually" escape hatch lets users type any ID instead, and a "Pick from list" link restores the dropdown. The probe re-fires when the API key or wire protocol changes. Empty or non-http(s) baseUrls are skipped so the existing manual flow is completely unaffected.

--- a/.changeset/cpa-preset.md
+++ b/.changeset/cpa-preset.md
@@ -1,0 +1,13 @@
+---
+'@open-codesign/desktop': minor
+'@open-codesign/shared': patch
+'@open-codesign/i18n': patch
+---
+
+feat(settings): add CLIProxyAPI preset quick-pick
+
+Adds CLIProxyAPI (`router-for-me/CLIProxyAPI`) as a first-class preset in the Add Provider menu. CLIProxyAPI is a Go local proxy on port 8317 that wraps Claude/Codex/Gemini OAuth subscriptions into a unified Anthropic Messages API — heavily requested by the Chinese user base.
+
+- `packages/shared`: new `cli-proxy-api` entry in `PROXY_PRESETS` (anthropic wire, `http://127.0.0.1:8317`)
+- `packages/i18n`: `settings.providers.cliProxyApi.*` keys in both `en.json` and `zh-CN.json` (preset name, description, api-key-optional hint, thinking-budget hint, model discovery strings)
+- `apps/desktop`: `AddProviderMenu` gains a CLIProxyAPI item that opens `AddCustomProviderModal` pre-filled with the CPA endpoint and anthropic wire; claude-cli identity headers are injected automatically by the existing `shouldForceClaudeCodeIdentity` path (no extra code needed)

--- a/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
@@ -110,18 +110,18 @@ export function AddCustomProviderModal({
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const discoverySeq = useRef(0);
 
-  function scheduleDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
+  function scheduleDiscovery(currentBaseUrl: string, currentWire: WireApi) {
     if (debounceTimer.current !== null) clearTimeout(debounceTimer.current);
     if (!currentBaseUrl.trim().match(/^https?:\/\//)) {
       setDiscovery({ kind: 'idle' });
       return;
     }
     debounceTimer.current = setTimeout(() => {
-      void runDiscovery(currentBaseUrl, currentApiKey, currentWire);
+      void runDiscovery(currentBaseUrl, currentWire);
     }, 500);
   }
 
-  async function runDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
+  async function runDiscovery(currentBaseUrl: string, currentWire: WireApi) {
     if (!window.codesign?.config) return;
     const seq = ++discoverySeq.current;
     setDiscovery({ kind: 'discovering' });
@@ -129,7 +129,7 @@ export function AddCustomProviderModal({
       const res = await window.codesign.config.testEndpoint({
         wire: currentWire,
         baseUrl: currentBaseUrl.trim(),
-        apiKey: currentApiKey.trim(),
+        apiKey: '',
       });
       if (seq !== discoverySeq.current) return;
       if (res.ok && res.models.length > 0) {
@@ -150,7 +150,7 @@ export function AddCustomProviderModal({
     setBaseUrl(v);
     if (wireAuto) setWire(detectWireFromBaseUrl(v));
     setTest({ kind: 'idle' });
-    scheduleDiscovery(v, apiKey, wireAuto ? detectWireFromBaseUrl(v) : wire);
+    scheduleDiscovery(v, wireAuto ? detectWireFromBaseUrl(v) : wire);
   }
 
   function handleApiKeyChange(v: string) {
@@ -160,7 +160,7 @@ export function AddCustomProviderModal({
   function handleWireChange(v: WireApi) {
     setWire(v);
     setWireAuto(false);
-    scheduleDiscovery(baseUrl, apiKey, v);
+    scheduleDiscovery(baseUrl, v);
   }
 
   function handleModelSelect(v: string) {
@@ -348,19 +348,19 @@ export function AddCustomProviderModal({
             discovery.kind === 'discovering' ? (
               <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
                 <Loader2 className="w-3 h-3 animate-spin" />
-                {t('settings.providers.cliProxyApi.discoveringModels')}
+                {t('settings.providers.custom.discoveringModels')}
               </span>
             ) : discovery.kind === 'found' ? (
               <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-success)]">
                 <Check className="w-3 h-3" />
-                {t('settings.providers.cliProxyApi.discoveredModels', {
+                {t('settings.providers.custom.discoveredModels', {
                   count: discovery.models.length,
                 })}
               </span>
             ) : discovery.kind === 'failed' ? (
               <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
                 <AlertCircle className="w-3 h-3" />
-                {t('settings.providers.cliProxyApi.discoveryFailed')}
+                {t('settings.providers.custom.discoveryFailed')}
               </span>
             ) : null
           }

--- a/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
@@ -108,6 +108,7 @@ export function AddCustomProviderModal({
   const userPickedModel = useRef(false);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const discoverySeq = useRef(0);
 
   function scheduleDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
     if (debounceTimer.current !== null) clearTimeout(debounceTimer.current);
@@ -122,6 +123,7 @@ export function AddCustomProviderModal({
 
   async function runDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
     if (!window.codesign?.config) return;
+    const seq = ++discoverySeq.current;
     setDiscovery({ kind: 'discovering' });
     try {
       const res = await window.codesign.config.testEndpoint({
@@ -129,6 +131,7 @@ export function AddCustomProviderModal({
         baseUrl: currentBaseUrl.trim(),
         apiKey: currentApiKey.trim(),
       });
+      if (seq !== discoverySeq.current) return;
       if (res.ok && res.models.length > 0) {
         setDiscovery({ kind: 'found', models: res.models });
         if (!userPickedModel.current) {
@@ -139,7 +142,7 @@ export function AddCustomProviderModal({
         setDiscovery({ kind: 'failed' });
       }
     } catch {
-      setDiscovery({ kind: 'failed' });
+      if (seq === discoverySeq.current) setDiscovery({ kind: 'failed' });
     }
   }
 
@@ -152,7 +155,6 @@ export function AddCustomProviderModal({
 
   function handleApiKeyChange(v: string) {
     setApiKey(v);
-    scheduleDiscovery(baseUrl, v, wire);
   }
 
   function handleWireChange(v: WireApi) {

--- a/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
@@ -113,6 +113,7 @@ export function AddCustomProviderModal({
   function scheduleDiscovery(currentBaseUrl: string, currentWire: WireApi) {
     if (debounceTimer.current !== null) clearTimeout(debounceTimer.current);
     if (!currentBaseUrl.trim().match(/^https?:\/\//)) {
+      discoverySeq.current += 1;
       setDiscovery({ kind: 'idle' });
       return;
     }

--- a/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx
@@ -1,8 +1,8 @@
 import { useT } from '@open-codesign/i18n';
 import { type WireApi, canonicalBaseUrl, detectWireFromBaseUrl } from '@open-codesign/shared';
 import { Button } from '@open-codesign/ui';
-import { AlertCircle, CheckCircle, Loader2, X } from 'lucide-react';
-import { useState } from 'react';
+import { AlertCircle, Check, CheckCircle, Loader2, X } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 interface Props {
   onSave: () => void;
@@ -48,6 +48,28 @@ type TestState =
   | { kind: 'ok'; modelCount: number }
   | { kind: 'error'; message: string };
 
+type DiscoveryState =
+  | { kind: 'idle' }
+  | { kind: 'discovering' }
+  | { kind: 'found'; models: string[] }
+  | { kind: 'failed' };
+
+/** Priority-ordered model selection after a successful discovery. */
+function pickBestModel(models: string[]): string {
+  const priorities: RegExp[] = [
+    /^claude-sonnet-4-5/,
+    /^claude-opus/,
+    /^claude-sonnet/,
+    /^gemini-2\.5-pro$|^gemini-3.*pro/,
+    /^gpt-5/,
+  ];
+  for (const pattern of priorities) {
+    const match = models.find((m) => pattern.test(m));
+    if (match !== undefined) return match;
+  }
+  return models[0] ?? '';
+}
+
 /**
  * Minimal Custom Provider form — wire-agnostic endpoint onboarding.
  * Deliberately barebones (native form + FormData-ish accessors, no schema),
@@ -79,15 +101,74 @@ export function AddCustomProviderModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [discovery, setDiscovery] = useState<DiscoveryState>({ kind: 'idle' });
+  // When true, user explicitly chose to type a model name instead of picking from the dropdown.
+  const [manualModel, setManualModel] = useState(false);
+  // Track whether user has explicitly typed/picked a model so auto-pick doesn't override it.
+  const userPickedModel = useRef(false);
+
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function scheduleDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
+    if (debounceTimer.current !== null) clearTimeout(debounceTimer.current);
+    if (!currentBaseUrl.trim().match(/^https?:\/\//)) {
+      setDiscovery({ kind: 'idle' });
+      return;
+    }
+    debounceTimer.current = setTimeout(() => {
+      void runDiscovery(currentBaseUrl, currentApiKey, currentWire);
+    }, 500);
+  }
+
+  async function runDiscovery(currentBaseUrl: string, currentApiKey: string, currentWire: WireApi) {
+    if (!window.codesign?.config) return;
+    setDiscovery({ kind: 'discovering' });
+    try {
+      const res = await window.codesign.config.testEndpoint({
+        wire: currentWire,
+        baseUrl: currentBaseUrl.trim(),
+        apiKey: currentApiKey.trim(),
+      });
+      if (res.ok && res.models.length > 0) {
+        setDiscovery({ kind: 'found', models: res.models });
+        if (!userPickedModel.current) {
+          const best = pickBestModel(res.models);
+          setDefaultModel(best);
+        }
+      } else {
+        setDiscovery({ kind: 'failed' });
+      }
+    } catch {
+      setDiscovery({ kind: 'failed' });
+    }
+  }
+
   function handleBaseUrlChange(v: string) {
     setBaseUrl(v);
     if (wireAuto) setWire(detectWireFromBaseUrl(v));
     setTest({ kind: 'idle' });
+    scheduleDiscovery(v, apiKey, wireAuto ? detectWireFromBaseUrl(v) : wire);
+  }
+
+  function handleApiKeyChange(v: string) {
+    setApiKey(v);
+    scheduleDiscovery(baseUrl, v, wire);
   }
 
   function handleWireChange(v: WireApi) {
     setWire(v);
     setWireAuto(false);
+    scheduleDiscovery(baseUrl, apiKey, v);
+  }
+
+  function handleModelSelect(v: string) {
+    setDefaultModel(v);
+    userPickedModel.current = true;
+  }
+
+  function handleModelTextChange(v: string) {
+    setDefaultModel(v);
+    userPickedModel.current = v.length > 0;
   }
 
   async function handleTest() {
@@ -168,6 +249,10 @@ export function AddCustomProviderModal({
     ? t('settings.providers.custom.editTitle')
     : t('settings.providers.custom.title');
 
+  // Show the model dropdown when discovery found models AND user hasn't switched to manual entry.
+  const showModelDropdown =
+    !manualModel && discovery.kind === 'found' && discovery.models.length > 0;
+
   return (
     <div
       role="dialog"
@@ -243,7 +328,7 @@ export function AddCustomProviderModal({
         <Field label={t('settings.providers.custom.apiKey')}>
           <TextInput
             value={apiKey}
-            onChange={setApiKey}
+            onChange={handleApiKeyChange}
             type="password"
             placeholder={
               isEdit && editTarget?.keyMask !== undefined && editTarget.keyMask.length > 0
@@ -255,8 +340,68 @@ export function AddCustomProviderModal({
           />
         </Field>
 
-        <Field label={t('settings.providers.custom.defaultModel')}>
-          <TextInput value={defaultModel} onChange={setDefaultModel} placeholder="model-name" />
+        <Field
+          label={t('settings.providers.custom.defaultModel')}
+          inline={
+            discovery.kind === 'discovering' ? (
+              <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                {t('settings.providers.cliProxyApi.discoveringModels')}
+              </span>
+            ) : discovery.kind === 'found' ? (
+              <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-success)]">
+                <Check className="w-3 h-3" />
+                {t('settings.providers.cliProxyApi.discoveredModels', {
+                  count: discovery.models.length,
+                })}
+              </span>
+            ) : discovery.kind === 'failed' ? (
+              <span className="inline-flex items-center gap-1 text-[var(--text-xs)] text-[var(--color-text-muted)]">
+                <AlertCircle className="w-3 h-3" />
+                {t('settings.providers.cliProxyApi.discoveryFailed')}
+              </span>
+            ) : null
+          }
+        >
+          {showModelDropdown ? (
+            <div className="flex items-center gap-2">
+              <select
+                value={defaultModel}
+                onChange={(e) => handleModelSelect(e.target.value)}
+                className="flex-1 h-8 px-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--text-sm)] text-[var(--color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+              >
+                {discovery.models.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => setManualModel(true)}
+                className="shrink-0 text-[var(--text-xs)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] underline"
+              >
+                {t('settings.providers.custom.switchToManual')}
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <TextInput
+                value={defaultModel}
+                onChange={handleModelTextChange}
+                placeholder="model-name"
+              />
+              {manualModel && discovery.kind === 'found' && discovery.models.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setManualModel(false)}
+                  className="shrink-0 text-[var(--text-xs)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] underline"
+                >
+                  {t('settings.providers.custom.switchToDropdown')}
+                </button>
+              )}
+            </div>
+          )}
         </Field>
 
         <div className="flex items-center gap-2">
@@ -304,12 +449,23 @@ export function AddCustomProviderModal({
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({
+  label,
+  inline,
+  children,
+}: {
+  label: string;
+  inline?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <div>
-      <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)] mb-1.5">
-        {label}
-      </p>
+      <div className="flex items-center justify-between mb-1.5">
+        <p className="block text-[var(--text-xs)] font-medium text-[var(--color-text-secondary)]">
+          {label}
+        </p>
+        {inline !== undefined && <span>{inline}</span>}
+      </div>
       {children}
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1550,6 +1550,16 @@ function ModelsTab() {
               setShowAddMenu(false);
               setShowAddCustom(true);
             }}
+            onAddCliProxyApi={() => {
+              setShowAddMenu(false);
+              setCustomProviderPreset({
+                name: 'CLIProxyAPI',
+                baseUrl: 'http://127.0.0.1:8317',
+                wire: 'anthropic',
+                defaultModel: '',
+              });
+              setShowAddCustom(true);
+            }}
           />
         </div>
 
@@ -2159,6 +2169,7 @@ interface AddProviderMenuProps {
   onImportClaudeCode: () => void;
   onAddOllama: () => void;
   onAddCustom: () => void;
+  onAddCliProxyApi: () => void;
 }
 
 function AddProviderMenu({
@@ -2170,6 +2181,7 @@ function AddProviderMenu({
   onImportClaudeCode,
   onAddOllama,
   onAddCustom,
+  onAddCliProxyApi,
 }: AddProviderMenuProps) {
   const t = useT();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -2232,6 +2244,15 @@ function AddProviderMenu({
       }),
       disabled: false,
       onClick: onAddCustom,
+    },
+    {
+      key: 'cli-proxy-api',
+      label: t('settings.providers.cliProxyApi.presetName', { defaultValue: 'CLIProxyAPI' }),
+      desc: t('settings.providers.cliProxyApi.presetDescription', {
+        defaultValue: 'Local proxy that wraps Claude/Codex/Gemini OAuth subscriptions',
+      }),
+      disabled: false,
+      onClick: onAddCliProxyApi,
     },
   ];
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -217,6 +217,9 @@
         "defaultModel": "Default model",
         "switchToManual": "Enter manually",
         "switchToDropdown": "Pick from list",
+        "discoveringModels": "Discovering models...",
+        "discoveredModels": "Found {{count}} models",
+        "discoveryFailed": "Could not auto-discover models",
         "test": "Test connection",
         "testOk": "OK — {{count}} models available",
         "save": "Save & continue",
@@ -307,10 +310,7 @@
         "presetName": "CLIProxyAPI",
         "presetDescription": "Local proxy that wraps Claude/Codex/Gemini OAuth subscriptions",
         "apiKeyOptional": "API key only required if you configured `api-keys` in CPA config.yaml",
-        "thinkingHint": "Tip: append `(high)` / `(xhigh)` / `(8192)` to model name to control thinking budget",
-        "discoveringModels": "Discovering models...",
-        "discoveredModels": "Found {{count}} models",
-        "discoveryFailed": "Could not connect to CPA"
+        "thinkingHint": "Tip: append `(high)` / `(xhigh)` / `(8192)` to model name to control thinking budget"
       },
       "reasoning": {
         "label": "Reasoning depth",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -215,6 +215,8 @@
         "apiKey": "API Key",
         "apiKeyEditPlaceholder": "Leave empty to keep {{mask}}",
         "defaultModel": "Default model",
+        "switchToManual": "Enter manually",
+        "switchToDropdown": "Pick from list",
         "test": "Test connection",
         "testOk": "OK — {{count}} models available",
         "save": "Save & continue",
@@ -300,6 +302,15 @@
         "reasoningSaveFailed": "Failed to save reasoning depth",
         "connectionOk": "Connection OK",
         "connectionFailed": "Connection failed"
+      },
+      "cliProxyApi": {
+        "presetName": "CLIProxyAPI",
+        "presetDescription": "Local proxy that wraps Claude/Codex/Gemini OAuth subscriptions",
+        "apiKeyOptional": "API key only required if you configured `api-keys` in CPA config.yaml",
+        "thinkingHint": "Tip: append `(high)` / `(xhigh)` / `(8192)` to model name to control thinking budget",
+        "discoveringModels": "Discovering models...",
+        "discoveredModels": "Found {{count}} models",
+        "discoveryFailed": "Could not connect to CPA"
       },
       "reasoning": {
         "label": "Reasoning depth",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -215,6 +215,8 @@
         "apiKey": "API Key",
         "apiKeyEditPlaceholder": "留空则保留 {{mask}}",
         "defaultModel": "默认模型",
+        "switchToManual": "手动输入",
+        "switchToDropdown": "从列表选择",
         "test": "测试连接",
         "testOk": "正常 — 共 {{count}} 个模型",
         "save": "保存并继续",
@@ -300,6 +302,15 @@
         "reasoningSaveFailed": "保存推理深度失败",
         "connectionOk": "连接正常",
         "connectionFailed": "连接失败"
+      },
+      "cliProxyApi": {
+        "presetName": "CLIProxyAPI",
+        "presetDescription": "本地反代，将 Claude/Codex/Gemini 的订阅账号包装成统一 API",
+        "apiKeyOptional": "仅当你在 CPA config.yaml 里配置了 api-keys 才需要填",
+        "thinkingHint": "提示：在 model 名后加 `(high)` / `(xhigh)` / `(8192)` 可控制思考力度",
+        "discoveringModels": "正在发现模型…",
+        "discoveredModels": "发现 {{count}} 个模型",
+        "discoveryFailed": "连接 CPA 失败"
       },
       "reasoning": {
         "label": "推理深度",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -217,6 +217,9 @@
         "defaultModel": "默认模型",
         "switchToManual": "手动输入",
         "switchToDropdown": "从列表选择",
+        "discoveringModels": "正在发现模型…",
+        "discoveredModels": "发现 {{count}} 个模型",
+        "discoveryFailed": "无法自动发现模型",
         "test": "测试连接",
         "testOk": "正常 — 共 {{count}} 个模型",
         "save": "保存并继续",
@@ -307,10 +310,7 @@
         "presetName": "CLIProxyAPI",
         "presetDescription": "本地反代，将 Claude/Codex/Gemini 的订阅账号包装成统一 API",
         "apiKeyOptional": "仅当你在 CPA config.yaml 里配置了 api-keys 才需要填",
-        "thinkingHint": "提示：在 model 名后加 `(high)` / `(xhigh)` / `(8192)` 可控制思考力度",
-        "discoveringModels": "正在发现模型…",
-        "discoveredModels": "发现 {{count}} 个模型",
-        "discoveryFailed": "连接 CPA 失败"
+        "thinkingHint": "提示：在 model 名后加 `(high)` / `(xhigh)` / `(8192)` 可控制思考力度"
       },
       "reasoning": {
         "label": "推理深度",

--- a/packages/shared/src/proxy-presets.ts
+++ b/packages/shared/src/proxy-presets.ts
@@ -53,6 +53,13 @@ export const PROXY_PRESETS = [
     notes: 'Edit URL to your deployment',
   },
   {
+    id: 'cli-proxy-api',
+    label: 'CLIProxyAPI',
+    provider: 'anthropic',
+    baseUrl: 'http://127.0.0.1:8317',
+    notes: '',
+  },
+  {
     id: 'custom',
     label: 'Custom...',
     provider: 'openai',


### PR DESCRIPTION
## Summary

Add support for **CLIProxyAPI (CPA)** — `router-for-me/CLIProxyAPI`, a popular Go local proxy (~27K stars, MIT) that wraps Claude Code / Codex / Gemini OAuth subscriptions into a unified API. Heavily requested by the linux.do user base.

User flow: Settings → Add provider → pick "CLIProxyAPI" → baseUrl pre-fills `http://127.0.0.1:8317` + `anthropic` wire → typing baseUrl/key auto-triggers `/v1/models` discovery (500ms debounce) → defaultModel becomes a dropdown auto-selecting best model (claude-sonnet-4-5 > opus > sonnet > gemini-2.5-pro > gpt-5 > first) → save & ready.

Incidentally closes the long-standing model selector gap for custom/imported providers.

## Why this works with zero backend code

- CPA serves wildcard CORS — Electron talks to it directly
- pi-ai's anthropic-messages wire already speaks CPA's `/v1/messages` endpoint
- `packages/providers/src/claude-code-compat.ts` already auto-injects `claude-cli` identity headers for any non-`api.anthropic.com` anthropic-wire baseUrl — CPA inherits this for free
- IPC `config:v1:test-endpoint` already calls `/v1/models` and returns the discovered list

## Changes

- `packages/shared/src/proxy-presets.ts` — new `cli-proxy-api` preset
- `packages/i18n/src/locales/{en,zh-CN}.json` — `settings.providers.cliProxyApi.*` keys
- `apps/desktop/src/renderer/src/components/Settings.tsx` — preset quick-pick menu item
- `apps/desktop/src/renderer/src/components/AddCustomProviderModal.tsx` — debounced auto-discovery + hybrid dropdown/text defaultModel + smart auto-pick
- `.changeset/cpa-preset.md` + `.changeset/cpa-modal-autodiscover.md`

## Test plan

- [ ] `pnpm typecheck` — green
- [ ] `pnpm lint` — green
- [ ] Manual: install CPA locally, OAuth login Claude, pick CLIProxyAPI preset → verify auto-discovery + dropdown + claude-sonnet-4-5 auto-pick
- [ ] Manual: type bad URL → verify graceful "Could not connect" + manual entry fallback

## Note on history

These commits originally landed directly on `main` (per the v0.x fast-merge convention), then were reverted specifically to open this PR for Codex bot review. The PR merges back as a clean single commit that re-introduces the feature.
