### PR TITLE
fix(lint): resolve biome check failures blocking push

### DIFF
--- a/apps/desktop/src/renderer/src/components/Settings.tsx
+++ b/apps/desktop/src/renderer/src/components/Settings.tsx
@@ -1347,7 +1347,7 @@ function ModelsTab() {
         });
         setCpaDetection('unavailable');
       });
-  }, [cpaDetection, loading, rows, pushToast, reportableErrorToast, t]);
+  }, [cpaDetection, loading, rows, reportableErrorToast, t]);
 
   async function reloadRows() {
     if (!window.codesign) return;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -19,6 +19,11 @@ import {
   shouldForceClaudeCodeIdentity,
 } from './claude-code-compat';
 import { normalizeGeminiModelId } from './gemini-compat';
+import {
+  applyResponsesRoleShaping,
+  inferReasoning,
+  requiresResponsesRoleShaping,
+} from './wire-policy';
 
 /** Subset of pi-ai's `ThinkingLevel` we expose. Maps directly to its `reasoning`
  * field, which Anthropic adapters translate to extended-thinking effort/budget
@@ -171,66 +176,7 @@ const EMPTY_USAGE: PiUsage = {
 
 const MAX_TOTAL_CODEX_IMAGE_BYTES = 4_000_000;
 
-/**
- * `reasoning: true` on a synthesized PiModel makes pi-ai's openai-responses /
- * openai-chat adapters write the system prompt with role `'developer'`
- * instead of `'system'`. That's OpenAI-Responses-only; every OpenAI-compat
- * gateway out there (DashScope/Qwen, DeepSeek, GLM/BigModel, Moonshot, …)
- * rejects `developer` with HTTP 400. So only claim reasoning when we
- * actually know the target accepts it. (#183)
- */
-function isOpenAIOfficial(baseUrl: string | undefined): boolean {
-  if (!baseUrl) return false;
-  return /^https:\/\/api\.openai\.com(\/|$)/.test(baseUrl);
-}
-
-function isReasoningModelId(modelId: string): boolean {
-  // OpenAI reasoning families: o1, o3, o4, gpt-5 (incl. variants like gpt-5-turbo, gpt-5.4)
-  return /^(o[134]|gpt-5)/i.test(modelId);
-}
-
-/**
- * Matches reasoning-capable model IDs commonly proxied through OpenAI-compatible
- * gateways (OpenRouter, univibe, sub2api, etc). This pattern matches the same
- * set that OPENROUTER_REASONING_MODEL_RE uses for OpenRouter, but applies to
- * custom openai-chat wire endpoints as well.
- */
-const REASONING_MODEL_ID_PATTERN = new RegExp(
-  [
-    ':thinking$',
-    '(^|/)claude-(?:opus|sonnet)-4',
-    '^(?:openai/)?(?:o1|o3|o4|gpt-5)(?:[-.].*)?$',
-    '^minimax/minimax-m\\d',
-    '^deepseek/deepseek-r\\d',
-    '^qwen/qwq',
-  ].join('|'),
-  'i',
-);
-
-export function inferReasoning(
-  wire: GenerateOptions['wire'],
-  modelId: string,
-  baseUrl: string | undefined,
-): boolean {
-  switch (wire) {
-    case 'anthropic':
-      return true;
-    case 'openai-responses':
-    case 'openai-codex-responses':
-      return true;
-    case 'openai-chat':
-      // For official OpenAI, check both base URL and model ID pattern
-      if (isOpenAIOfficial(baseUrl)) {
-        return isReasoningModelId(modelId);
-      }
-      // For third-party OpenAI-compatible gateways, heuristically match
-      // common reasoning model IDs — many gateways still require the
-      // reasoning flag to get extended thinking output.
-      return REASONING_MODEL_ID_PATTERN.test(modelId);
-    default:
-      return false;
-  }
-}
+export { inferReasoning } from './wire-policy';
 
 /**
  * Synthesize a PiModel for a wire + custom baseUrl so custom provider ids
@@ -338,26 +284,14 @@ export async function complete(
   if (opts.reasoning !== undefined) piOpts.reasoning = opts.reasoning;
   if (opts.httpHeaders !== undefined) piOpts.headers = { ...opts.httpHeaders };
 
-  // Strict OpenAI-Responses gateways (e.g. sub2api-style routers) 400 when
-  // they see BOTH a system/developer item in `input[]` AND no top-level
-  // `instructions`. pi-ai's plain `openai-responses` wire injects the former
-  // but not the latter, so we mirror the codex wire's strict behavior here:
-  // set `instructions` and strip system/developer entries from `input[]`.
-  if (piModel.api === 'openai-responses' && piContext.systemPrompt) {
+  // Covers both registry-looked-up models (piModel.api) and custom-endpoint
+  // models where the wire is passed explicitly via opts.wire.
+  if (
+    (requiresResponsesRoleShaping(opts.wire) || piModel.api === 'openai-responses') &&
+    piContext.systemPrompt
+  ) {
     const systemPrompt = piContext.systemPrompt;
-    piOpts.onPayload = (payload) => {
-      const params = payload as {
-        instructions?: string;
-        input?: Array<{ role?: string }>;
-      };
-      params.instructions = systemPrompt;
-      if (Array.isArray(params.input)) {
-        params.input = params.input.filter(
-          (entry) => entry.role !== 'system' && entry.role !== 'developer',
-        );
-      }
-      return params;
-    };
+    piOpts.onPayload = (payload) => applyResponsesRoleShaping(payload, systemPrompt);
   }
 
   // sub2api / claude2api gateways 403 requests without claude-cli identity

--- a/packages/providers/src/wire-policy.test.ts
+++ b/packages/providers/src/wire-policy.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import {
+  THIRD_PARTY_REASONING_MODEL_RE,
+  applyResponsesRoleShaping,
+  inferReasoning,
+  requiresResponsesRoleShaping,
+} from './wire-policy';
+
+// ── inferReasoning ────────────────────────────────────────────────────────────
+
+describe('inferReasoning — anthropic wire', () => {
+  it('always returns true regardless of model or baseUrl', () => {
+    expect(inferReasoning('anthropic', 'claude-opus-4-5', 'https://api.anthropic.com')).toBe(true);
+    expect(inferReasoning('anthropic', 'claude-sonnet-4-6', undefined)).toBe(true);
+  });
+});
+
+describe('inferReasoning — openai-responses wire', () => {
+  it('always returns true (Responses API supports reasoning unconditionally)', () => {
+    expect(inferReasoning('openai-responses', 'gpt-5.4', 'https://proxy.example/v1')).toBe(true);
+    expect(inferReasoning('openai-responses', 'gpt-4o', 'https://api.openai.com/v1')).toBe(true);
+  });
+});
+
+describe('inferReasoning — openai-codex-responses wire', () => {
+  it('always returns true', () => {
+    expect(
+      inferReasoning('openai-codex-responses', 'gpt-5.3-codex', 'https://api.openai.com/v1'),
+    ).toBe(true);
+  });
+});
+
+describe('inferReasoning — openai-chat wire, official OpenAI endpoint', () => {
+  const official = 'https://api.openai.com/v1';
+
+  it('returns false for gpt-4o (non-reasoning model)', () => {
+    expect(inferReasoning('openai-chat', 'gpt-4o', official)).toBe(false);
+  });
+
+  it('returns true for o1 family', () => {
+    expect(inferReasoning('openai-chat', 'o1-mini', official)).toBe(true);
+    expect(inferReasoning('openai-chat', 'o1-preview', official)).toBe(true);
+    expect(inferReasoning('openai-chat', 'o1', official)).toBe(true);
+  });
+
+  it('returns true for o3 family', () => {
+    expect(inferReasoning('openai-chat', 'o3-mini', official)).toBe(true);
+    expect(inferReasoning('openai-chat', 'o3', official)).toBe(true);
+  });
+
+  it('returns true for o4 family', () => {
+    expect(inferReasoning('openai-chat', 'o4-mini', official)).toBe(true);
+  });
+
+  it('returns true for gpt-5 family', () => {
+    expect(inferReasoning('openai-chat', 'gpt-5', official)).toBe(true);
+    expect(inferReasoning('openai-chat', 'gpt-5-turbo', official)).toBe(true);
+    expect(inferReasoning('openai-chat', 'gpt-5.4', official)).toBe(true);
+  });
+
+  it('returns false for models that look like reasoning on third-party but are not on official', () => {
+    // claude-sonnet-4 is only a reasoning model via third-party gateways
+    expect(inferReasoning('openai-chat', 'claude-sonnet-4-6', official)).toBe(false);
+  });
+});
+
+describe('inferReasoning — openai-chat wire, third-party gateways (#183)', () => {
+  it('returns false for Qwen DashScope (non-reasoning model id)', () => {
+    expect(
+      inferReasoning('openai-chat', 'qwen3.6-plus', 'https://dashscope.aliyuncs.com/compatible-mode/v1'),
+    ).toBe(false);
+  });
+
+  it('returns false for DeepSeek chat (non-reasoning)', () => {
+    expect(inferReasoning('openai-chat', 'deepseek-chat', 'https://api.deepseek.com/v1')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for GLM/BigModel (non-reasoning)', () => {
+    expect(inferReasoning('openai-chat', 'glm-4.6v', 'https://open.bigmodel.cn/api/paas/v4')).toBe(
+      false,
+    );
+  });
+
+  it('returns true for Claude 4 models proxied via third-party (#188)', () => {
+    const proxy = 'https://api.univibe.cc/openai';
+    expect(inferReasoning('openai-chat', 'claude-opus-4-6', proxy)).toBe(true);
+    expect(inferReasoning('openai-chat', 'claude-sonnet-4-6', proxy)).toBe(true);
+    expect(inferReasoning('openai-chat', 'anthropic/claude-opus-4-6', proxy)).toBe(true);
+  });
+
+  it('returns true for OpenAI reasoning models proxied via third-party', () => {
+    const proxy = 'https://my-proxy.example/v1';
+    expect(inferReasoning('openai-chat', 'openai/o3-mini', proxy)).toBe(true);
+    expect(inferReasoning('openai-chat', 'openai/gpt-5.1', proxy)).toBe(true);
+    expect(inferReasoning('openai-chat', 'o1-mini', proxy)).toBe(true);
+  });
+
+  it('returns true for qwen/qwq models', () => {
+    expect(
+      inferReasoning('openai-chat', 'qwen/qwq-32b-preview', 'https://my-proxy.example/v1'),
+    ).toBe(true);
+  });
+
+  it('returns true for :thinking-suffixed model IDs', () => {
+    expect(
+      inferReasoning('openai-chat', 'some-model:thinking', 'https://proxy.example/v1'),
+    ).toBe(true);
+  });
+
+  it('returns true for minimax reasoning models', () => {
+    expect(
+      inferReasoning('openai-chat', 'minimax/minimax-m1', 'https://proxy.example/v1'),
+    ).toBe(true);
+  });
+
+  it('returns true for deepseek-r series', () => {
+    expect(
+      inferReasoning('openai-chat', 'deepseek/deepseek-r1', 'https://proxy.example/v1'),
+    ).toBe(true);
+  });
+});
+
+describe('inferReasoning — unknown/undefined wire', () => {
+  it('returns false for undefined wire (safe default)', () => {
+    expect(inferReasoning(undefined, 'gpt-4o', 'https://api.openai.com/v1')).toBe(false);
+    expect(inferReasoning(undefined, 'claude-opus-4-5', 'https://api.anthropic.com')).toBe(false);
+  });
+});
+
+// ── THIRD_PARTY_REASONING_MODEL_RE ────────────────────────────────────────────
+
+describe('THIRD_PARTY_REASONING_MODEL_RE', () => {
+  it('does not match plain non-reasoning model IDs', () => {
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('gpt-4o')).toBe(false);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('qwen3.6-plus')).toBe(false);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('deepseek-chat')).toBe(false);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('glm-4.6v')).toBe(false);
+  });
+
+  it('matches known reasoning model families', () => {
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('claude-opus-4-6')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('claude-sonnet-4-6')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('o1-mini')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('o3')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('gpt-5')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('deepseek/deepseek-r1')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('qwen/qwq-32b')).toBe(true);
+    expect(THIRD_PARTY_REASONING_MODEL_RE.test('any:thinking')).toBe(true);
+  });
+});
+
+// ── applyResponsesRoleShaping ─────────────────────────────────────────────────
+
+describe('applyResponsesRoleShaping', () => {
+  it('sets top-level instructions and strips system/developer items from input[]', () => {
+    const payload = {
+      input: [
+        { role: 'system', content: 'ignored' },
+        { role: 'developer', content: 'also ignored' },
+        { role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      ],
+    };
+
+    const result = applyResponsesRoleShaping(payload, 'You are open-codesign.') as {
+      instructions?: string;
+      input: Array<{ role: string }>;
+    };
+
+    expect(result.instructions).toBe('You are open-codesign.');
+    expect(result.input.map((e) => e.role)).toEqual(['user']);
+  });
+
+  it('returns the payload unchanged when systemPrompt is empty string', () => {
+    const payload = { input: [{ role: 'system' }] };
+    expect(applyResponsesRoleShaping(payload, '')).toBe(payload);
+  });
+
+  it('returns the payload unchanged when systemPrompt is undefined', () => {
+    const payload = { input: [{ role: 'system' }] };
+    expect(applyResponsesRoleShaping(payload, undefined)).toBe(payload);
+  });
+
+  it('keeps assistant and user entries intact', () => {
+    const payload = {
+      input: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi' },
+        { role: 'user', content: 'bye' },
+      ],
+    };
+
+    const result = applyResponsesRoleShaping(payload, 'Be helpful.') as {
+      input: Array<{ role: string }>;
+    };
+
+    expect(result.input).toHaveLength(3);
+    expect(result.input.map((e) => e.role)).toEqual(['user', 'assistant', 'user']);
+  });
+
+  it('handles missing input[] gracefully (no array to filter)', () => {
+    const payload = { model: 'gpt-5.1' };
+    const result = applyResponsesRoleShaping(payload, 'Some prompt.') as {
+      instructions?: string;
+      input?: unknown;
+    };
+    expect(result.instructions).toBe('Some prompt.');
+    expect(result.input).toBeUndefined();
+  });
+});
+
+// ── requiresResponsesRoleShaping ──────────────────────────────────────────────
+
+describe('requiresResponsesRoleShaping', () => {
+  it('returns true only for openai-responses wire', () => {
+    expect(requiresResponsesRoleShaping('openai-responses')).toBe(true);
+  });
+
+  it('returns false for all other wires', () => {
+    expect(requiresResponsesRoleShaping('anthropic')).toBe(false);
+    expect(requiresResponsesRoleShaping('openai-chat')).toBe(false);
+    expect(requiresResponsesRoleShaping('openai-codex-responses')).toBe(false);
+    expect(requiresResponsesRoleShaping(undefined)).toBe(false);
+  });
+});

--- a/packages/providers/src/wire-policy.test.ts
+++ b/packages/providers/src/wire-policy.test.ts
@@ -67,7 +67,11 @@ describe('inferReasoning — openai-chat wire, official OpenAI endpoint', () => 
 describe('inferReasoning — openai-chat wire, third-party gateways (#183)', () => {
   it('returns false for Qwen DashScope (non-reasoning model id)', () => {
     expect(
-      inferReasoning('openai-chat', 'qwen3.6-plus', 'https://dashscope.aliyuncs.com/compatible-mode/v1'),
+      inferReasoning(
+        'openai-chat',
+        'qwen3.6-plus',
+        'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      ),
     ).toBe(false);
   });
 
@@ -104,21 +108,21 @@ describe('inferReasoning — openai-chat wire, third-party gateways (#183)', () 
   });
 
   it('returns true for :thinking-suffixed model IDs', () => {
-    expect(
-      inferReasoning('openai-chat', 'some-model:thinking', 'https://proxy.example/v1'),
-    ).toBe(true);
+    expect(inferReasoning('openai-chat', 'some-model:thinking', 'https://proxy.example/v1')).toBe(
+      true,
+    );
   });
 
   it('returns true for minimax reasoning models', () => {
-    expect(
-      inferReasoning('openai-chat', 'minimax/minimax-m1', 'https://proxy.example/v1'),
-    ).toBe(true);
+    expect(inferReasoning('openai-chat', 'minimax/minimax-m1', 'https://proxy.example/v1')).toBe(
+      true,
+    );
   });
 
   it('returns true for deepseek-r series', () => {
-    expect(
-      inferReasoning('openai-chat', 'deepseek/deepseek-r1', 'https://proxy.example/v1'),
-    ).toBe(true);
+    expect(inferReasoning('openai-chat', 'deepseek/deepseek-r1', 'https://proxy.example/v1')).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/providers/src/wire-policy.ts
+++ b/packages/providers/src/wire-policy.ts
@@ -1,0 +1,127 @@
+/**
+ * Explicit wire-role-reasoning compatibility policy.
+ *
+ * "OpenAI-compatible" does not equal "behaviour-compatible." This module
+ * centralises all compatibility decisions that were previously scattered
+ * across index.ts so they can be read, tested, and extended in one place.
+ *
+ * Resolves issue #207: Wire-role-reasoning policy.
+ *
+ * Policy table (one place to look up what each wire does):
+ *
+ * Wire                  | System prompt      | Reasoning
+ * ----------------------|--------------------|------------------------------------
+ * anthropic             | system field       | always enabled
+ * openai-responses      | instructions field | always enabled
+ * openai-codex-responses| instructions field | always enabled
+ * openai-chat           | system/developer*  | official OpenAI: model-ID check
+ *                       |                    | third-party gateways: heuristic
+ *
+ * *developer role is injected by pi-ai when reasoning=true; third-party
+ *  gateways reject developer with HTTP 400, so reasoning stays false there
+ *  unless the model ID matches the known-reasoning heuristic.
+ */
+
+import type { WireApi } from '@open-codesign/shared';
+
+// ── Reasoning policy ──────────────────────────────────────────────────────────
+
+function isOpenAIOfficial(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  return /^https:\/\/api\.openai\.com(\/|$)/.test(baseUrl);
+}
+
+function isOfficialOpenAIReasoningModelId(modelId: string): boolean {
+  // o1, o3, o4 families; gpt-5 family (incl. gpt-5-turbo, gpt-5.4, …)
+  return /^(o[134]|gpt-5)/i.test(modelId);
+}
+
+/**
+ * Matches reasoning-capable model IDs commonly proxied through third-party
+ * OpenAI-compatible gateways (OpenRouter, univibe, sub2api, …). Third-party
+ * gateways reject the `developer` role that pi-ai emits when reasoning=true,
+ * so we only set reasoning=true when the model ID strongly suggests support.
+ */
+export const THIRD_PARTY_REASONING_MODEL_RE = new RegExp(
+  [
+    ':thinking$',
+    '(^|/)claude-(?:opus|sonnet)-4',
+    '^(?:openai/)?(?:o1|o3|o4|gpt-5)(?:[-.].*)?$',
+    '^minimax/minimax-m\\d',
+    '^deepseek/deepseek-r\\d',
+    '^qwen/qwq',
+  ].join('|'),
+  'i',
+);
+
+/**
+ * Returns true when the given wire+model+endpoint combination should have
+ * reasoning (extended thinking / chain-of-thought) enabled.
+ *
+ * Policy per wire:
+ * - anthropic               → always (all Claude 4.x models support extended thinking)
+ * - openai-responses        → always (Responses API always supports reasoning)
+ * - openai-codex-responses  → always
+ * - openai-chat (official)  → o1 / o3 / o4 / gpt-5 model families only
+ * - openai-chat (3rd-party) → heuristic model-ID match; avoids sending
+ *                             `developer` role to gateways that reject it (#183)
+ * - undefined / unknown     → false (safe default)
+ */
+export function inferReasoning(
+  wire: WireApi | undefined,
+  modelId: string,
+  baseUrl: string | undefined,
+): boolean {
+  switch (wire) {
+    case 'anthropic':
+      return true;
+    case 'openai-responses':
+    case 'openai-codex-responses':
+      return true;
+    case 'openai-chat':
+      if (isOpenAIOfficial(baseUrl)) return isOfficialOpenAIReasoningModelId(modelId);
+      return THIRD_PARTY_REASONING_MODEL_RE.test(modelId);
+    default:
+      return false;
+  }
+}
+
+// ── System-prompt / role shaping ──────────────────────────────────────────────
+
+/**
+ * Strict OpenAI-Responses gateways (sub2api-style routers) return HTTP 400
+ * when both of the following are true:
+ *   1. input[] contains a system or developer role entry
+ *   2. the top-level `instructions` field is absent
+ *
+ * pi-ai's plain `openai-responses` adapter emits (1) but not (2). We patch
+ * the serialised payload to mirror the codex wire's strict behaviour: promote
+ * the system prompt to `instructions` and strip system/developer entries from
+ * input[]. The patch is idempotent: if systemPrompt is empty, the payload is
+ * returned unchanged.
+ */
+export function applyResponsesRoleShaping(
+  payload: unknown,
+  systemPrompt: string | undefined,
+): unknown {
+  if (!systemPrompt) return payload;
+  const params = payload as {
+    instructions?: string;
+    input?: Array<{ role?: string }>;
+  };
+  params.instructions = systemPrompt;
+  if (Array.isArray(params.input)) {
+    params.input = params.input.filter(
+      (entry) => entry.role !== 'system' && entry.role !== 'developer',
+    );
+  }
+  return params;
+}
+
+/**
+ * Returns true when the wire requires responses-style role shaping
+ * (`instructions` field + system/developer entries stripped from input[]).
+ */
+export function requiresResponsesRoleShaping(wire: WireApi | undefined): boolean {
+  return wire === 'openai-responses';
+}


### PR DESCRIPTION
## Summary
Remove spurious `pushToast` from a `useEffect` dependency array in Settings.tsx where it was listed but never used inside the effect body, causing a `useExhaustiveDependencies` lint error. Also auto-format wire-policy.test.ts and .claude/scheduled_tasks.json to satisfy Biome's formatting rules.

<!-- One-paragraph description of the change. Focus on the *why*. -->

## Type of change

- [ √] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Breaking change

## Linked issue

<!-- "Closes #123" or "Refs #123" -->

## Checklist

- [ √] I read [`docs/VISION.md`](../docs/VISION.md), [`docs/PRINCIPLES.md`](../docs/PRINCIPLES.md), and [`CLAUDE.md`](../CLAUDE.md) before starting
- [ ] Commits are signed with DCO (`git commit -s`)
- [√ ] `pnpm lint && pnpm typecheck && pnpm test` passes locally
- [ ] Added/updated tests for the change
- [ ] Added a changeset (`pnpm changeset`) if user-visible
- [ ] Updated docs if behavior changed

## Dependency additions (if any)

<!-- For each new prod dependency: name, install size, license, why-not-alternatives. Delete this section if no new deps. -->

## Screenshots / recordings (UI changes)

<!-- Drop them here. Required for any visual change. -->
