### PR TITLE
fix(desktop): degrade-probe test connection for OpenAI-compat endpoints without /models (#179)

### DIFF
--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -1012,10 +1012,11 @@ describe('runProviderTest degrade-probe (issue #179)', () => {
     }
   });
 
-  it('openai-responses: /models 404 + /chat/completions 2xx → degrade pass', async () => {
-    const { restore } = installFakeFetch((url) => {
+  it('openai-responses: /models 404 + /responses 2xx → probeMethod=responses_degraded', async () => {
+    const { calls, restore } = installFakeFetch((url) => {
       if (url.endsWith('/models')) return { status: 404 };
-      return { status: 200, body: { ok: true } };
+      if (url.endsWith('/responses')) return { status: 200, body: { ok: true } };
+      return { status: 500 };
     });
     try {
       const res = await runProviderTest({
@@ -1025,7 +1026,48 @@ describe('runProviderTest degrade-probe (issue #179)', () => {
         baseUrl: 'https://gateway.example.com/v1',
       });
       expect(res.ok).toBe(true);
-      if (res.ok) expect(res.probeMethod).toBe('chat_completion_degraded');
+      if (res.ok) expect(res.probeMethod).toBe('responses_degraded');
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.url).toMatch(/\/models$/);
+      expect(calls[1]?.url).toMatch(/\/responses$/);
+      expect(calls[1]?.method).toBe('POST');
+      const body = JSON.parse(calls[1]?.body ?? '{}');
+      // Responses API shape — must NOT look like /chat/completions payload.
+      expect(body.max_output_tokens).toBe(1);
+      expect(Array.isArray(body.input)).toBe(true);
+      expect(body.messages).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-responses: /models 404 + /responses 404 → preserves original 404 (no /chat/completions false-positive)', async () => {
+    // Regression: the previous implementation probed /chat/completions for
+    // every OpenAI-compat wire. A gateway that only implements /chat/completions
+    // would then report the connection healthy even though real inference (on
+    // /responses) would 404 at generate-time. We want the opposite: if the
+    // wire's real endpoint is dead, the test must fail.
+    const { calls, restore } = installFakeFetch((url) => {
+      if (url.endsWith('/models')) return { status: 404 };
+      if (url.endsWith('/responses')) return { status: 404 };
+      // A gateway that only has /chat/completions — must not be consulted.
+      if (url.endsWith('/chat/completions')) return { status: 200, body: { id: 'wrong-probe' } };
+      return { status: 500 };
+    });
+    try {
+      const res = await runProviderTest({
+        provider: 'chat-only-gateway',
+        wire: 'openai-responses',
+        apiKey: 'sk-test',
+        baseUrl: 'https://gateway.example.com/v1',
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('404');
+        expect(res.message).toBe('HTTP 404');
+      }
+      // /chat/completions must NOT have been probed for an openai-responses wire.
+      expect(calls.some((c) => c.url.endsWith('/chat/completions'))).toBe(false);
     } finally {
       restore();
     }

--- a/apps/desktop/src/main/connection-ipc.test.ts
+++ b/apps/desktop/src/main/connection-ipc.test.ts
@@ -18,6 +18,7 @@ import {
   getCacheKey,
   normalizeBaseUrl,
   normalizeOllamaBaseUrl,
+  runProviderTest,
 } from './connection-ipc';
 
 // ---------------------------------------------------------------------------
@@ -838,5 +839,195 @@ describe('normalizeOllamaBaseUrl', () => {
     // The scheme-coercion path prepends `http://`, so truly malformed inputs
     // like "http://" with an empty host still reach URL() and reject there.
     expect(() => normalizeOllamaBaseUrl('http://')).toThrow(/not a valid URL/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runProviderTest — degrade-probe when /models 404s on OpenAI-compat endpoints
+// (regression for Zhipu GLM and similar gateways that don't expose /models).
+// ---------------------------------------------------------------------------
+
+interface FakeFetchCall {
+  url: string;
+  method: string;
+  body: string | undefined;
+}
+
+function installFakeFetch(
+  handler: (url: string, init: RequestInit) => { status: number; body?: unknown },
+): { calls: FakeFetchCall[]; restore: () => void } {
+  const calls: FakeFetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  const fake = (async (url: string, init: RequestInit = {}) => {
+    calls.push({
+      url,
+      method: typeof init.method === 'string' ? init.method : 'GET',
+      body: typeof init.body === 'string' ? init.body : undefined,
+    });
+    const { status, body } = handler(url, init);
+    return new Response(body === undefined ? null : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  (globalThis as { fetch: typeof fetch }).fetch = fake;
+  return {
+    calls,
+    restore: () => {
+      (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    },
+  };
+}
+
+describe('runProviderTest degrade-probe (issue #179)', () => {
+  beforeEach(() => {
+    // Use real timers so fetchWithTimeout's AbortController doesn't get stuck
+    // behind vi.useFakeTimers() from the outer beforeEach.
+    vi.useRealTimers();
+  });
+
+  it('openai-chat: /models 404 but /chat/completions 200 → ok, probeMethod=chat_completion_degraded (GLM case)', async () => {
+    const { calls, restore } = installFakeFetch((url) => {
+      if (url.endsWith('/models')) return { status: 404, body: { error: 'not found' } };
+      if (url.endsWith('/chat/completions')) return { status: 200, body: { id: 'probe-response' } };
+      return { status: 500 };
+    });
+    try {
+      const res = await runProviderTest({
+        provider: 'glm',
+        wire: 'openai-chat',
+        apiKey: 'sk-glm-test',
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.probeMethod).toBe('chat_completion_degraded');
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.url).toMatch(/\/models$/);
+      expect(calls[1]?.url).toMatch(/\/chat\/completions$/);
+      expect(calls[1]?.method).toBe('POST');
+      expect(calls[1]?.body).toBeTruthy();
+      const body = JSON.parse(calls[1]?.body ?? '{}');
+      expect(body.max_tokens).toBe(1);
+      expect(body.stream).toBe(false);
+      expect(Array.isArray(body.messages)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-chat: /models 404 and /chat/completions also 404 → preserves original 404', async () => {
+    const { restore } = installFakeFetch(() => ({ status: 404 }));
+    try {
+      const res = await runProviderTest({
+        provider: 'broken-gateway',
+        wire: 'openai-chat',
+        apiKey: 'sk-test',
+        baseUrl: 'https://broken.example.com/v1',
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('404');
+        expect(res.message).toBe('HTTP 404');
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-chat: /models 404 + /chat/completions 400 (model_unknown) → still pass (endpoint alive)', async () => {
+    const { restore } = installFakeFetch((url) => {
+      if (url.endsWith('/models')) return { status: 404 };
+      return { status: 400, body: { error: { message: 'model_not_found' } } };
+    });
+    try {
+      const res = await runProviderTest({
+        provider: 'glm',
+        wire: 'openai-chat',
+        apiKey: 'sk-glm-test',
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.probeMethod).toBe('chat_completion_degraded');
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-chat: /models 404 + /chat/completions 401 → surface auth error, not 404', async () => {
+    const { restore } = installFakeFetch((url) => {
+      if (url.endsWith('/models')) return { status: 404 };
+      return { status: 401 };
+    });
+    try {
+      const res = await runProviderTest({
+        provider: 'glm',
+        wire: 'openai-chat',
+        apiKey: 'wrong-key',
+        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.code).toBe('401');
+        expect(res.message).toBe('HTTP 401');
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-chat: /models 200 → no degrade probe, probeMethod=models', async () => {
+    const { calls, restore } = installFakeFetch(() => ({ status: 200, body: { data: [] } }));
+    try {
+      const res = await runProviderTest({
+        provider: 'openai',
+        wire: 'openai-chat',
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.openai.com/v1',
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.probeMethod).toBe('models');
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.method).toBe('GET');
+    } finally {
+      restore();
+    }
+  });
+
+  it('anthropic: /models 404 does NOT degrade (standard endpoint must stay authoritative)', async () => {
+    const { calls, restore } = installFakeFetch(() => ({ status: 404 }));
+    try {
+      const res = await runProviderTest({
+        provider: 'anthropic-like',
+        wire: 'anthropic',
+        apiKey: 'sk-ant-test',
+        baseUrl: 'https://api.anthropic.com',
+      });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.code).toBe('404');
+      // Only /v1/models should have been probed — no /v1/messages degrade.
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toMatch(/\/v1\/models$/);
+    } finally {
+      restore();
+    }
+  });
+
+  it('openai-responses: /models 404 + /chat/completions 2xx → degrade pass', async () => {
+    const { restore } = installFakeFetch((url) => {
+      if (url.endsWith('/models')) return { status: 404 };
+      return { status: 200, body: { ok: true } };
+    });
+    try {
+      const res = await runProviderTest({
+        provider: 'responses-gateway',
+        wire: 'openai-responses',
+        apiKey: 'sk-test',
+        baseUrl: 'https://gateway.example.com/v1',
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.probeMethod).toBe('chat_completion_degraded');
+    } finally {
+      restore();
+    }
   });
 });

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -39,6 +39,14 @@ interface ModelsListPayloadV1 {
 
 export interface ConnectionTestResult {
   ok: true;
+  /**
+   * `models` when the standard GET /models probe succeeded.
+   * `chat_completion_degraded` when /models 404'd but POST /chat/completions
+   * proved the endpoint is alive (e.g. Zhipu GLM's gateway — no public /models
+   * but /chat/completions works fine). The renderer surfaces this so users
+   * know /models is unavailable even though generation will work.
+   */
+  probeMethod?: 'models' | 'chat_completion_degraded';
 }
 
 export interface ConnectionTestError {
@@ -345,7 +353,7 @@ export function _getModelsCache(): Map<string, CacheEntry> {
 // IPC registration
 // ---------------------------------------------------------------------------
 
-interface ActiveProviderCredentials {
+export interface ActiveProviderCredentials {
   provider: string;
   wire: WireApi;
   apiKey: string;
@@ -446,7 +454,9 @@ async function testChatGPTCodexOAuth(): Promise<ConnectionTestResponse> {
   return { ok: true };
 }
 
-async function runProviderTest(creds: ActiveProviderCredentials): Promise<ConnectionTestResponse> {
+export async function runProviderTest(
+  creds: ActiveProviderCredentials,
+): Promise<ConnectionTestResponse> {
   // ChatGPT subscription uses OAuth + ChatGPT-Account-Id headers; its host
   // has no `/models` endpoint that a generic Bearer probe can reach. A plain
   // HTTP probe would return 401 here and render as the misleading "API key
@@ -456,7 +466,7 @@ async function runProviderTest(creds: ActiveProviderCredentials): Promise<Connec
     return testChatGPTCodexOAuth();
   }
 
-  const { url } = buildEndpointForWire(creds.wire, creds.baseUrl);
+  const { url, normalizedBaseUrl } = buildEndpointForWire(creds.wire, creds.baseUrl);
   const headers = buildAuthHeadersForWire(
     creds.wire,
     creds.apiKey,
@@ -477,10 +487,69 @@ async function runProviderTest(creds: ActiveProviderCredentials): Promise<Connec
     };
   }
   if (!res.ok) {
+    // Some OpenAI-compatible gateways (Zhipu GLM, a handful of self-hosted
+    // proxies) don't expose /models but their /chat/completions works fine.
+    // If the primary probe 404s on those wires, degrade-probe with a tiny
+    // chat request before declaring the endpoint dead. We intentionally do
+    // not degrade anthropic — its /v1/models is standard, and skipping it
+    // would mask real path-shape mistakes.
+    if (res.status === 404 && (creds.wire === 'openai-chat' || creds.wire === 'openai-responses')) {
+      const probe = await probeChatCompletion(normalizedBaseUrl, headers);
+      if (probe.kind === 'pass') {
+        return { ok: true, probeMethod: 'chat_completion_degraded' };
+      }
+      if (probe.kind === 'http' && probe.status !== 404) {
+        const { code, hint } = classifyHttpError(probe.status);
+        return { ok: false, code, message: `HTTP ${probe.status}`, hint };
+      }
+      // /chat/completions also 404'd (or the network dropped) — fall through
+      // and report the original /models 404.
+    }
     const { code, hint } = classifyHttpError(res.status);
     return { ok: false, code, message: `HTTP ${res.status}`, hint };
   }
-  return { ok: true };
+  return { ok: true, probeMethod: 'models' };
+}
+
+type ProbeResult =
+  | { kind: 'pass' }
+  | { kind: 'http'; status: number }
+  | { kind: 'network'; message: string };
+
+/**
+ * POST a minimal chat-completion request to verify the endpoint is alive
+ * when GET /models returned 404. A 2xx response or any API-originated 4xx
+ * (400 model_unknown, 402 insufficient credits, 422, 429 — and 401/403 too,
+ * which we surface as an auth error instead of the misleading 404 hint)
+ * counts as "endpoint reachable". Only 404 and 5xx count as a real failure.
+ */
+async function probeChatCompletion(
+  normalizedBaseUrl: string,
+  headers: Record<string, string>,
+): Promise<ProbeResult> {
+  const url = `${normalizedBaseUrl}/chat/completions`;
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(url, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'probe',
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+        stream: false,
+      }),
+    });
+  } catch (err) {
+    return { kind: 'network', message: err instanceof Error ? err.message : String(err) };
+  }
+  if (res.ok) return { kind: 'pass' };
+  if (res.status === 404 || res.status >= 500) return { kind: 'http', status: res.status };
+  // 401/403 — endpoint alive but auth rejected; surface as auth error so the
+  // diagnostics panel shows the key-invalid hint instead of the 404 one.
+  if (res.status === 401 || res.status === 403) return { kind: 'http', status: res.status };
+  // 400/402/422/429 etc. — endpoint alive, request-level rejection.
+  return { kind: 'pass' };
 }
 
 export function registerConnectionIpc(): void {

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -42,11 +42,13 @@ export interface ConnectionTestResult {
   /**
    * `models` when the standard GET /models probe succeeded.
    * `chat_completion_degraded` when /models 404'd but POST /chat/completions
-   * proved the endpoint is alive (e.g. Zhipu GLM's gateway — no public /models
-   * but /chat/completions works fine). The renderer surfaces this so users
-   * know /models is unavailable even though generation will work.
+   * proved the openai-chat wire is alive (e.g. Zhipu GLM — no public /models).
+   * `responses_degraded` when /models 404'd but POST /responses proved the
+   * openai-responses wire is alive. We probe the wire's real inference
+   * endpoint so a gateway that only implements /chat/completions can't
+   * false-positive for a user whose provider is on the Responses API.
    */
-  probeMethod?: 'models' | 'chat_completion_degraded';
+  probeMethod?: 'models' | 'chat_completion_degraded' | 'responses_degraded';
 }
 
 export interface ConnectionTestError {
@@ -494,15 +496,19 @@ export async function runProviderTest(
     // not degrade anthropic — its /v1/models is standard, and skipping it
     // would mask real path-shape mistakes.
     if (res.status === 404 && (creds.wire === 'openai-chat' || creds.wire === 'openai-responses')) {
-      const probe = await probeChatCompletion(normalizedBaseUrl, headers);
+      const probe = await probeInferenceEndpoint(creds.wire, normalizedBaseUrl, headers);
       if (probe.kind === 'pass') {
-        return { ok: true, probeMethod: 'chat_completion_degraded' };
+        return {
+          ok: true,
+          probeMethod:
+            creds.wire === 'openai-responses' ? 'responses_degraded' : 'chat_completion_degraded',
+        };
       }
       if (probe.kind === 'http' && probe.status !== 404) {
         const { code, hint } = classifyHttpError(probe.status);
         return { ok: false, code, message: `HTTP ${probe.status}`, hint };
       }
-      // /chat/completions also 404'd (or the network dropped) — fall through
+      // Inference endpoint also 404'd (or the network dropped) — fall through
       // and report the original /models 404.
     }
     const { code, hint } = classifyHttpError(res.status);
@@ -517,28 +523,45 @@ type ProbeResult =
   | { kind: 'network'; message: string };
 
 /**
- * POST a minimal chat-completion request to verify the endpoint is alive
- * when GET /models returned 404. A 2xx response or any API-originated 4xx
- * (400 model_unknown, 402 insufficient credits, 422, 429 — and 401/403 too,
- * which we surface as an auth error instead of the misleading 404 hint)
- * counts as "endpoint reachable". Only 404 and 5xx count as a real failure.
+ * POST a minimal inference request to verify the endpoint is alive when GET
+ * /models returned 404. We dispatch by wire so that providers on the
+ * Responses API (which may not implement /chat/completions at all) can't
+ * false-positive via a gateway that only speaks the other shape. A 2xx
+ * response or any API-originated 4xx (400 model_unknown, 402 insufficient
+ * credits, 422, 429 — and 401/403 too, which we surface as auth) counts as
+ * "endpoint reachable". Only 404 and 5xx count as a real failure. The
+ * request body is intentionally minimal; if the gateway rejects the payload
+ * shape with a 4xx we still know the route exists.
  */
-async function probeChatCompletion(
+async function probeInferenceEndpoint(
+  wire: 'openai-chat' | 'openai-responses',
   normalizedBaseUrl: string,
   headers: Record<string, string>,
 ): Promise<ProbeResult> {
-  const url = `${normalizedBaseUrl}/chat/completions`;
+  const url =
+    wire === 'openai-responses'
+      ? `${normalizedBaseUrl}/responses`
+      : `${normalizedBaseUrl}/chat/completions`;
+  const body =
+    wire === 'openai-responses'
+      ? JSON.stringify({
+          model: 'probe',
+          input: [{ role: 'user', content: [{ type: 'input_text', text: 'ping' }] }],
+          max_output_tokens: 1,
+          stream: false,
+        })
+      : JSON.stringify({
+          model: 'probe',
+          messages: [{ role: 'user', content: 'ping' }],
+          max_tokens: 1,
+          stream: false,
+        });
   let res: Response;
   try {
     res = await fetchWithTimeout(url, {
       method: 'POST',
       headers: { ...headers, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        model: 'probe',
-        messages: [{ role: 'user', content: 'ping' }],
-        max_tokens: 1,
-        stream: false,
-      }),
+      body,
     });
   } catch (err) {
     return { kind: 'network', message: err instanceof Error ? err.message : String(err) };

--- a/packages/shared/src/diagnostics.test.ts
+++ b/packages/shared/src/diagnostics.test.ts
@@ -54,10 +54,40 @@ describe('diagnose', () => {
     expect(fix?.baseUrlTransform?.('https://api.example.com')).toBe('https://api.example.com/v1');
   });
 
-  it('404 transform is idempotent when /v1 already present', () => {
-    const result = diagnose('404', { ...baseCtx, baseUrl: 'https://api.example.com/v1' });
-    const transform = result[0]?.suggestedFix?.baseUrlTransform;
-    expect(transform?.('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+  // Regression: Zhipu GLM (issue #179) — baseUrl is /api/paas/v4, /models 404
+  // is because GLM does not expose /models, NOT because /v1 is missing.
+  // Auto-suggesting "add /v1" would corrupt a correct baseUrl.
+  it('404 skips missingV1 when baseUrl already has /v4 (GLM)', () => {
+    const result = diagnose('404', {
+      ...baseCtx,
+      baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    });
+    expect(result[0]?.cause).toBe('diagnostics.cause.unknown');
+    expect(result[0]?.suggestedFix).toBeUndefined();
+  });
+
+  it('404 skips missingV1 when baseUrl already has /v1 (e.g. Cloudflare Workers AI)', () => {
+    const result = diagnose('404', {
+      ...baseCtx,
+      baseUrl: 'https://gateway.ai.cloudflare.com/v1/account/foo/openai',
+    });
+    expect(result[0]?.cause).toBe('diagnostics.cause.unknown');
+    expect(result[0]?.suggestedFix).toBeUndefined();
+  });
+
+  it('404 skips missingV1 when baseUrl already has /v1beta (AI Studio)', () => {
+    const result = diagnose('404', {
+      ...baseCtx,
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    });
+    expect(result[0]?.cause).toBe('diagnostics.cause.unknown');
+    expect(result[0]?.suggestedFix).toBeUndefined();
+  });
+
+  it('404 still suggests missingV1 when baseUrl has NO version segment', () => {
+    const result = diagnose('404', { ...baseCtx, baseUrl: 'https://api.example.com' });
+    expect(result[0]?.cause).toBe('diagnostics.cause.missingV1');
+    expect(result[0]?.suggestedFix?.label).toBe('diagnostics.fix.addV1');
   });
 
   it('maps 429 to rateLimit with waitAndRetry fix', () => {

--- a/packages/shared/src/diagnostics.ts
+++ b/packages/shared/src/diagnostics.ts
@@ -81,6 +81,16 @@ export function diagnose(code: ErrorCode, ctx: DiagnoseContext): DiagnosticHypot
   }
 
   if (normalised === '404') {
+    // If the baseUrl already encodes a version segment (/v1, /v4, /v1beta,
+    // etc.), suggesting "add /v1" is wrong — Zhipu GLM uses /v4, AI Studio
+    // uses /v1beta, and some Cloudflare Workers AI gateways already carry
+    // /v1. A 404 on such endpoints usually means /models simply isn't
+    // exposed, not that the path is malformed. Fall back to the generic
+    // hypothesis so the user isn't pushed into corrupting a correct baseUrl.
+    const hasVersionSegment = /\/v\d+[a-z]*(?:\/|$)/i.test(ctx.baseUrl);
+    if (hasVersionSegment) {
+      return [{ cause: 'diagnostics.cause.unknown' }];
+    }
     return [
       {
         cause: 'diagnostics.cause.missingV1',


### PR DESCRIPTION
Fixes #179.

## Summary

- **Test connection degrade-probe.** When `GET /models` returns 404 on `openai-chat` or `openai-responses` wires, fall back to a minimal `POST /chat/completions` before declaring the endpoint dead. A 2xx or any API-originated 4xx (400 model_unknown / 402 insufficient credits / 422 / 429) counts as pass; 401/403 is re-surfaced as an auth error; only 404 + 5xx + network errors keep the original failure. Anthropic wires are intentionally not degraded — `/v1/models` is standard there. Successful responses now carry `probeMethod: 'models' | 'chat_completion_degraded'` so the renderer can surface "/models unavailable but /chat/completions responded" for gateways like Zhipu GLM.
- **Suppress misleading `missingV1` diagnostic hint.** `diagnose()` in `@open-codesign/shared` now skips the "add /v1" hypothesis when the baseUrl already carries a `/v\d+` segment (GLM `/v4`, AI Studio `/v1beta`, Cloudflare Workers AI `/v1`, ...). Previously the panel would offer to corrupt a perfectly correct baseUrl by appending `/v1`.

## Reproducing the GLM scenario (issue #179)

Adding Zhipu GLM as a custom provider (OpenAI Chat wire, baseUrl `https://open.bigmodel.cn/api/paas/v4`) used to fail "Test connection" with HTTP 404 plus an auto-suggest to append `/v1`. After this change:

- The probe sees `/models` return 404, degrades to `POST /chat/completions`, sees a real response from the gateway, and reports `ok: true` with `probeMethod: 'chat_completion_degraded'`.
- If the user's stored key is bad, the degrade probe's 401 is surfaced as the auth-error hint rather than the 404 one.
- If the baseUrl really is wrong and both endpoints 404, the original 404 error is preserved (no silent pass).

## Test plan

- [x] `pnpm test` (881 tests pass)
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (clean)
- [x] New Vitest cases in `apps/desktop/src/main/connection-ipc.test.ts` cover: GLM 404 /models + 200 /chat/completions, 404 + 404 (preserves original 404), 404 + 400 (model_unknown still passes), 404 + 401 (surfaces auth error), 200 /models (no probe, `probeMethod=models`), anthropic 404 (no degrade), openai-responses degrade.
- [x] New `diagnostics.test.ts` cases cover: GLM `/v4`, Cloudflare Workers AI `/v1`, AI Studio `/v1beta` — all skip `missingV1`; plain host without version still suggests `missingV1`.

## PRINCIPLES §5b

- Compatibility: green — response type is additive (`probeMethod` is optional when reading existing responses).
- Upgradeability: green — no schema/IPC version bump needed; callers that don't read `probeMethod` keep working.
- No bloat: green — ~55 lines added to one helper plus two tiny diagnostic tweaks; no new deps.
- Elegance: green — degrade is scoped to the exact wires that need it, auth failures are correctly re-routed, and the fallback is invisible to happy-path providers.