### PR TITLE
feat(desktop): align connection test credential resolution with runtime

### DIFF
--- a/apps/desktop/src/main/connection-ipc.credentials.test.ts
+++ b/apps/desktop/src/main/connection-ipc.credentials.test.ts
@@ -1,0 +1,86 @@
+import { type Config, hydrateConfig } from '@open-codesign/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./electron-runtime', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+const { getCachedConfigMock, getApiKeyForProviderMock } = vi.hoisted(() => ({
+  getCachedConfigMock: vi.fn<() => Config | null>(),
+  getApiKeyForProviderMock: vi.fn<(providerId: string) => string>(),
+}));
+
+vi.mock('./onboarding-ipc', () => ({
+  getCachedConfig: getCachedConfigMock,
+  getApiKeyForProvider: getApiKeyForProviderMock,
+}));
+
+vi.mock('./codex-oauth-ipc', () => ({
+  getCodexTokenStore: () => ({
+    getValidAccessToken: vi.fn(async () => 'codex-token'),
+    read: vi.fn(async () => null),
+  }),
+}));
+
+import { resolveActiveCredentials, resolveCredentialsForProvider } from './connection-ipc';
+
+function makeCfg(): Config {
+  return hydrateConfig({
+    version: 3,
+    activeProvider: 'claude-shell',
+    activeModel: 'claude-sonnet-4-6',
+    providers: {
+      'claude-shell': {
+        id: 'claude-shell',
+        name: 'Claude (shell env)',
+        builtin: false,
+        wire: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        defaultModel: 'claude-sonnet-4-6',
+        envKey: 'ANTHROPIC_AUTH_TOKEN',
+      },
+    },
+    secrets: {},
+  });
+}
+
+describe('connection credential resolution via envKey fallback', () => {
+  beforeEach(() => {
+    getCachedConfigMock.mockReset();
+    getApiKeyForProviderMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolveCredentialsForProvider delegates to getApiKeyForProvider for env-backed imported providers', async () => {
+    getCachedConfigMock.mockReturnValue(makeCfg());
+    getApiKeyForProviderMock.mockReturnValue('sk-from-env');
+
+    const result = await resolveCredentialsForProvider('claude-shell');
+
+    expect(getApiKeyForProviderMock).toHaveBeenCalledWith('claude-shell');
+    expect(result).toEqual({
+      provider: 'claude-shell',
+      wire: 'anthropic',
+      apiKey: 'sk-from-env',
+      baseUrl: 'https://api.anthropic.com',
+    });
+  });
+
+  it('resolveActiveCredentials also reaches env-backed imported providers without a stored secret', async () => {
+    getCachedConfigMock.mockReturnValue(makeCfg());
+    getApiKeyForProviderMock.mockReturnValue('sk-from-env');
+
+    const result = await resolveActiveCredentials();
+
+    expect(getApiKeyForProviderMock).toHaveBeenCalledWith('claude-shell');
+    expect(result).toEqual({
+      provider: 'claude-shell',
+      wire: 'anthropic',
+      apiKey: 'sk-from-env',
+      baseUrl: 'https://api.anthropic.com',
+    });
+  });
+});

