### PR TITLE
fix: avoid calc utility parsing in model search

### DIFF
--- a/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
+++ b/apps/desktop/src/renderer/src/components/ModelSwitcher.tsx
@@ -200,8 +200,11 @@ export function ModelSwitcher({ variant }: ModelSwitcherProps) {
                 aria-label={t('topbar.modelSwitcher.searchAriaLabel', {
                   defaultValue: 'Filter models by name',
                 })}
-                className="w-full h-[var(--size-control-xs)] pl-[calc(var(--space-2)+var(--size-icon-xs)+var(--space-1_5))] pr-[calc(var(--space-2)+var(--size-icon-sm))] rounded-[var(--radius-sm)] bg-transparent border-0 text-[var(--text-xs)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
-                style={{ fontFamily: 'var(--font-mono)' }}
+                className="w-full h-[var(--size-control-xs)] pr-[calc(var(--space-2)+var(--size-icon-sm))] rounded-[var(--radius-sm)] bg-transparent border-0 text-[var(--text-xs)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  paddingLeft: 'calc(var(--space-2) + var(--size-icon-xs) + var(--space-1_5))',
+                }}
               />
               {query.length > 0 && (
                 <button


### PR DESCRIPTION
## Summary
- move the ModelSwitcher search input left padding calc from the Tailwind class string into inline style
- keep the same visual spacing while avoiding class parsing ambiguity in the utility scanner

## Test plan
- [ ] pnpm lint
- [ ] open the model picker and verify the search icon/input spacing is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)