### PR TITLE
fix(core): retry transport-level terminated errors with conversation replay

### DIFF
--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -967,6 +967,76 @@ describe('generateViaAgent() — transport-level retry', () => {
     const retryAgentMessages = agentCalls[1]?.options.initialState?.messages;
     expect(retryAgentMessages?.length).toBe(2);
   });
+
+  it('strips tool-call and toolResult messages from the failed turn', async () => {
+    // Simulate a failed turn that includes tool activity:
+    // [user, assistant(success), user, assistant(tool-call), toolResult, assistant(error)]
+    // After strip, only [user, assistant(success)] should remain.
+    const { stripFailedTurn } = await import('./agent.js');
+    const messages = [
+      { role: 'user', content: 'first request', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'first reply' }],
+        api: 'openai-completions',
+        provider: 'openrouter',
+        model: 'test',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'stop',
+        timestamp: 2,
+      },
+      { role: 'user', content: 'design a dashboard', timestamp: 3 },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'text_editor', input: {} }],
+        api: 'openai-completions',
+        provider: 'openrouter',
+        model: 'test',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'toolUse',
+        timestamp: 4,
+      },
+      { role: 'toolResult', toolUseId: 'call_1', content: 'ok', timestamp: 5 },
+      {
+        role: 'assistant',
+        content: [],
+        api: 'openai-completions',
+        provider: 'openrouter',
+        model: 'test',
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'error',
+        errorMessage: 'fetch failed: terminated',
+        timestamp: 6,
+      },
+    ] as unknown as Parameters<typeof stripFailedTurn>[0];
+    const result = stripFailedTurn(messages);
+    // Should keep only the first 2 messages (user + successful assistant)
+    expect(result.length).toBe(2);
+    expect(result[0]?.role).toBe('user');
+    expect(result[1]?.role).toBe('assistant');
+    expect((result[1] as Record<string, unknown>).stopReason).toBe('stop');
+  });
 });
 
 describe('loadFrameTemplates — device frame starter assets', () => {

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -58,6 +58,14 @@ interface AgentScript {
    * behavior that flattens getApiKey throws into `errorMessage: string`).
    */
   invokeGetApiKey?: boolean;
+  /**
+   * When set, the mock switches to `overrideScript` starting from this
+   * agent-call index (0-based). Lets transport-retry tests script
+   * "first agent fails, second agent succeeds" without mutating
+   * `scriptedAgent` mid-test.
+   */
+  overrideScriptForCallIndex?: number;
+  overrideScript?: Partial<AgentScript>;
 }
 
 let scriptedAgent: AgentScript = { assistantText: '' };
@@ -78,10 +86,17 @@ vi.mock('@mariozechner/pi-agent-core', () => {
     }
     async prompt(message: unknown): Promise<void> {
       this.call.prompts.push({ message });
-      if (scriptedAgent.promptThrows) {
-        const limit = scriptedAgent.promptThrowsTimes ?? Number.POSITIVE_INFINITY;
+      const callIndex = agentCalls.indexOf(this.call);
+      const script =
+        scriptedAgent.overrideScriptForCallIndex !== undefined &&
+        callIndex >= scriptedAgent.overrideScriptForCallIndex &&
+        scriptedAgent.overrideScript
+          ? { ...scriptedAgent, ...scriptedAgent.overrideScript }
+          : scriptedAgent;
+      if (script.promptThrows) {
+        const limit = script.promptThrowsTimes ?? Number.POSITIVE_INFINITY;
         if (this.call.prompts.length <= limit) {
-          if (scriptedAgent.promptPushesAssistantBeforeThrow) {
+          if (script.promptPushesAssistantBeforeThrow) {
             const partial: AgentMessage = {
               role: 'assistant',
               // biome-ignore lint/suspicious/noExplicitAny: same.
@@ -103,7 +118,7 @@ vi.mock('@mariozechner/pi-agent-core', () => {
             };
             this.state.messages.push(partial);
           }
-          throw scriptedAgent.promptThrows;
+          throw script.promptThrows;
         }
       }
 
@@ -112,7 +127,7 @@ vi.mock('@mariozechner/pi-agent-core', () => {
       // agent-loop.js); if that rejects, `runWithLifecycle` catches it and
       // emits a failure AgentMessage with just `errorMessage: string` —
       // which is why our code captures the original throw in a closure.
-      if (scriptedAgent.invokeGetApiKey && this.call.options.getApiKey) {
+      if (script.invokeGetApiKey && this.call.options.getApiKey) {
         try {
           await this.call.options.getApiKey('test-provider');
         } catch (err) {
@@ -160,8 +175,8 @@ vi.mock('@mariozechner/pi-agent-core', () => {
         // biome-ignore lint/suspicious/noExplicitAny: same.
         provider: 'anthropic' as any,
         model: 'mock-model',
-        content: [{ type: 'text', text: scriptedAgent.assistantText }],
-        usage: scriptedAgent.usage ?? {
+        content: [{ type: 'text', text: script.assistantText }],
+        usage: script.usage ?? {
           input: 0,
           output: 0,
           cacheRead: 0,
@@ -169,18 +184,18 @@ vi.mock('@mariozechner/pi-agent-core', () => {
           totalTokens: 0,
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         },
-        stopReason: scriptedAgent.stopReason ?? 'stop',
-        ...(scriptedAgent.errorMessage ? { errorMessage: scriptedAgent.errorMessage } : {}),
+        stopReason: script.stopReason ?? 'stop',
+        ...(script.errorMessage ? { errorMessage: script.errorMessage } : {}),
         timestamp: Date.now(),
       };
       this.state.messages.push(assistantMsg);
 
-      for (const e of scriptedAgent.events ?? []) this.emit(e);
+      for (const e of script.events ?? []) this.emit(e);
       this.emit({
         type: 'message_update',
         message: assistantMsg,
         // biome-ignore lint/suspicious/noExplicitAny: AssistantMessageEvent shape not re-exported.
-        assistantMessageEvent: { type: 'text_delta', delta: scriptedAgent.assistantText } as any,
+        assistantMessageEvent: { type: 'text_delta', delta: script.assistantText } as any,
       });
       this.emit({ type: 'message_end', message: assistantMsg });
       this.emit({ type: 'turn_end', message: assistantMsg, toolResults: [] });
@@ -829,6 +844,128 @@ describe('generateViaAgent() — first-turn retry', () => {
     // Single attempt: replaying a partial multi-turn session would corrupt
     // tool state, so the second+ turn must surface transient errors directly.
     expect(agentCalls[0]?.prompts.length).toBe(1);
+  });
+});
+
+describe('generateViaAgent() — transport-level retry', () => {
+  it('retries a terminated error by creating a fresh agent with conversation replay', async () => {
+    scriptedAgent = {
+      assistantText: RESPONSE_WITH_ARTIFACT,
+      stopReason: 'error',
+      errorMessage: 'fetch failed: terminated',
+      overrideScriptForCallIndex: 1,
+      overrideScript: {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        stopReason: 'stop',
+      },
+    };
+    const onRetry = vi.fn();
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [
+          { role: 'user', content: 'first request' },
+          { role: 'assistant', content: 'first reply' },
+        ],
+        model: MODEL,
+        apiKey: 'sk-test',
+      },
+      { onRetry, fs: makeStubFs({ 'index.html': SAMPLE_HTML }) },
+    );
+    expect(result.artifacts).toHaveLength(1);
+    expect(agentCalls.length).toBe(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/transport retry/);
+  });
+
+  it('does not retry non-transport errors like 400', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'error',
+      errorMessage: 'bad request',
+    };
+    await expect(
+      generateViaAgent({
+        prompt: 'design a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      }),
+    ).rejects.toBeTruthy();
+    expect(agentCalls.length).toBe(1);
+  });
+
+  it('exhausts transport retries and throws after MAX_TRANSPORT_RETRIES', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'error',
+      errorMessage: 'fetch failed: terminated',
+    };
+    const onRetry = vi.fn();
+    await expect(
+      generateViaAgent(
+        {
+          prompt: 'design a dashboard',
+          history: [],
+          model: MODEL,
+          apiKey: 'sk-test',
+        },
+        { onRetry },
+      ),
+    ).rejects.toBeTruthy();
+    // 1 original + 2 retries = 3 agent calls
+    expect(agentCalls.length).toBe(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips transport retry when signal is aborted', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'error',
+      errorMessage: 'fetch failed: terminated',
+    };
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await expect(
+      generateViaAgent({
+        prompt: 'design a dashboard',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+        signal: ctrl.signal,
+      }),
+    ).rejects.toBeTruthy();
+    expect(agentCalls.length).toBe(1);
+  });
+
+  it('strips the failed turn from message history on retry', async () => {
+    scriptedAgent = {
+      assistantText: RESPONSE_WITH_ARTIFACT,
+      stopReason: 'error',
+      errorMessage: 'premature close',
+      overrideScriptForCallIndex: 1,
+      overrideScript: {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        stopReason: 'stop',
+      },
+    };
+    await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [
+          { role: 'user', content: 'first request' },
+          { role: 'assistant', content: 'first reply' },
+        ],
+        model: MODEL,
+        apiKey: 'sk-test',
+      },
+      { fs: makeStubFs({ 'index.html': SAMPLE_HTML }) },
+    );
+    // Second agent should be seeded with only the successful history
+    // (original 2 messages), not the failed turn (which would be 4 messages:
+    // user, assistant, user, failed-assistant)
+    const retryAgentMessages = agentCalls[1]?.options.initialState?.messages;
+    expect(retryAgentMessages?.length).toBe(2);
   });
 });
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -505,20 +505,27 @@ const IMAGE_ASSET_TOOL_GUIDANCE = [
 const MAX_TRANSPORT_RETRIES = 2;
 
 /**
- * Remove the failed final turn (assistant + preceding user message) from the
- * agent message history so a fresh agent can retry the turn with a clean slate.
+ * Remove the failed final turn from the agent message history so a fresh agent
+ * can retry with a clean slate. Walks backwards from the terminal error
+ * assistant message to find the user message that started the turn, removing
+ * all intermediate tool-call / toolResult entries in between.
  */
-function stripFailedTurn(messages: readonly AgentMessage[]): AgentMessage[] {
+export function stripFailedTurn(messages: readonly AgentMessage[]): AgentMessage[] {
+  let errorIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (!msg) continue;
-    if (msg.role === 'assistant' && (msg as PiAssistantMessage).stopReason === 'error') {
-      const end = i;
-      const start = i > 0 && messages[i - 1]?.role === 'user' ? i - 1 : i;
-      return [...messages.slice(0, start), ...messages.slice(end + 1)];
+    if (errorIndex === -1) {
+      if (msg.role === 'assistant' && (msg as PiAssistantMessage).stopReason === 'error') {
+        errorIndex = i;
+      }
+      continue;
+    }
+    if (msg.role === 'user') {
+      return [...messages.slice(0, i), ...messages.slice(errorIndex + 1)];
     }
   }
-  return [...messages];
+  return errorIndex === -1 ? [...messages] : messages.slice(0, errorIndex);
 }
 
 // ---------------------------------------------------------------------------
@@ -897,8 +904,19 @@ export async function generateViaAgent(
       }
     }
 
-    await agent.prompt(userContent);
-    await agent.waitForIdle();
+    const retryStart = Date.now();
+    try {
+      await agent.prompt(userContent);
+      await agent.waitForIdle();
+    } catch (err) {
+      log.error('[generate] step=transport_retry.fail', {
+        ...ctx,
+        attempt: transportRetryCount,
+        ms: Date.now() - retryStart,
+        errorClass: err instanceof Error ? err.constructor.name : typeof err,
+      });
+      throw remapProviderError(err, input.model.provider, input.wire);
+    }
   }
 
   const finalAssistant = findFinalAssistantMessage(agent.state.messages);

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -37,6 +37,7 @@ import {
   classifyError,
   claudeCodeIdentityHeaders,
   inferReasoning,
+  isTransportLevelError,
   looksLikeClaudeOAuthToken,
   normalizeGeminiModelId,
   shouldForceClaudeCodeIdentity,
@@ -498,6 +499,27 @@ const IMAGE_ASSET_TOOL_GUIDANCE = [
 ].join('\n');
 
 // ---------------------------------------------------------------------------
+// Transport-level retry helpers.
+// ---------------------------------------------------------------------------
+
+const MAX_TRANSPORT_RETRIES = 2;
+
+/**
+ * Remove the failed final turn (assistant + preceding user message) from the
+ * agent message history so a fresh agent can retry the turn with a clean slate.
+ */
+function stripFailedTurn(messages: readonly AgentMessage[]): AgentMessage[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg) continue;
+    if (msg.role === 'assistant' && (msg as PiAssistantMessage).stopReason === 'error') {
+      const end = i;
+      const start = i > 0 && messages[i - 1]?.role === 'user' ? i - 1 : i;
+      return [...messages.slice(0, start), ...messages.slice(end + 1)];
+    }
+  }
+  return [...messages];
+}
 
 // ---------------------------------------------------------------------------
 // Public API.
@@ -720,58 +742,49 @@ export async function generateViaAgent(
   // original lets the post-agent branch rethrow it as-is, so the renderer
   // sees the same code the initial IPC-level resolution would emit.
   let capturedGetApiKeyError: unknown = null;
-  const agent = new Agent({
-    initialState: {
-      systemPrompt: augmentedSystemPrompt,
-      model: piModel as unknown as PiAiModel<'openai-completions'>,
-      messages: historyAsAgentMessages,
-      tools,
-      thinkingLevel,
-    },
-    convertToLlm: (messages) =>
-      messages.filter(
-        (m): m is PiAiMessage =>
-          m.role === 'user' || m.role === 'assistant' || m.role === 'toolResult',
-      ),
-    // Sliding-window compaction — stubs toolResult.content for rounds older
-    // than the last 8 (or 4 if total size still exceeds the safety cap).
-    // Without this, assistant.toolCall.input + big view results grow O(N²)
-    // in LLM-facing size across a long tool-using run and blow past 1 M
-    // tokens. See context-prune.ts for the full strategy.
-    transformContext: buildTransformContext(log, deps.onAggressivePrune),
-    // Async getter so OAuth tokens can be refreshed between agent turns. On a
-    // long tool-using run, `input.apiKey` captured at start-of-request would
-    // eventually expire; the caller passes `input.getApiKey` for codex so each
-    // LLM round-trip calls into the token store (which auto-refreshes inside
-    // its 5-min buffer). We stash any throw in `capturedGetApiKeyError` so
-    // the post-agent branch below can rethrow the original structured error
-    // — otherwise pi-agent-core's plain-string failure shape would cause us
-    // to downgrade to PROVIDER_ERROR, hiding the sign-in-again affordance.
-    getApiKey: input.getApiKey
-      ? async () => {
-          try {
-            const key = await input.getApiKey?.();
-            const trimmedKey = key?.trim() ?? '';
-            if (trimmedKey.length > 0) return trimmedKey;
-            if (input.allowKeyless === true) return initialApiKey || 'open-codesign-keyless';
-            throw new CodesignError(
-              `No API key returned for provider "${input.model.provider}".`,
-              ERROR_CODES.PROVIDER_AUTH_MISSING,
-            );
-          } catch (err) {
-            capturedGetApiKeyError = err;
-            throw err;
-          }
-        }
-      : () => initialApiKey || 'open-codesign-keyless',
-  });
 
-  if (deps.onEvent) {
-    const listener = deps.onEvent;
-    agent.subscribe((event) => {
-      listener(event);
+  // Factory for creating agents with a given message history. Used for both
+  // the initial agent and transport-level retry agents (conversation replay).
+  const createRetryAgent = (messages: AgentMessage[]): Agent => {
+    const retryAgent = new Agent({
+      initialState: {
+        systemPrompt: augmentedSystemPrompt,
+        model: piModel as unknown as PiAiModel<'openai-completions'>,
+        messages,
+        tools,
+        thinkingLevel,
+      },
+      convertToLlm: (msgs) =>
+        msgs.filter(
+          (m): m is PiAiMessage =>
+            m.role === 'user' || m.role === 'assistant' || m.role === 'toolResult',
+        ),
+      transformContext: buildTransformContext(log, deps.onAggressivePrune),
+      getApiKey: input.getApiKey
+        ? async () => {
+            try {
+              const key = await input.getApiKey?.();
+              const trimmedKey = key?.trim() ?? '';
+              if (trimmedKey.length > 0) return trimmedKey;
+              if (input.allowKeyless === true) return initialApiKey || 'open-codesign-keyless';
+              throw new CodesignError(
+                `No API key returned for provider "${input.model.provider}".`,
+                ERROR_CODES.PROVIDER_AUTH_MISSING,
+              );
+            } catch (err) {
+              capturedGetApiKeyError = err;
+              throw err;
+            }
+          }
+        : () => initialApiKey || 'open-codesign-keyless',
     });
-  }
+    if (deps.onEvent) {
+      retryAgent.subscribe((event) => deps.onEvent?.(event));
+    }
+    return retryAgent;
+  };
+
+  let agent = createRetryAgent(historyAsAgentMessages);
 
   if (input.signal) {
     if (input.signal.aborted) {
@@ -843,6 +856,49 @@ export async function generateViaAgent(
       errorClass: err instanceof Error ? err.constructor.name : typeof err,
     });
     throw remapProviderError(err, input.model.provider, input.wire);
+  }
+
+  // Post-agent transport-level retry: if the agent loop exited with a
+  // transport-level error (terminated, premature close, ECONNRESET), create a
+  // fresh agent with the successful conversation history and retry the turn.
+  // This handles proxy servers that drop long-lived SSE connections after N
+  // minutes. Tool side effects (file writes) are idempotent, so replaying
+  // prior turns is safe.
+  let transportRetryCount = 0;
+  while (transportRetryCount < MAX_TRANSPORT_RETRIES) {
+    const checkMsg = findFinalAssistantMessage(agent.state.messages);
+    if (!checkMsg || checkMsg.stopReason === 'stop') break;
+    if (checkMsg.stopReason !== 'error') break;
+    if (!isTransportLevelError(checkMsg.errorMessage)) break;
+    if (input.signal?.aborted) break;
+
+    transportRetryCount++;
+    log.warn('[generate] step=transport_retry', {
+      ...ctx,
+      attempt: transportRetryCount,
+      maxAttempts: MAX_TRANSPORT_RETRIES,
+      reason: checkMsg.errorMessage,
+    });
+    deps.onRetry?.({
+      attempt: transportRetryCount,
+      totalAttempts: MAX_TRANSPORT_RETRIES,
+      delayMs: 0,
+      reason: `transport retry: ${checkMsg.errorMessage}`,
+    });
+
+    const cleanMessages = stripFailedTurn(agent.state.messages);
+    capturedGetApiKeyError = null;
+    agent = createRetryAgent(cleanMessages);
+    if (input.signal) {
+      if (input.signal.aborted) {
+        agent.abort();
+      } else {
+        input.signal.addEventListener('abort', () => agent.abort(), { once: true });
+      }
+    }
+
+    await agent.prompt(userContent);
+    await agent.waitForIdle();
   }
 
   const finalAssistant = findFinalAssistantMessage(agent.state.messages);

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -531,7 +531,13 @@ export type {
   RetryDecision,
   RetryReason,
 } from './retry';
-export { classifyError, completeWithRetry, sleepWithAbort, withBackoff } from './retry';
+export {
+  classifyError,
+  completeWithRetry,
+  isTransportLevelError,
+  sleepWithAbort,
+  withBackoff,
+} from './retry';
 
 export { filterActive, formatSkillsForPrompt, injectSkillsIntoMessages } from './skill-injector';
 export type { ValidateResult } from './validate';

--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -70,6 +70,30 @@ describe('classifyError', () => {
   it('marks TypeError (fetch failure) as retryable', () => {
     expect(classifyError(new TypeError('fetch failed'))).toMatchObject({ retry: true });
   });
+  it('marks fetch failed: terminated as retryable', () => {
+    const d = classifyError(new Error('fetch failed: terminated'));
+    expect(d.retry).toBe(true);
+    expect(d.reason).toMatch(/transport-level error/);
+  });
+  it('marks premature close as retryable', () => {
+    const d = classifyError(new Error('premature close'));
+    expect(d.retry).toBe(true);
+    expect(d.reason).toMatch(/transport-level error/);
+  });
+  it('marks stream ended as retryable', () => {
+    const d = classifyError(new Error('stream ended'));
+    expect(d.retry).toBe(true);
+    expect(d.reason).toMatch(/transport-level error/);
+  });
+  it('marks ECONNRESET as retryable via network code', () => {
+    const err = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    const d = classifyError(err);
+    expect(d.retry).toBe(true);
+  });
+  it('does not retry regular errors without transport indicators', () => {
+    const d = classifyError(new Error('something went wrong'));
+    expect(d.retry).toBe(false);
+  });
 });
 
 describe('completeWithRetry', () => {

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -84,12 +84,23 @@ function classifyByStatus(status: number, err: unknown, wire?: WireApi): RetryDe
   return undefined;
 }
 
+const TRANSPORT_ERROR_RE =
+  /(?:fetch\s+failed.*terminated|premature\s+close|stream\s+(?:ended|closed)|ECONNRESET)\b/i;
+
+export function isTransportLevelError(errorMessage: string | undefined): boolean {
+  if (!errorMessage) return false;
+  return TRANSPORT_ERROR_RE.test(errorMessage);
+}
+
 function classifyByNetwork(err: unknown): RetryDecision | undefined {
   if (err instanceof TypeError) return { retry: true, reason: 'network error' };
   if (!(err instanceof Error)) return undefined;
   const code = (err as Error & { code?: unknown }).code;
   if (typeof code === 'string' && RETRYABLE_NET_CODES.has(code)) {
     return { retry: true, reason: `network error (${code})` };
+  }
+  if (isTransportLevelError(err.message)) {
+    return { retry: true, reason: 'transport-level error (stream terminated)' };
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- When a proxy server drops a long-lived SSE connection (`terminated`, `premature close`, `stream ended`), the agent loop exits with `stopReason: "error"` but `agent.prompt()` resolves normally — so the existing `withBackoff` retry never triggers
- Add a post-agent transport retry loop that detects these errors and retries by creating a fresh agent with the successful conversation history (failed turn stripped)
- Tool side effects are idempotent, so replaying prior turns is safe; max 2 retries before giving up

## Changes

- **`packages/providers/src/retry.ts`**: Add `isTransportLevelError()` helper + update `classifyByNetwork` to recognize transport errors as retryable
- **`packages/providers/src/index.ts`**: Export `isTransportLevelError`
- **`packages/core/src/agent.ts`**: Extract agent creation into `createRetryAgent`, add `stripFailedTurn()` helper, add post-agent transport retry loop with conversation replay
- **`packages/core/src/agent.test.ts`**: 4 new tests covering transport retry, non-transport error rejection, retry exhaustion, and abort handling
- **`packages/providers/src/retry.test.ts`**: 5 new tests for `classifyError` transport-level recognition

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — all new tests pass (2 pre-existing failures in unrelated packages)
- [ ] Manual: trigger a generation with a proxy that has a short SSE timeout → verify retry fires and generation completes

Closes #254 Bug #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)