### PR TITLE
fix(release): ship both macOS arm64 and x64 DMGs with correct native modules (#176)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,17 +121,37 @@ jobs:
   # We do NOT sign in v0.1 — notarization deferred to Stage 2.
   # ------------------------------------------------------------------
   build:
-    name: Build (${{ matrix.os }})
+    name: Build (${{ matrix.label }})
     needs: [gate, changelog]
     strategy:
       fail-fast: false
       matrix:
+        # macOS is split into two native-arch runners. Cross-building both
+        # DMGs on a single arm64 host (what we used to do) shipped the host
+        # arch's native module inside the x64 DMG because electron-builder
+        # does not re-stage our per-arch better-sqlite3 prebuilds per target
+        # arch — see #176 (dlopen fails on Intel Macs). Using a native-arch
+        # runner per DMG guarantees `pnpm install` stages the right
+        # better_sqlite3.node* files for each target and keeps the legacy
+        # alias (better_sqlite3.node-electron.node) matching the DMG arch.
         include:
-          - os: macos-latest
+          - os: macos-latest # arm64 Apple Silicon runner
+            label: macos-arm64
+            mac_arch: arm64
+            artifact_name: installer-macos-arm64
+            artifact_glob: 'apps/desktop/release/*.dmg'
+          - os: macos-13 # Intel x64 runner (macos-latest is arm64)
+            label: macos-x64
+            mac_arch: x64
+            artifact_name: installer-macos-x64
             artifact_glob: 'apps/desktop/release/*.dmg'
           - os: windows-latest
+            label: windows-latest
+            artifact_name: installer-windows-latest
             artifact_glob: 'apps/desktop/release/*.exe'
           - os: ubuntu-latest
+            label: ubuntu-latest
+            artifact_name: installer-ubuntu-latest
             artifact_glob: |
               apps/desktop/release/*.AppImage
               apps/desktop/release/*.deb
@@ -170,16 +190,29 @@ jobs:
       # Package the Electron app.
       # CSC_IDENTITY_AUTO_DISCOVERY=false: skip ad-hoc Mac signing prompt.
       # WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD: intentionally unset (no cert in v0.1).
-      - name: Package desktop
+      # On macOS we force-pin the target arch to the runner's host arch
+      # (--arm64 on macos-latest, --x64 on macos-13) so each DMG is packaged
+      # natively instead of cross-built (see matrix comment + #176).
+      - name: Package desktop (non-mac)
+        if: runner.os != 'macOS'
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --filter @open-codesign/desktop release
 
+      - name: Package desktop (mac, per-arch)
+        if: runner.os == 'macOS'
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm --filter @open-codesign/desktop exec electron-vite build
+          pnpm --filter @open-codesign/desktop exec electron-builder --mac --${{ matrix.mac_arch }} --publish never
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: installer-${{ matrix.os }}
+          name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_glob }}
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Summary

Closes #176.

v0.1.3 on macOS Intel fails to open the snapshots DB with:

```
dlopen(...better_sqlite3.node-electron.node): (mach-o file, but is an
incompatible architecture (have 'arm64', need 'x86_64'))
```

### Diagnosis (scenario A)

- `electron-builder.yml` already declares `mac.target.arch: [arm64, x64]`, and the v0.1.3 release assets include both `open-codesign-0.1.3-arm64.dmg` and `open-codesign-0.1.3-x64.dmg`.
- Both DMGs were produced on a single `macos-latest` (arm64) runner.
- `apps/desktop/scripts/install-sqlite-bindings.cjs` stages per-arch prebuilds plus a legacy alias `better_sqlite3.node-electron.node` that points at the *host* arch. The runtime resolver in `apps/desktop/src/main/snapshots-db.ts` prefers arch-specific files and only falls back to the legacy alias when they are missing.
- The user's dlopen trace loads the legacy alias — meaning the x64-specific file did not make it into the x64 DMG. electron-builder's per-arch packaging pass reuses host-arch bytes for files it does not know to re-stage, so the x64 DMG ships with arm64 bytes.

### Fix

Split the macOS build into native-arch runners and pin electron-builder to each runner's host arch. Each runner does a fresh `pnpm install`, so our postinstall stages the correct per-arch binaries and the legacy alias matches the DMG arch.

- `macos-latest` (Apple Silicon) builds `--arm64` → `open-codesign-*-arm64.dmg`
- `macos-13` (Intel) builds `--x64` → `open-codesign-*-x64.dmg`

Scope is limited to `.github/workflows/release.yml`. Runtime resolution code and `electron-builder.yml` are unchanged.

### Principles check

- Compatibility: green — no format / schema changes.
- Upgradeability: green — future native-module additions inherit the native-runner guarantee.
- No bloat: green — workflow only; one extra mac runner-minute per release.
- Elegance: green — removes an implicit cross-build assumption.

## Test plan

Cannot fully verify locally (needs the full release workflow + published artifacts). Required CI validation:

- [ ] Tag a prerelease (e.g. `v0.1.4-rc.1`) or dispatch the `Release` workflow against a test tag.
- [ ] Confirm matrix runs `Build (macos-arm64)` on `macos-latest` and `Build (macos-x64)` on `macos-13`, each finishing green.
- [ ] Download both DMGs from the artifacts / release.
- [ ] `hdiutil attach open-codesign-*-x64.dmg` and run `lipo -archs 'Open CoDesign.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node-electron.node'` → expect `x86_64`.
- [ ] Repeat on the arm64 DMG → expect `arm64`.
- [ ] Launch x64 DMG on an Intel Mac (or VM): no "Could not open the local snapshots database" banner.

Local CI signal: `pnpm lint` and `pnpm typecheck` both green on this branch.