### PR TITLE
fix(providers): match standalone 'terminated' in transport retry regex

### DIFF
--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -1238,6 +1238,32 @@ describe('generateViaAgent() — transport-level retry', () => {
     expect(onRetry.mock.calls[0]?.[0].reason).toMatch(/transport retry/);
   });
 
+  it('retries a standalone terminated error (without fetch failed prefix)', async () => {
+    scriptedAgent = {
+      assistantText: RESPONSE_WITH_ARTIFACT,
+      stopReason: 'error',
+      errorMessage: 'terminated',
+      overrideScriptForCallIndex: 1,
+      overrideScript: {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        stopReason: 'stop',
+      },
+    };
+    const onRetry = vi.fn();
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      },
+      { onRetry, fs: makeStubFs({ 'index.html': SAMPLE_HTML }) },
+    );
+    expect(result.artifacts).toHaveLength(1);
+    expect(agentCalls.length).toBe(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry non-transport errors like 400', async () => {
     scriptedAgent = {
       assistantText: '',

--- a/packages/providers/src/retry.test.ts
+++ b/packages/providers/src/retry.test.ts
@@ -75,6 +75,15 @@ describe('classifyError', () => {
     expect(d.retry).toBe(true);
     expect(d.reason).toMatch(/transport-level error/);
   });
+  it('marks standalone terminated as retryable', () => {
+    const d = classifyError(new Error('terminated'));
+    expect(d.retry).toBe(true);
+    expect(d.reason).toMatch(/transport-level error/);
+  });
+  it('does not treat unterminated as a terminated transport error', () => {
+    const d = classifyError(new Error('unterminated JSON response'));
+    expect(d.retry).toBe(false);
+  });
   it('marks premature close as retryable', () => {
     const d = classifyError(new Error('premature close'));
     expect(d.retry).toBe(true);

--- a/packages/providers/src/retry.ts
+++ b/packages/providers/src/retry.ts
@@ -85,7 +85,7 @@ function classifyByStatus(status: number, err: unknown, wire?: WireApi): RetryDe
 }
 
 const TRANSPORT_ERROR_RE =
-  /(?:fetch\s+failed.*terminated|premature\s+close|stream\s+(?:ended|closed)|ECONNRESET)\b/i;
+  /(?:fetch\s+failed.*\bterminated\b|\bterminated\b|premature\s+close|stream\s+(?:ended|closed)|ECONNRESET)\b/i;
 
 export function isTransportLevelError(errorMessage: string | undefined): boolean {
   if (!errorMessage) return false;


### PR DESCRIPTION
## Summary

- The transport-level retry regex in `isTransportLevelError` required `fetch failed` before `terminated`, but pi-agent-core only captures `error.message` (not `error.cause`), so the `errorMessage` can be just `"terminated"` without the prefix
- This caused the retry logic to be skipped, surfacing `CodesignError: terminated` directly to the user instead of retrying with conversation replay
- Added `terminated` as a standalone match in the regex, and added tests at both the provider and agent layers

## Test plan

- [x] `pnpm --filter @open-codesign/providers test` — all 37 tests pass (new: `marks standalone terminated as retryable`)
- [x] `pnpm --filter @open-codesign/core test -- -t "transport-level retry"` — all 7 tests pass (new: `retries a standalone terminated error`)
- [ ] Manual: trigger a generation with a proxy that drops SSE connections → should retry instead of showing "terminated" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)