### PR TITLE
feat: add MiniMax as a built-in onboarding provider (default M3)

### DIFF
--- a/.changeset/add-minimax-provider.md
+++ b/.changeset/add-minimax-provider.md
@@ -1,0 +1,9 @@
+---
+"@open-codesign/shared": minor
+"@open-codesign/providers": patch
+"@open-codesign/desktop": patch
+---
+
+Add MiniMax as a built-in onboarding provider.
+
+MiniMax is now available as a first-class provider option alongside Anthropic, OpenAI, OpenRouter, and Ollama. It uses the OpenAI-compatible wire (`openai-chat`) with a default base URL of `https://api.minimax.io/v1` and ships with a static model hint for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`. Credentials can be supplied via the `MINIMAX_API_KEY` environment variable or entered during onboarding.

--- a/.changeset/add-minimax-provider.md
+++ b/.changeset/add-minimax-provider.md
@@ -6,4 +6,4 @@
 
 Add MiniMax as a built-in onboarding provider.
 
-MiniMax is now available as a first-class provider option alongside Anthropic, OpenAI, OpenRouter, and Ollama. It uses the OpenAI-compatible wire (`openai-chat`) with a default base URL of `https://api.minimax.io/v1` and ships with a static model hint for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`. Credentials can be supplied via the `MINIMAX_API_KEY` environment variable or entered during onboarding.
+MiniMax is now available as a first-class provider option alongside Anthropic, OpenAI, OpenRouter, and Ollama. It uses the OpenAI-compatible wire (`openai-chat`) with a default base URL of `https://api.minimax.io/v1` and ships with a static model hint for `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`. Credentials can be supplied via the `MINIMAX_API_KEY` environment variable or entered during onboarding.

--- a/apps/desktop/src/main/imports/codex-config.ts
+++ b/apps/desktop/src/main/imports/codex-config.ts
@@ -48,6 +48,7 @@ export const ALLOWED_IMPORT_ENV_KEYS: ReadonlySet<string> = new Set([
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
   'GROQ_API_KEY',
+  'MINIMAX_API_KEY',
   'MISTRAL_API_KEY',
   'OPENAI_API_KEY',
   'OPENROUTER_API_KEY',

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -285,7 +285,7 @@ function parseValidateKey(raw: unknown): ValidateKeyInput {
   }
   if (!isSupportedOnboardingProvider(provider)) {
     throw new CodesignError(
-      `Provider "${provider}" is not supported in v0.1. Only anthropic, openai, openrouter.`,
+      `Provider "${provider}" is not supported in v0.1. Only anthropic, openai, openrouter, minimax.`,
       ERROR_CODES.PROVIDER_NOT_SUPPORTED,
     );
   }

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -285,7 +285,7 @@ function parseValidateKey(raw: unknown): ValidateKeyInput {
   }
   if (!isSupportedOnboardingProvider(provider)) {
     throw new CodesignError(
-      `Provider "${provider}" is not supported in v0.1. Only anthropic, openai, openrouter, minimax.`,
+      `Provider "${provider}" is not supported in v0.1. Only anthropic, openai, openrouter, ollama, minimax.`,
       ERROR_CODES.PROVIDER_NOT_SUPPORTED,
     );
   }

--- a/packages/providers/src/validate.test.ts
+++ b/packages/providers/src/validate.test.ts
@@ -205,4 +205,34 @@ describe('pingProvider', () => {
     });
     await pingProvider('anthropic', 'sk-ant-oat-xyz', 'https://sub2api.example.com');
   });
