### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -11,6 +11,8 @@ const FORMAT_FILTERS: Record<ExporterFormat, Electron.FileFilter[]> = {
   markdown: [{ name: 'Markdown', extensions: ['md'] }],
 };
 
+const MAX_HTML_CONTENT_BYTES = 10 * 1024 * 1024;
+
 export interface ExportRequest {
   format: ExporterFormat;
   htmlContent: string;
@@ -45,6 +47,9 @@ export function parseRequest(raw: unknown): ExportRequest {
   }
   if (typeof html !== 'string' || html.length === 0) {
     throw new CodesignError('export requires non-empty htmlContent', ERROR_CODES.IPC_BAD_INPUT);
+  }
+  if (Buffer.byteLength(html, 'utf8') > MAX_HTML_CONTENT_BYTES) {
+    throw new CodesignError('export htmlContent exceeds size limit', ERROR_CODES.IPC_BAD_INPUT);
   }
   const out: ExportRequest = { format, htmlContent: html };
   if (typeof defaultFilename === 'string' && defaultFilename.length > 0) {

--- a/apps/desktop/src/main/imports/safe-read.ts
+++ b/apps/desktop/src/main/imports/safe-read.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises';
+import { open, stat } from 'node:fs/promises';
 import { getLogger } from '../logger';
 
 /**
@@ -11,9 +11,10 @@ import { getLogger } from '../logger';
  *   - plant a 10-GB file at the same path and exhaust the heap;
  *   - point the path at a socket / FIFO / directory to hang `readFile`.
  *
- * `safeReadImportFile` stats first, rejects anything that isn't a regular
- * file or that exceeds `MAX_IMPORT_FILE_BYTES`, and falls through to
- * `readFile` only when the stat says it's safe. Returns `null` on
+ * `safeReadImportFile` opens the path once, stats via that handle,
+ * rejects anything that isn't a regular file or that exceeds
+ * `MAX_IMPORT_FILE_BYTES`, and reads only when the stat says it's safe.
+ * Returns `null` on
  * missing/too-big/not-a-file so callers keep their existing "no config
  * found" branches; logs the reason so diagnostics bundles capture a
  * rejection trail.
@@ -26,28 +27,44 @@ const log = getLogger('import-read');
 export const MAX_IMPORT_FILE_BYTES = 256 * 1024;
 
 export async function safeReadImportFile(path: string): Promise<string | null> {
-  let stats: Awaited<ReturnType<typeof stat>>;
+  let fileHandle: Awaited<ReturnType<typeof open>>;
   try {
-    stats = await stat(path);
+    fileHandle = await open(path, 'r');
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') return null;
-    log.warn('safe_read.stat_failed', { path, code: code ?? 'unknown' });
+    log.warn('safe_read.open_failed', { path, code: code ?? 'unknown' });
     return null;
   }
-  if (!stats.isFile()) {
-    // Symlink to /dev/zero, symlink to a directory, named pipe, etc.
-    // `isFile()` follows symlinks, so a symlink to a regular file is fine.
-    log.warn('safe_read.not_regular_file', { path });
-    return null;
+
+  try {
+    let stats: Awaited<ReturnType<typeof stat>>;
+    try {
+      stats = await fileHandle.stat();
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return null;
+      log.warn('safe_read.stat_failed', { path, code: code ?? 'unknown' });
+      return null;
+    }
+
+    if (!stats.isFile()) {
+      // Symlink to /dev/zero, symlink to a directory, named pipe, etc.
+      // `isFile()` follows symlinks, so a symlink to a regular file is fine.
+      log.warn('safe_read.not_regular_file', { path });
+      return null;
+    }
+    if (stats.size > MAX_IMPORT_FILE_BYTES) {
+      log.warn('safe_read.size_exceeded', {
+        path,
+        size: stats.size,
+        cap: MAX_IMPORT_FILE_BYTES,
+      });
+      return null;
+    }
+
+    return fileHandle.readFile('utf8');
+  } finally {
+    await fileHandle.close();
   }
-  if (stats.size > MAX_IMPORT_FILE_BYTES) {
-    log.warn('safe_read.size_exceeded', {
-      path,
-      size: stats.size,
-      cap: MAX_IMPORT_FILE_BYTES,
-    });
-    return null;
-  }
-  return readFile(path, 'utf8');
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `apps/desktop/src/main/imports/safe-read.ts:L34`

`safeReadImportFile` performs `stat(path)` to validate file type and size, then separately calls `readFile(path)`. An attacker with local write access to the same filesystem location can race-replace the file between these calls (e.g., swap a small regular file for a FIFO/device/very large file), bypassing the earlier validation and potentially causing hangs or memory pressure in the main process.

## Solution

Open the file once and validate/read via the same file descriptor to avoid path re-resolution races. For example: `const fh = await open(path, O_RDONLY | O_NOFOLLOW)` (where supported), then `const st = await fh.stat()`, enforce `st.isFile()` and size cap, then `await fh.readFile('utf8')`, finally close handle in `finally`.

## Changes

- `apps/desktop/src/main/imports/safe-read.ts` (modified)
- `apps/desktop/src/main/exporter-ipc.ts` (modified)