### PR TITLE
fix: clarify ChatGPT OAuth region login errors

### DIFF
--- a/.changeset/fix-chatgpt-oauth-region-message.md
+++ b/.changeset/fix-chatgpt-oauth-region-message.md
@@ -1,0 +1,7 @@
+---
+"@open-codesign/desktop": patch
+"@open-codesign/i18n": patch
+"@open-codesign/providers": patch
+---
+
+Show a friendly localized message when ChatGPT OAuth rejects token exchange for unsupported countries or regions.

--- a/apps/desktop/src/renderer/src/components/ChatgptLoginCard.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatgptLoginCard.test.tsx
@@ -7,7 +7,12 @@ import {
   resolveViewState,
 } from './ChatgptLoginCard';
 
-const LOGIN_STRINGS = { failedTitle: 'login failed', unknownError: 'unknown' };
+const LOGIN_STRINGS = {
+  failedTitle: 'login failed',
+  unknownError: 'unknown',
+  unsupportedCountryRegion:
+    'ChatGPT subscription login is not available for this account, country, region, or territory.',
+};
 const LOGOUT_STRINGS = {
   confirmMessage: 'sign out?',
   failedTitle: 'logout failed',
@@ -100,6 +105,37 @@ describe('performLogin', () => {
     expect(pushToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: 'error', description: 'network down' }),
     );
+  });
+
+  it('shows a friendly message when OpenAI rejects the OAuth exchange for country or region support', async () => {
+    const rawMessage =
+      'Error invoking remote method \'codex-oauth:v1:login\': CodesignError: Codex login failed: Codex OAuth exchange failed: 403 {"error":{"code":"unsupported_country_region_territory","message":"Country, region, or territory not supported","param":null,"type":"request_forbidden"}}';
+    const api = {
+      status: vi.fn(),
+      login: vi.fn().mockRejectedValue(new Error(rawMessage)),
+      cancelLogin: vi.fn(),
+      logout: vi.fn(),
+    };
+    const setLoading = vi.fn();
+    const pushToast = vi.fn();
+
+    await performLogin({
+      api,
+      setStatus: vi.fn(),
+      setLoading,
+      pushToast,
+      strings: LOGIN_STRINGS,
+    });
+
+    expect(pushToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'error',
+        title: 'login failed',
+        description: LOGIN_STRINGS.unsupportedCountryRegion,
+      }),
+    );
+    const toast = pushToast.mock.calls[0]?.[0] as { description?: string };
+    expect(toast.description).not.toContain('unsupported_country_region_territory');
   });
 
   it('silently resets loading when login is cancelled by the user', async () => {

--- a/apps/desktop/src/renderer/src/components/ChatgptLoginCard.tsx
+++ b/apps/desktop/src/renderer/src/components/ChatgptLoginCard.tsx
@@ -36,12 +36,25 @@ export interface PerformLoginDeps {
   setLoading: (v: boolean) => void;
   pushToast: PushToastLike;
   onStatusChange?: () => void | Promise<void>;
-  strings: { failedTitle: string; unknownError: string };
+  strings: { failedTitle: string; unknownError: string; unsupportedCountryRegion: string };
 }
 
 function isCodexLoginCancelledError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return /Codex login cancelled|Codex OAuth callback aborted/.test(err.message);
+}
+
+function isUnsupportedCountryRegionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.message.includes('unsupported_country_region_territory');
+}
+
+function formatLoginErrorDescription(
+  err: unknown,
+  strings: { unknownError: string; unsupportedCountryRegion: string },
+): string {
+  if (isUnsupportedCountryRegionError(err)) return strings.unsupportedCountryRegion;
+  return err instanceof Error ? err.message : strings.unknownError;
 }
 
 export async function performLogin(deps: PerformLoginDeps): Promise<void> {
@@ -55,7 +68,7 @@ export async function performLogin(deps: PerformLoginDeps): Promise<void> {
     deps.pushToast({
       variant: 'error',
       title: deps.strings.failedTitle,
-      description: err instanceof Error ? err.message : deps.strings.unknownError,
+      description: formatLoginErrorDescription(err, deps.strings),
     });
   } finally {
     deps.setLoading(false);
@@ -159,6 +172,7 @@ export function ChatgptLoginCard({ onStatusChange }: ChatgptLoginCardProps) {
       strings: {
         failedTitle: t('settings.providers.chatgptLogin.loginFailedTitle'),
         unknownError: t('settings.providers.chatgptLogin.unknownError'),
+        unsupportedCountryRegion: t('settings.providers.chatgptLogin.unsupportedCountryRegion'),
       },
       ...(onStatusChange !== undefined ? { onStatusChange } : {}),
     });

--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1347,7 +1347,7 @@ function ModelsTab() {
         });
         setCpaDetection('unavailable');
       });