--- a/apps/desktop/src/main/connection-ipc.parity.test.ts
+++ b/apps/desktop/src/main/connection-ipc.parity.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./electron-runtime', () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+const onboardingMocks = vi.hoisted(() => ({
+  getCachedConfig: vi.fn(),
+  getApiKeyForProvider: vi.fn(),
+}));
+
+vi.mock('./onboarding-ipc', () => ({
+  getCachedConfig: onboardingMocks.getCachedConfig,
+  getApiKeyForProvider: onboardingMocks.getApiKeyForProvider,
+}));
+
+const codexMocks = vi.hoisted(() => ({
+  getValidAccessToken: vi.fn(),
+}));
+
+vi.mock('./codex-oauth-ipc', async () => {
+  const actual = await vi.importActual<typeof import('./codex-oauth-ipc')>('./codex-oauth-ipc');
+  return {
+    ...actual,
+    getCodexTokenStore: () => ({
+      getValidAccessToken: codexMocks.getValidAccessToken,
+    }),
+  };
+});
+
+import {
+  BUILTIN_PROVIDERS,
+  CHATGPT_CODEX_PROVIDER_ID,
+  type Config,
+  hydrateConfig,
+} from '@open-codesign/shared';
+import { resolveActiveCredentials, resolveCredentialsForProvider } from './connection-ipc';
+
+function makeCfg(input: {
+  activeProvider: string;
+  activeModel: string;
+  providers?: Record<string, import('@open-codesign/shared').ProviderEntry>;
+  secrets?: Record<string, { ciphertext: string }>;
+}): Config {
+  return hydrateConfig({
+    version: 3,
+    activeProvider: input.activeProvider,
+    activeModel: input.activeModel,
+    providers: {
+      openai: { ...BUILTIN_PROVIDERS.openai },
+      ...(input.providers ?? {}),
+    },
+    secrets: input.secrets ?? {},
+  });
+}
+
+describe('connection test credential parity', () => {
+  beforeEach(() => {
+    onboardingMocks.getCachedConfig.mockReset();
+    onboardingMocks.getApiKeyForProvider.mockReset();
+    codexMocks.getValidAccessToken.mockReset();
+  });
+
+  it('test-active resolves ChatGPT Codex auth via the same token accessor runtime uses', async () => {
+    onboardingMocks.getCachedConfig.mockReturnValue(
+      makeCfg({
+        activeProvider: CHATGPT_CODEX_PROVIDER_ID,
+        activeModel: 'gpt-5.3-codex',
+        providers: {
+          [CHATGPT_CODEX_PROVIDER_ID]: {
+            id: CHATGPT_CODEX_PROVIDER_ID,
+            name: 'ChatGPT Codex',
+            builtin: false,
+            wire: 'openai-codex-responses',
+            baseUrl: 'https://chatgpt.com/backend-api',
+            defaultModel: 'gpt-5.3-codex',
+            requiresApiKey: false,
+            capabilities: {
+              supportsKeyless: true,
+              supportsModelsEndpoint: false,
+              supportsReasoning: true,
+              requiresClaudeCodeIdentity: false,
+              modelDiscoveryMode: 'static-hint',
+            },
+          },
+        },
+      }),
+    );
+    codexMocks.getValidAccessToken.mockResolvedValue('oauth-access-token');
+
+    const result = await resolveActiveCredentials();
+
+    expect('provider' in result).toBe(true);
+    if ('provider' in result) {
+      expect(result.provider).toBe(CHATGPT_CODEX_PROVIDER_ID);
+      expect(result.wire).toBe('openai-codex-responses');
+      expect(result.apiKey).toBe('oauth-access-token');
+      expect(codexMocks.getValidAccessToken).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('test-provider respects explicit keyless capability and returns an empty bearer', async () => {
+    onboardingMocks.getCachedConfig.mockReturnValue(
+      makeCfg({
+        activeProvider: 'openai',
+        activeModel: 'gpt-4o',
+        secrets: { openai: { ciphertext: 'enc-openai' } },
+        providers: {
+          'litellm-proxy': {
+            id: 'litellm-proxy',
+            name: 'LiteLLM Proxy',
+            builtin: false,
+            wire: 'openai-chat',
+            baseUrl: 'https://proxy.example.com/v1',
+            defaultModel: 'gpt-4.1',
+            capabilities: {
+              supportsKeyless: true,
+              supportsModelsEndpoint: true,
+              supportsReasoning: true,
+              requiresClaudeCodeIdentity: false,
+              modelDiscoveryMode: 'models',
+            },
+          },
+        },
+      }),
+    );
+    onboardingMocks.getApiKeyForProvider.mockImplementation(() => {
+      throw new Error('missing secret');
+    });
+
+    const result = await resolveCredentialsForProvider('litellm-proxy');
+
+    expect('provider' in result).toBe(true);
+    if ('provider' in result) {
+      expect(result.provider).toBe('litellm-proxy');
+      expect(result.apiKey).toBe('');
+      expect(result.baseUrl).toBe('https://proxy.example.com/v1');
+    }
+  });
+
+  it('test-provider returns an actionable config error for unknown providers', async () => {
+    onboardingMocks.getCachedConfig.mockReturnValue(
+      makeCfg({
+        activeProvider: 'openai',
+        activeModel: 'gpt-4o',
+        secrets: { openai: { ciphertext: 'enc-openai' } },
+      }),
+    );
+
+    const result = await resolveCredentialsForProvider('missing-provider');
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'IPC_BAD_INPUT',
+    });
+    if (!('provider' in result)) {
+      expect(result.message).toContain('missing-provider');
+    }
+  });
+});

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
   BUILTIN_PROVIDERS,
+  CHATGPT_CODEX_PROVIDER_ID,
   CodesignError,
   ERROR_CODES,
   type SupportedOnboardingProvider,
@@ -14,7 +15,8 @@ import { buildAuthHeaders, buildAuthHeadersForWire } from './auth-headers';
 import { getCodexTokenStore } from './codex-oauth-ipc';
 import { ipcMain } from './electron-runtime';
 import { getApiKeyForProvider, getCachedConfig } from './onboarding-ipc';
-import { isKeylessProviderAllowed } from './provider-settings';
+import { isKeylessProviderAllowed, resolveProviderConfig } from './provider-settings';
+import { resolveApiKeyWithKeylessFallback } from './resolve-api-key';
 
 // Re-export so existing importers (tests, other main-process modules) keep
 // working after the helpers moved to `./auth-headers` to break a circular
@@ -363,109 +365,96 @@ export interface ActiveProviderCredentials {
   httpHeaders?: Record<string, string>;
 }
 
-function resolveCredentialsForProvider(
+export function resolveCredentialsForProvider(
   providerId: string,
-): ActiveProviderCredentials | ConnectionTestError {
+): Promise<ActiveProviderCredentials | ConnectionTestError> {
   const cfg = getCachedConfig();
   if (cfg === null || providerId.length === 0) {
-    return {
+    return Promise.resolve({
       ok: false,
       code: 'IPC_BAD_INPUT',
       message: 'No active provider configured',
       hint: 'Complete onboarding first',
-    };
+    });
   }
-  const entry =
-    cfg.providers[providerId] ??
-    (isSupportedOnboardingProvider(providerId) ? BUILTIN_PROVIDERS[providerId] : undefined);
-  if (entry === undefined) {
-    return {
-      ok: false,
-      code: 'IPC_BAD_INPUT',
-      message: `Provider "${providerId}" not found in config`,
-      hint: 'Re-add the provider from Settings',
-    };
-  }
-  let apiKey: string;
+  let resolved: ReturnType<typeof resolveProviderConfig>;
   try {
-    apiKey = getApiKeyForProvider(providerId);
+    resolved = resolveProviderConfig(cfg, providerId);
   } catch (err) {
-    // No stored key — provider may be keyless (IP-whitelisted proxy).
-    if (!isKeylessProviderAllowed(providerId, entry)) {
-      return {
-        ok: false,
-        code: 'IPC_BAD_INPUT',
-        message:
-          err instanceof Error ? err.message : `No API key stored for provider "${providerId}"`,
-        hint: 'Open Settings and import Codex again, or add an API key for this provider',
-      };
-    }
-    apiKey = '';
+    return Promise.resolve(mapCredentialResolutionError(providerId, err));
   }
-  return {
-    provider: providerId,
-    wire: entry.wire,
-    apiKey,
-    baseUrl: entry.baseUrl,
-    ...(entry.httpHeaders !== undefined ? { httpHeaders: entry.httpHeaders } : {}),
-  };
+  return resolveApiKeyWithKeylessFallback(providerId, resolved.allowKeyless, {
+    getCodexAccessToken: () => getCodexTokenStore().getValidAccessToken(),
+    getApiKeyForProvider,
+  })
+    .then((apiKey) => ({
+      provider: providerId,
+      wire: resolved.wire,
+      apiKey,
+      baseUrl: resolved.baseUrl,
+      ...(resolved.httpHeaders !== undefined ? { httpHeaders: resolved.httpHeaders } : {}),
+    }))
+    .catch((err: unknown) => mapCredentialResolutionError(providerId, err));
 }
 
-function resolveActiveCredentials(): ActiveProviderCredentials | ConnectionTestError {
+export function resolveActiveCredentials(): Promise<
+  ActiveProviderCredentials | ConnectionTestError
+> {
   const cfg = getCachedConfig();
   const active = cfg?.activeProvider;
   if (active === undefined || active.length === 0) {
-    return {
+    return Promise.resolve({
       ok: false,
       code: 'IPC_BAD_INPUT',
       message: 'No active provider configured',
       hint: 'Complete onboarding first',
-    };
+    });
   }
   return resolveCredentialsForProvider(active);
 }
 
-async function testChatGPTCodexOAuth(): Promise<ConnectionTestResponse> {
-  let stored: Awaited<ReturnType<ReturnType<typeof getCodexTokenStore>['read']>>;
-  try {
-    stored = await getCodexTokenStore().read();
-  } catch (err) {
-    return {
-      ok: false,
-      code: '401',
-      message: err instanceof Error ? err.message : String(err),
-      hint: 'ChatGPT 订阅凭证读取失败，请到 Settings 重新登录',
-    };
+function mapCredentialResolutionError(providerId: string, err: unknown): ConnectionTestError {
+  if (err instanceof CodesignError) {
+    if (
+      providerId === CHATGPT_CODEX_PROVIDER_ID &&
+      err.code === ERROR_CODES.PROVIDER_AUTH_MISSING
+    ) {
+      return {
+        ok: false,
+        code: '401',
+        message: err.message,
+        hint: 'ChatGPT subscription sign-in expired. Re-login from Settings.',
+      };
+    }
+    if (
+      err.code === ERROR_CODES.PROVIDER_NOT_SUPPORTED ||
+      err.code === ERROR_CODES.PROVIDER_KEY_MISSING ||
+      err.code === ERROR_CODES.PROVIDER_AUTH_MISSING
+    ) {
+      return {
+        ok: false,
+        code: 'IPC_BAD_INPUT',
+        message: err.message,
+        hint: 'Open Settings and import Codex again, or add an API key for this provider',
+      };
+    }
   }
-  if (stored === null) {
-    return {
-      ok: false,
-      code: '401',
-      message: 'No ChatGPT OAuth token stored',
-      hint: 'ChatGPT 订阅未登录，请到 Settings 登录',
-    };
-  }
-  if (stored.expiresAt < Date.now()) {
-    return {
-      ok: false,
-      code: '401',
-      message: 'ChatGPT OAuth token expired',
-      hint: 'ChatGPT 订阅登录已过期，请重新登录',
-    };
-  }
-  return { ok: true };
+  return {
+    ok: false,
+    code: 'IPC_BAD_INPUT',
+    message: err instanceof Error ? err.message : `Failed to resolve provider "${providerId}"`,
+    hint: 'Open Settings and import Codex again, or add an API key for this provider',
+  };
 }
 
 export async function runProviderTest(
   creds: ActiveProviderCredentials,
 ): Promise<ConnectionTestResponse> {
-  // ChatGPT subscription uses OAuth + ChatGPT-Account-Id headers; its host
-  // has no `/models` endpoint that a generic Bearer probe can reach. A plain
-  // HTTP probe would return 401 here and render as the misleading "API key
-  // 错误或权限不足" hint — so we check the OAuth token store directly and
-  // surface a login-specific hint instead.
+  // ChatGPT subscription has no generic /models probe path that matches the
+  // runtime SDK route. Once the OAuth bearer resolves via the same credential
+  // helper runtime uses, treat the connection test as passed.
   if (creds.wire === 'openai-codex-responses') {
-    return testChatGPTCodexOAuth();
+    return { ok: true };
   }
 
   const { url, normalizedBaseUrl } = buildEndpointForWire(creds.wire, creds.baseUrl);
@@ -697,7 +686,7 @@ export function registerConnectionIpc(): void {
 
   // Tests the currently active provider using the stored (encrypted) key — no key passed from renderer.
   ipcMain.handle('connection:v1:test-active', async (): Promise<ConnectionTestResponse> => {
-    const creds = resolveActiveCredentials();
+    const creds = await resolveActiveCredentials();
     if (!('provider' in creds)) return creds;
     return runProviderTest(creds);
   });
@@ -715,7 +704,7 @@ export function registerConnectionIpc(): void {
           hint: 'Internal error — missing provider id',
         };
       }
-      const creds = resolveCredentialsForProvider(raw);
+      const creds = await resolveCredentialsForProvider(raw);
       if (!('provider' in creds)) return creds;
       return runProviderTest(creds);
     },

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -11,6 +11,7 @@ import {
   getAddProviderDefaults,
   isKeylessProviderAllowed,
   resolveActiveModel,
+  resolveProviderConfig,
   toProviderRows,
 } from './provider-settings';
 
@@ -458,5 +459,63 @@ describe('resolveActiveModel', () => {
         modelId: 'gpt-5.4',
       }),
     ).toThrowError(CodesignError);
+  });
+});
+
+describe('resolveProviderConfig', () => {
+  it('resolves the stored provider contract for a saved provider id', () => {
+    const cfg = makeCfg({
+      provider: 'openai',
+      modelPrimary: 'gpt-4o',
+      secrets: { openai: { ciphertext: 'enc-oai' } },
+      baseUrls: { openai: 'https://api.duckcoding.ai/v1' },
+    });
+
+    const result = resolveProviderConfig(cfg, 'openai');
+
+    expect(result).toMatchObject({
+      provider: 'openai',
+      defaultModel: 'gpt-4o',
+      baseUrl: 'https://api.duckcoding.ai/v1',
+      wire: 'openai-chat',
+      allowKeyless: false,
+    });
+  });
+
+  it('allows keyless imported providers and carries their stored wire/baseUrl', () => {
+    const cfg = makeCfg({
+      provider: 'codex-proxy',
+      modelPrimary: 'gpt-5.3-codex',
+      providers: {
+        'codex-proxy': {
+          id: 'codex-proxy',
+          name: 'Codex (imported)',
+          builtin: false,
+          wire: 'openai-responses',
+          baseUrl: 'https://proxy.example.com/v1',
+          defaultModel: 'gpt-5.3-codex',
+        },
+      },
+    });
+
+    const result = resolveProviderConfig(cfg, 'codex-proxy');
+
+    expect(result).toMatchObject({
+      provider: 'codex-proxy',
+      defaultModel: 'gpt-5.3-codex',
+      baseUrl: 'https://proxy.example.com/v1',
+      wire: 'openai-responses',
+      allowKeyless: true,
+    });
+  });
+
+  it('throws for unknown providers', () => {
+    const cfg = makeCfg({
+      provider: 'openai',
+      modelPrimary: 'gpt-4o',
+      secrets: { openai: { ciphertext: 'enc-oai' } },
+    });
+
+    expect(() => resolveProviderConfig(cfg, 'missing-provider')).toThrowError(CodesignError);
   });
 });

