### PR TITLE
fix(providers): only flag reasoning=true for known OpenAI reasoning models (#183)

### DIFF
--- a/.changeset/fix-reasoning-flag-openai-compat.md
+++ b/.changeset/fix-reasoning-flag-openai-compat.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/providers": patch
+---
+
+Fix 400 "developer is not one of ['system', 'assistant', 'user', 'tool', 'function']" when talking to OpenAI-compatible gateways (Qwen/DashScope, DeepSeek, GLM/BigModel, Moonshot, …) through a custom provider. `synthesizeWireModel` no longer hard-codes `reasoning: true`; it only flags reasoning for Anthropic, openai-responses, openai-codex-responses, or OpenAI-official endpoints on known reasoning model families (o1/o3/o4/gpt-5). (#183)

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock('@mariozechner/pi-ai', () => ({
   completeSimple: (...args: unknown[]) => completeSimpleMock(...args),
 }));
 
-import { complete } from './index';
+import { complete, inferReasoning } from './index';
 
 const MODEL: ModelRef = { provider: 'openai', modelId: 'gpt-4o' };
 
@@ -280,6 +280,42 @@ describe('complete', () => {
     expect(result.content).toBe('ok');
   });
 
+  it('synthesizes openai-chat PiModel with reasoning=false for Qwen DashScope (#183)', async () => {
+    getModelMock.mockReturnValue(undefined);
+    completeSimpleMock.mockImplementationOnce(async (model) => {
+      expect(model.reasoning).toBe(false);
+      expect(model.api).toBe('openai-completions');
+      expect(model.baseUrl).toBe('https://dashscope.aliyuncs.com/compatible-mode/v1');
+      return {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        api: 'openai-completions',
+        provider: 'custom-qwen',
+        model: 'qwen3.6-plus',
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      };
+    });
+
+    await complete(
+      { provider: 'custom-qwen', modelId: 'qwen3.6-plus' },
+      [{ role: 'user', content: 'hi' }],
+      {
+        apiKey: 'sk-test',
+        wire: 'openai-chat',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      },
+    );
+  });
+
   it('rejects oversized combined image inputs for openai-codex-responses', async () => {
     getModelMock.mockReturnValue({
       id: 'gpt-5.4',
@@ -302,5 +338,53 @@ describe('complete', () => {
         },
       ),
     ).rejects.toMatchObject({ code: 'ATTACHMENT_TOO_LARGE' });
+  });
+});
+
+describe('inferReasoning', () => {
+  it('returns false for Qwen DashScope via openai-chat (#183)', () => {
+    expect(
+      inferReasoning(
+        'openai-chat',
+        'qwen3.6-plus',
+        'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for DeepSeek via openai-chat', () => {
+    expect(inferReasoning('openai-chat', 'deepseek-chat', 'https://api.deepseek.com/v1')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for GLM (BigModel) via openai-chat', () => {
+    expect(inferReasoning('openai-chat', 'glm-4.6v', 'https://open.bigmodel.cn/api/paas/v4')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for OpenAI official non-reasoning model (gpt-4o)', () => {
+    expect(inferReasoning('openai-chat', 'gpt-4o', 'https://api.openai.com/v1')).toBe(false);
+  });
+
+  it('returns true for OpenAI official gpt-5 family via openai-chat', () => {
+    expect(inferReasoning('openai-chat', 'gpt-5-turbo', 'https://api.openai.com/v1')).toBe(true);
+  });
+
+  it('returns true for OpenAI official o3 family via openai-chat', () => {
+    expect(inferReasoning('openai-chat', 'o3-mini', 'https://api.openai.com/v1')).toBe(true);
+  });
+
+  it('returns true for openai-responses regardless of model id (preserves #134 fix)', () => {
+    expect(inferReasoning('openai-responses', 'gpt-5.4', 'https://proxy.example/v1')).toBe(true);
+  });
+
+  it('returns true for anthropic wire', () => {
+    expect(inferReasoning('anthropic', 'claude-opus-4-5', 'https://api.anthropic.com')).toBe(true);
+  });
+
+  it('returns false when wire is undefined', () => {
+    expect(inferReasoning(undefined, 'gpt-4o', 'https://api.openai.com/v1')).toBe(false);
   });
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -171,6 +171,42 @@ const EMPTY_USAGE: PiUsage = {
 const MAX_TOTAL_CODEX_IMAGE_BYTES = 4_000_000;
 
 /**
+ * `reasoning: true` on a synthesized PiModel makes pi-ai's openai-responses /
+ * openai-chat adapters write the system prompt with role `'developer'`
+ * instead of `'system'`. That's OpenAI-Responses-only; every OpenAI-compat
+ * gateway out there (DashScope/Qwen, DeepSeek, GLM/BigModel, Moonshot, …)
+ * rejects `developer` with HTTP 400. So only claim reasoning when we
+ * actually know the target accepts it. (#183)
+ */
+function isOpenAIOfficial(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  return /^https:\/\/api\.openai\.com(\/|$)/.test(baseUrl);
+}
+
+function isReasoningModelId(modelId: string): boolean {
+  // OpenAI reasoning families: o1, o3, o4, gpt-5 (incl. variants like gpt-5-turbo, gpt-5.4)
+  return /^(o[134]|gpt-5)/i.test(modelId);
+}
+
+export function inferReasoning(
+  wire: GenerateOptions['wire'],
+  modelId: string,
+  baseUrl: string | undefined,
+): boolean {
+  switch (wire) {
+    case 'anthropic':
+      return true;
+    case 'openai-responses':
+    case 'openai-codex-responses':
+      return true;
+    case 'openai-chat':
+      return isOpenAIOfficial(baseUrl) && isReasoningModelId(modelId);
+    default:
+      return false;
+  }
+}
+
+/**
  * Synthesize a PiModel for a wire + custom baseUrl so custom provider ids
  * (DeepSeek, Ollama, LiteLLM, Azure, …) route to the correct pi-ai adapter
  * without being in pi-ai's model registry.
@@ -195,7 +231,7 @@ function synthesizeWireModel(
     name: modelId,
     api,
     provider,
-    reasoning: true,
+    reasoning: inferReasoning(wire, modelId, baseUrl),
     input: supportsImageInput ? ['text', 'image'] : ['text'],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 131072,


### PR DESCRIPTION
Fixes #183.

## Problem

Custom providers on OpenAI-compatible gateways (Qwen/DashScope, DeepSeek, GLM/BigModel, Moonshot, any `openai-chat` wire pointing to a non-OpenAI baseUrl) returned:

```
400 developer is not one of ['system', 'assistant', 'user', 'tool', 'function']
```

## Root cause

`packages/providers/src/index.ts::synthesizeWireModel` hard-coded `reasoning: true` on every synthetic `PiModel`. pi-ai's openai-chat / openai-responses adapters treat `model.reasoning === true` as "this endpoint supports the Responses API `developer` role" and rewrite the system prompt role accordingly. `developer` is OpenAI-Responses-only (GPT-5 / o-family); no third-party OpenAI-compat gateway accepts it.

## Fix

New `inferReasoning(wire, modelId, baseUrl)`:

- `anthropic` -> `true`
- `openai-responses` / `openai-codex-responses` -> `true` (preserves #134)
- `openai-chat` -> `true` only when baseUrl is `api.openai.com` AND modelId matches `^(o[134]|gpt-5)` (OpenAI reasoning families)
- otherwise -> `false`

## Coverage

Unblocks every OpenAI-compatible Chinese gateway and any generic OpenAI-compat endpoint:
- Qwen / DashScope (`dashscope.aliyuncs.com`)
- DeepSeek (`api.deepseek.com`)
- GLM / Zhipu BigModel (`open.bigmodel.cn`)
- Moonshot / Kimi
- Any user-configured LiteLLM / Azure / self-hosted openai-chat gateway

## Tests

`packages/providers/src/index.test.ts` — 9 new `inferReasoning` cases + 1 integration case asserting Qwen DashScope gets `reasoning: false` through `complete()`.

## Four-principle check (PRINCIPLES §5b)

- Compatibility: green — #134 (openai-responses) + #175 unchanged; Anthropic unchanged
- Upgradeability: green — central helper; adding new reasoning model families is a regex edit
- No bloat: green — single helper function, no new file, no new dep
- Elegance: green — intent-revealing name; replaces a hard-coded `true` with a predicate

## Out of scope

Didn't touch retry / errors / Settings / agent.ts.