-  }, [cpaDetection, loading, rows, pushToast, reportableErrorToast, t]);
+  }, [cpaDetection, loading, rows, reportableErrorToast, t]);
 
   async function reloadRows() {
     if (!window.codesign) return;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -209,7 +209,8 @@
         "loginFailedTitle": "ChatGPT sign-in failed",
         "logoutFailedTitle": "ChatGPT sign-out failed",
         "statusFailedTitle": "ChatGPT status check failed",
-        "unknownError": "Unknown error"
+        "unknownError": "Unknown error",
+        "unsupportedCountryRegion": "ChatGPT subscription login is not available for this account, country, region, or territory."
       },
       "addProvider": "Add provider",
       "addCustom": "Add custom",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -181,7 +181,8 @@
         "loginFailedTitle": "Falha ao entrar no ChatGPT",
         "logoutFailedTitle": "Falha ao sair do ChatGPT",
         "statusFailedTitle": "Falha ao verificar status do ChatGPT",
-        "unknownError": "Erro desconhecido"
+        "unknownError": "Erro desconhecido",
+        "unsupportedCountryRegion": "O login com assinatura do ChatGPT não está disponível para esta conta, país, região ou território."
       },
       "addProvider": "Adicionar provedor",
       "addCustom": "Adicionar personalizado",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -209,7 +209,8 @@
         "loginFailedTitle": "ChatGPT 登录失败",
         "logoutFailedTitle": "ChatGPT 登出失败",
         "statusFailedTitle": "ChatGPT 登录状态读取失败",
-        "unknownError": "未知错误"
+        "unknownError": "未知错误",
+        "unsupportedCountryRegion": "当前账号、国家、地区或区域暂不支持 ChatGPT 订阅登录。"
       },
       "addProvider": "添加服务",
       "addCustom": "添加自定义",

--- a/packages/providers/src/codex/oauth.test.ts
+++ b/packages/providers/src/codex/oauth.test.ts
@@ -179,6 +179,33 @@ describe('exchangeCode', () => {
     );
     await expect(exchangeCode('c', 'v', 'r')).rejects.toThrow(/400.*bad thing/);
   });