--- a/apps/desktop/src/main/provider-settings.test.ts
+++ b/apps/desktop/src/main/provider-settings.test.ts
@@ -396,7 +396,7 @@ describe('resolveActiveModel', () => {
     expect(result.baseUrl).not.toBe('https://api.duckcoding.ai/v1');
   });
 
-  it('throws PROVIDER_KEY_MISSING when the active provider has no stored secret', () => {
+  it('still resolves the active provider contract when the secret is loaded later at runtime', () => {
     const cfg = makeCfg({
       provider: 'anthropic',
       modelPrimary: 'claude-sonnet-4-6',
@@ -405,9 +405,11 @@ describe('resolveActiveModel', () => {
         openrouter: { ciphertext: 'enc-or' },
       },
     });
-    expect(() =>
-      resolveActiveModel(cfg, { provider: 'anthropic', modelId: 'claude-sonnet-4-6' }),
-    ).toThrowError(CodesignError);
+
+    const result = resolveActiveModel(cfg, { provider: 'anthropic', modelId: 'claude-sonnet-4-6' });
+
+    expect(result.model).toEqual({ provider: 'anthropic', modelId: 'claude-sonnet-4-6' });
+    expect(result.allowKeyless).toBe(false);
   });
 
   it('allows active imported Codex providers without a stored secret', () => {
@@ -436,7 +438,7 @@ describe('resolveActiveModel', () => {
     expect(result.allowKeyless).toBe(true);
   });
 
-  it('throws for active imported Codex providers that require a stored secret', () => {
+  it('does not reject active imported providers that require a secret before runtime credential resolution', () => {
     const cfg = makeCfg({
       provider: 'codex-custom',
       modelPrimary: 'gpt-5.4',
@@ -453,12 +455,13 @@ describe('resolveActiveModel', () => {
       },
     });
 
-    expect(() =>
-      resolveActiveModel(cfg, {
-        provider: 'codex-custom',
-        modelId: 'gpt-5.4',
-      }),
-    ).toThrowError(CodesignError);
+    const result = resolveActiveModel(cfg, {
+      provider: 'codex-custom',
+      modelId: 'gpt-5.4',
+    });
+
+    expect(result.model).toEqual({ provider: 'codex-custom', modelId: 'gpt-5.4' });
+    expect(result.allowKeyless).toBe(false);
   });
 });
 
@@ -506,6 +509,34 @@ describe('resolveProviderConfig', () => {
       baseUrl: 'https://proxy.example.com/v1',
       wire: 'openai-responses',
       allowKeyless: true,
+    });
+  });
+
+  it('does not reject imported providers that rely on envKey fallback', () => {
+    const cfg = makeCfg({
+      provider: 'claude-shell',
+      modelPrimary: 'claude-sonnet-4-6',
+      providers: {
+        'claude-shell': {
+          id: 'claude-shell',
+          name: 'Claude (shell env)',
+          builtin: false,
+          wire: 'anthropic',
+          baseUrl: 'https://api.anthropic.com',
+          defaultModel: 'claude-sonnet-4-6',
+          envKey: 'ANTHROPIC_AUTH_TOKEN',
+        },
+      },
+    });
+
+    const result = resolveProviderConfig(cfg, 'claude-shell');
+
+    expect(result).toMatchObject({
+      provider: 'claude-shell',
+      defaultModel: 'claude-sonnet-4-6',
+      baseUrl: 'https://api.anthropic.com',
+      wire: 'anthropic',
+      allowKeyless: false,
     });
   });
 

--- a/apps/desktop/src/main/provider-settings.ts
+++ b/apps/desktop/src/main/provider-settings.ts
@@ -238,12 +238,6 @@ export function resolveProviderConfig(cfg: Config, providerId: string): Provider
     );
   }
   const allowKeyless = isKeylessProviderAllowed(providerId, entry);
-  if (cfg.secrets[providerId] === undefined && !allowKeyless) {
-    throw new CodesignError(
-      `No API key stored for provider "${providerId}". Re-run onboarding to add one.`,
-      ERROR_CODES.PROVIDER_KEY_MISSING,
-    );
-  }
   return {
     provider: providerId,
     defaultModel: entry.defaultModel,

--- a/apps/desktop/src/main/provider-settings.ts
+++ b/apps/desktop/src/main/provider-settings.ts
@@ -213,35 +213,65 @@ export interface ActiveModelResolution {
   overridden: boolean;
 }
 
-export function resolveActiveModel(
-  cfg: Config,
-  hint: { provider: string; modelId: string },
-): ActiveModelResolution {
-  const activeId = cfg.activeProvider;
-  const entry = resolveEntryFor(cfg, activeId);
+/**
+ * Shared provider resolution for any main-process path that needs the stored
+ * provider contract as persisted on disk, regardless of whether the caller is
+ * about to generate, list models, or probe the connection.
+ */
+export interface ProviderConfigResolution {
+  provider: string;
+  defaultModel: string;
+  baseUrl: string;
+  wire: WireApi;
+  httpHeaders: Record<string, string> | undefined;
+  queryParams: Record<string, string> | undefined;
+  reasoningLevel: ReasoningLevel | undefined;
+  allowKeyless: boolean;
+}
+
+export function resolveProviderConfig(cfg: Config, providerId: string): ProviderConfigResolution {
+  const entry = resolveEntryFor(cfg, providerId);
   if (entry === null) {
     throw new CodesignError(
-      `Active provider "${activeId}" has no provider entry on disk.`,
+      `Provider "${providerId}" has no provider entry on disk.`,
       ERROR_CODES.PROVIDER_NOT_SUPPORTED,
     );
   }
-  const allowKeyless = isKeylessProviderAllowed(activeId, entry);
-  if (cfg.secrets[activeId] === undefined && !allowKeyless) {
+  const allowKeyless = isKeylessProviderAllowed(providerId, entry);
+  if (cfg.secrets[providerId] === undefined && !allowKeyless) {
     throw new CodesignError(
-      `No API key stored for active provider "${activeId}". Re-run onboarding to add one.`,
+      `No API key stored for provider "${providerId}". Re-run onboarding to add one.`,
       ERROR_CODES.PROVIDER_KEY_MISSING,
     );
   }
-  const overridden = activeId !== hint.provider;
-  const modelId = overridden ? cfg.activeModel : hint.modelId;
   return {
-    model: { provider: activeId, modelId },
+    provider: providerId,
+    defaultModel: entry.defaultModel,
     baseUrl: entry.baseUrl,
     wire: entry.wire,
     httpHeaders: entry.httpHeaders,
     queryParams: entry.queryParams,
     reasoningLevel: entry.reasoningLevel,
     allowKeyless,
+  };
+}
+
+export function resolveActiveModel(
+  cfg: Config,
+  hint: { provider: string; modelId: string },
+): ActiveModelResolution {
+  const activeId = cfg.activeProvider;
+  const resolved = resolveProviderConfig(cfg, activeId);
+  const overridden = activeId !== hint.provider;
+  const modelId = overridden ? cfg.activeModel : hint.modelId;
+  return {
+    model: { provider: activeId, modelId },
+    baseUrl: resolved.baseUrl,
+    wire: resolved.wire,
+    httpHeaders: resolved.httpHeaders,
+    queryParams: resolved.queryParams,
+    reasoningLevel: resolved.reasoningLevel,
+    allowKeyless: resolved.allowKeyless,
     overridden,
   };
 }


### PR DESCRIPTION
## Summary / 摘要

This PR lands a first slice of #216 by aligning how connection tests resolve stored provider config and credentials with the same main-process helpers runtime invocation already relies on.

这个 PR 先为 #216 落第一刀：让“测试连接”在解析已保存 provider 配置与 credential 时，尽量复用 runtime 已经依赖的主进程 helper，而不是继续维护一套单独的语义。

### What changed / 变更内容

- add `resolveProviderConfig()` in `provider-settings.ts` as a shared stored-provider resolver
- make `resolveActiveModel()` build on top of that shared provider config resolution
- update `connection-ipc.ts` to reuse shared provider resolution + `resolveApiKeyWithKeylessFallback()`
- align ChatGPT Codex connection auth with the runtime token-access path instead of a raw token-store probe
- add focused parity tests for active-provider resolution, explicit keyless providers, and unknown-provider handling

### Why this shape / 为什么这样做

Issue #216 is larger than one PR. This first slice focuses on the lowest-level semantic mismatch:

- runtime already uses canonical provider resolution + shared API-key logic
- connection test still had its own provider-entry + keyless + credential path

By aligning those first, we reduce one major source of `test-pass/runtime-fail` and `test-fail/runtime-pass` divergence before touching richer diagnostics or UI wording.

### Testing / 验证

Ran locally:

- `corepack pnpm --filter @open-codesign/desktop test -- --run src/main/connection-ipc.parity.test.ts src/main/provider-settings.test.ts src/main/connection-ipc.test.ts`
- `corepack pnpm --filter @open-codesign/desktop typecheck`
- `corepack pnpm exec biome check apps/desktop/src/main/provider-settings.ts apps/desktop/src/main/provider-settings.test.ts apps/desktop/src/main/connection-ipc.ts apps/desktop/src/main/connection-ipc.parity.test.ts`

Note: the repo still has one unrelated pre-existing Biome warning in `apps/desktop/src/renderer/src/components/Settings.tsx` about exhaustive deps. This PR does not touch that file.

Refs #216
Refs #214