+
+  it('validates MiniMax with Bearer auth and returns model count', async () => {
+    mockFetch(async (url, init) => {
+      expect(url).toBe('https://api.minimax.io/v1/models');
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers['authorization']).toBe('Bearer mm-test-key');
+      return new Response(
+        JSON.stringify({ data: [{ id: 'MiniMax-M2.7' }, { id: 'MiniMax-M2.7-highspeed' }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    const result = await pingProvider('minimax', 'mm-test-key');
+    expect(result).toEqual({ ok: true, modelCount: 2 });
+  });
+
+  it('returns 401 code for MiniMax invalid key', async () => {
+    mockFetch(async () => new Response('unauthorized', { status: 401 }));
+    const result = await pingProvider('minimax', 'bad-key');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('401');
+  });
+
+  it('respects custom baseUrl for MiniMax', async () => {
+    mockFetch(async (url) => {
+      expect(url).toBe('https://api.minimaxi.com/v1/models');
+      return new Response(JSON.stringify({ data: [{ id: 'MiniMax-M2.7' }] }), { status: 200 });
+    });
+    const result = await pingProvider('minimax', 'mm-test-key', 'https://api.minimaxi.com/v1');
+    expect(result).toEqual({ ok: true, modelCount: 1 });
+  });
 });

--- a/packages/providers/src/validate.test.ts
+++ b/packages/providers/src/validate.test.ts
@@ -212,12 +212,18 @@ describe('pingProvider', () => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
       expect(headers['authorization']).toBe('Bearer mm-test-key');
       return new Response(
-        JSON.stringify({ data: [{ id: 'MiniMax-M2.7' }, { id: 'MiniMax-M2.7-highspeed' }] }),
+        JSON.stringify({
+          data: [
+            { id: 'MiniMax-M3' },
+            { id: 'MiniMax-M2.7' },
+            { id: 'MiniMax-M2.7-highspeed' },
+          ],
+        }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
     });
     const result = await pingProvider('minimax', 'mm-test-key');
-    expect(result).toEqual({ ok: true, modelCount: 2 });
+    expect(result).toEqual({ ok: true, modelCount: 3 });
   });
 
   it('returns 401 code for MiniMax invalid key', async () => {
@@ -230,7 +236,7 @@ describe('pingProvider', () => {
   it('respects custom baseUrl for MiniMax', async () => {
     mockFetch(async (url) => {
       expect(url).toBe('https://api.minimaxi.com/v1/models');
-      return new Response(JSON.stringify({ data: [{ id: 'MiniMax-M2.7' }] }), { status: 200 });
+      return new Response(JSON.stringify({ data: [{ id: 'MiniMax-M3' }] }), { status: 200 });
     });
     const result = await pingProvider('minimax', 'mm-test-key', 'https://api.minimaxi.com/v1');
     expect(result).toEqual({ ok: true, modelCount: 1 });

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -67,6 +67,13 @@ function endpoint(provider: SupportedOnboardingProvider, baseUrl?: string): Prov
         headers: () => ({}),
       };
     }
+    case 'minimax': {
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'https://api.minimax.io';
+      return {
+        url: `${root}/v1/models`,
+        headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+      };
+    }
   }
 }
 
@@ -97,7 +104,7 @@ export async function pingProvider(
 ): Promise<ValidateResult> {
   if (!isSupportedOnboardingProvider(provider)) {
     throw new CodesignError(
-      `Provider "${provider}" is not supported in v0.1. Supported: anthropic, openai, openrouter, ollama.`,
+      `Provider "${provider}" is not supported in v0.1. Supported: anthropic, openai, openrouter, ollama, minimax.`,
       ERROR_CODES.PROVIDER_NOT_SUPPORTED,
     );
   }

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -92,7 +92,7 @@ describe('config v3 schema', () => {
 });
 
 describe('migrateLegacyToV3', () => {
-  it('seeds three builtin providers from an empty v2', () => {
+  it('seeds all builtin providers from an empty v2', () => {
     const legacy = {
       version: 2 as const,
       provider: 'anthropic' as const,
@@ -344,6 +344,42 @@ describe('provider capability helpers', () => {
     expect(caps.supportsSystemRole).toBe(false);
     expect(caps.supportsDeveloperRole).toBe(true);
     expect(caps.supportsToolCalling).toBe(false);
+  });
+});
+
+describe('MiniMax builtin provider', () => {
+  it('is included in SUPPORTED_ONBOARDING_PROVIDERS', () => {
+    expect(SUPPORTED_ONBOARDING_PROVIDERS).toContain('minimax');
+  });
+
+  it('has correct wire and baseUrl', () => {
+    expect(BUILTIN_PROVIDERS.minimax.wire).toBe('openai-chat');
+    expect(BUILTIN_PROVIDERS.minimax.baseUrl).toBe('https://api.minimax.io/v1');
+  });
+
+  it('uses static-hint model discovery with M2.7 models', () => {
+    expect(BUILTIN_PROVIDERS.minimax.capabilities?.modelDiscoveryMode).toBe('static-hint');
+    expect(BUILTIN_PROVIDERS.minimax.modelsHint).toEqual([
+      'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
+    ]);
+    expect(BUILTIN_PROVIDERS.minimax.defaultModel).toBe('MiniMax-M2.7');
+  });
+
+  it('reads MINIMAX_API_KEY env var', () => {
+    expect(BUILTIN_PROVIDERS.minimax.envKey).toBe('MINIMAX_API_KEY');
+  });
+
+  it('resolves capabilities correctly via resolveProviderCapabilities', () => {
+    const caps = resolveProviderCapabilities('minimax', {
+      wire: 'openai-chat',
+      baseUrl: 'https://api.minimax.io/v1',
+    });
+    expect(caps.supportsChatCompletions).toBe(true);
+    expect(caps.supportsSystemRole).toBe(true);
+    expect(caps.supportsToolCalling).toBe(true);
+    expect(caps.requiresClaudeCodeIdentity).toBe(false);
+    expect(caps.supportsReasoning).toBe(false);
   });
 });
 

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -357,13 +357,14 @@ describe('MiniMax builtin provider', () => {
     expect(BUILTIN_PROVIDERS.minimax.baseUrl).toBe('https://api.minimax.io/v1');
   });
 
-  it('uses static-hint model discovery with M2.7 models', () => {
+  it('uses static-hint model discovery with M3 + M2.7 models', () => {
     expect(BUILTIN_PROVIDERS.minimax.capabilities?.modelDiscoveryMode).toBe('static-hint');
     expect(BUILTIN_PROVIDERS.minimax.modelsHint).toEqual([
+      'MiniMax-M3',
       'MiniMax-M2.7',
       'MiniMax-M2.7-highspeed',
     ]);
-    expect(BUILTIN_PROVIDERS.minimax.defaultModel).toBe('MiniMax-M2.7');
+    expect(BUILTIN_PROVIDERS.minimax.defaultModel).toBe('MiniMax-M3');
   });
 
   it('reads MINIMAX_API_KEY env var', () => {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_ONBOARDING_PROVIDERS = [
   'openai',
   'openrouter',
   'ollama',
+  'minimax',
 ] as const;
 export type SupportedOnboardingProvider = (typeof SUPPORTED_ONBOARDING_PROVIDERS)[number];
 
@@ -327,6 +328,28 @@ export const BUILTIN_PROVIDERS: Readonly<Record<SupportedOnboardingProvider, Pro
       modelDiscoveryMode: 'models',
     },
   },
+  minimax: {
+    id: 'minimax',
+    name: 'MiniMax',
+    builtin: true,
+    wire: 'openai-chat',
+    baseUrl: 'https://api.minimax.io/v1',
+    envKey: 'MINIMAX_API_KEY',
+    defaultModel: 'MiniMax-M2.7',
+    modelsHint: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+    capabilities: {
+      supportsKeyless: false,
+      supportsModelsEndpoint: false,
+      supportsChatCompletions: true,
+      supportsResponsesApi: false,
+      supportsSystemRole: true,
+      supportsDeveloperRole: false,
+      supportsReasoning: false,
+      supportsToolCalling: true,
+      requiresClaudeCodeIdentity: false,
+      modelDiscoveryMode: 'static-hint',
+    },
+  },
 } as const;
 
 // ── ConfigSchema v3 — canonical on-disk shape ────────────────────────────────
@@ -519,6 +542,13 @@ export const PROVIDER_SHORTLIST: Record<SupportedOnboardingProvider, ProviderSho
     keyHelpUrl: 'https://ollama.com/download',
     primary: [OLLAMA_DEFAULT_MODEL, 'llama3.1', 'qwen2.5'],
     defaultPrimary: OLLAMA_DEFAULT_MODEL,
+  },
+  minimax: {
+    provider: 'minimax',
+    label: 'MiniMax',
+    keyHelpUrl: 'https://platform.minimax.io/user-center/basic-information/interface-key',
+    primary: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+    defaultPrimary: 'MiniMax-M2.7',
   },
 };
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -335,8 +335,8 @@ export const BUILTIN_PROVIDERS: Readonly<Record<SupportedOnboardingProvider, Pro
     wire: 'openai-chat',
     baseUrl: 'https://api.minimax.io/v1',
     envKey: 'MINIMAX_API_KEY',
-    defaultModel: 'MiniMax-M2.7',
-    modelsHint: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+    defaultModel: 'MiniMax-M3',
+    modelsHint: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     capabilities: {
       supportsKeyless: false,
       supportsModelsEndpoint: false,
@@ -547,8 +547,8 @@ export const PROVIDER_SHORTLIST: Record<SupportedOnboardingProvider, ProviderSho
     provider: 'minimax',
     label: 'MiniMax',
     keyHelpUrl: 'https://platform.minimax.io/user-center/basic-information/interface-key',
-    primary: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
-    defaultPrimary: 'MiniMax-M2.7',
+    primary: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+    defaultPrimary: 'MiniMax-M3',
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `minimax` to `SUPPORTED_ONBOARDING_PROVIDERS` and `BUILTIN_PROVIDERS` with `wire: 'openai-chat'` and `baseUrl: 'https://api.minimax.io/v1'`
- Ship `MiniMax-M3` (default), `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed` as static model hints (no `/models` endpoint call needed)
- Support `MINIMAX_API_KEY` env var via the `envKey` field — works for Codex import and env-fallback resolution
- Add `MINIMAX_API_KEY` to `ALLOWED_IMPORT_ENV_KEYS` allowlist in codex-config
- Add `pingProvider` case for `minimax` in validate.ts (Bearer auth, `https://api.minimax.io/v1/models`)
- Add unit tests for MiniMax config properties and validation behavior
- Add changeset (`minor` bump for `@open-codesign/shared`)

## Why

MiniMax offers an OpenAI-compatible API (`https://api.minimax.io/v1`) with competitive models. Adding it as a built-in provider lets users select it directly from the onboarding screen without needing to configure a custom endpoint manually.

`MiniMax-M3` is the latest model and is shipped as the default; `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available as alternatives for users who prefer the previous generation.

## API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [ ] All tests in `packages/shared` pass (`pnpm --filter @open-codesign/shared test`)
- [ ] All tests in `packages/providers` pass (`pnpm --filter @open-codesign/providers test`)
- [ ] All tests in `apps/desktop` onboarding-ipc pass
- [ ] Typecheck passes for `packages/shared` and `packages/providers`
- [ ] Biome lint passes on changed files
- [ ] Changeset included for user-visible change