+
+  it('exposes structured OpenAI OAuth error details on exchange failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'unsupported_country_region_territory',
+                message: 'Country, region, or territory not supported',
+                param: null,
+                type: 'request_forbidden',
+              },
+            }),
+            { status: 403, headers: { 'content-type': 'application/json' } },
+          ),
+      ),
+    );
+
+    await expect(exchangeCode('c', 'v', 'r')).rejects.toMatchObject({
+      name: 'CodexOAuthTokenError',
+      status: 403,
+      oauthErrorCode: 'unsupported_country_region_territory',
+      upstreamMessage: 'Country, region, or territory not supported',
+    });
+  });
 });
 
 describe('refreshTokens', () => {

--- a/packages/providers/src/codex/oauth.ts
+++ b/packages/providers/src/codex/oauth.ts
@@ -52,6 +52,75 @@ interface TokenResponse {
   expires_in?: number;
 }
 
+interface ParsedOAuthError {
+  oauthErrorCode: string | undefined;
+  upstreamMessage: string | undefined;
+}
+
+export class CodexOAuthTokenError extends Error {
+  public readonly kind: 'exchange' | 'refresh';
+  public readonly status: number;
+  public readonly responseBody: string;
+  public readonly oauthErrorCode: string | undefined;
+  public readonly upstreamMessage: string | undefined;
+
+  constructor(input: {
+    kind: 'exchange' | 'refresh';
+    status: number;
+    responseBody: string;
+    oauthErrorCode: string | undefined;
+    upstreamMessage: string | undefined;
+  }) {
+    super(
+      `Codex OAuth ${input.kind} failed: ${input.status}${formatOAuthErrorDetail(
+        input.responseBody,
+        input.oauthErrorCode,
+        input.upstreamMessage,
+      )}`,
+    );
+    this.name = 'CodexOAuthTokenError';
+    this.kind = input.kind;
+    this.status = input.status;
+    this.responseBody = input.responseBody;
+    this.oauthErrorCode = input.oauthErrorCode;
+    this.upstreamMessage = input.upstreamMessage;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseOAuthErrorBody(text: string): ParsedOAuthError {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isRecord(parsed)) return { oauthErrorCode: undefined, upstreamMessage: undefined };
+    const error = parsed['error'];
+    if (!isRecord(error)) return { oauthErrorCode: undefined, upstreamMessage: undefined };
+    const code = error['code'];
+    const message = error['message'];
+    return {
+      oauthErrorCode: typeof code === 'string' && code.length > 0 ? code : undefined,
+      upstreamMessage: typeof message === 'string' && message.length > 0 ? message : undefined,
+    };
+  } catch {
+    return { oauthErrorCode: undefined, upstreamMessage: undefined };
+  }
+}
+
+function formatOAuthErrorDetail(
+  responseBody: string,
+  oauthErrorCode: string | undefined,
+  upstreamMessage: string | undefined,
+): string {
+  if (oauthErrorCode !== undefined && upstreamMessage !== undefined) {
+    return ` ${oauthErrorCode} - ${upstreamMessage}`;
+  }
+  if (oauthErrorCode !== undefined) return ` ${oauthErrorCode}`;
+  if (upstreamMessage !== undefined) return ` ${upstreamMessage}`;
+  return ` ${responseBody}`;
+}
+
 async function postToken(
   body: URLSearchParams,
   kind: 'exchange' | 'refresh',
@@ -63,7 +132,14 @@ async function postToken(
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Codex OAuth ${kind} failed: ${res.status} ${text}`);
+    const parsed = parseOAuthErrorBody(text);
+    throw new CodexOAuthTokenError({
+      kind,
+      status: res.status,
+      responseBody: text,
+      oauthErrorCode: parsed.oauthErrorCode,
+      upstreamMessage: parsed.upstreamMessage,
+    });
   }
   return (await res.json()) as TokenResponse;
 }


### PR DESCRIPTION
## Summary
- parse structured OpenAI OAuth token-exchange failures instead of surfacing raw JSON blobs
- show a localized unsupported-region message when ChatGPT subscription login is rejected upstream
- remove the stale `pushToast` effect dependency warning in `Settings.tsx`

## Root Cause
OpenAI can reject ChatGPT subscription OAuth token exchange with `403 unsupported_country_region_territory`. The app previously passed that raw upstream payload through the IPC layer and rendered it directly in the settings toast.

## Impact
Users now get a clear login error that explains the subscription login is unavailable for the account, country, region, or territory. The settings bundle is also lint-clean again.

Closes #205.

## Validation
- `corepack pnpm lint`
- `corepack pnpm -r --if-present typecheck`
- `corepack pnpm -r --if-present test`

## Principles ��5b
- [x] Compatibility
- [x] Upgradeability
- [x] No bloat
- [x] Elegance
