### PR TITLE
feat(workspace): read existing files in bound folders + visible Files panel

### DIFF
--- a/.changeset/workspace-files-agent-visible.md
+++ b/.changeset/workspace-files-agent-visible.md
@@ -1,0 +1,6 @@
+---
+"@open-codesign/desktop": patch
+"@open-codesign/ui": patch
+---
+
+Expose bound workspace files to the agent and preview before the first generation, including workspace asset loading through `workspace://`, with bounded async workspace seeding.

--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -133,19 +133,22 @@ describe('bindWorkspace', () => {
     expect(await stat(path.join(workspace, 'tracked.txt'))).toEqual(destinationBefore);
   });
 
-  it('throws when another active design already owns the workspace path', async () => {
+  it('allows another design to share an already-bound workspace path', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db);
     const otherDesign = createDesign(db);
-    const conflictPath = normalizeWorkspacePath(await makeTempDir('ocd-ws-conflict-'));
-    updateDesignWorkspace(db, otherDesign.id, conflictPath);
+    const sharedPath = normalizeWorkspacePath(await makeTempDir('ocd-ws-shared-'));
+    updateDesignWorkspace(db, otherDesign.id, sharedPath);
 
-    await expect(bindWorkspace(db, design.id, conflictPath, false)).rejects.toThrow(
-      'Workspace path is already bound to another design',
-    );
+    const bound = await bindWorkspace(db, design.id, sharedPath, false);
+
+    expect(bound.workspacePath).toBe(sharedPath);
     expect(db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(design.id)).toEqual({
-      workspace_path: null,
+      workspace_path: sharedPath,
     });
+    expect(
+      db.prepare('SELECT workspace_path FROM designs WHERE id = ?').get(otherDesign.id),
+    ).toEqual({ workspace_path: sharedPath });
   });
 
   it('treats case-only workspace differences as the same path on Windows for the same design', async () => {
@@ -164,16 +167,16 @@ describe('bindWorkspace', () => {
     });
   });
 
-  it('treats case-only workspace differences as conflicts on Windows across designs', async () => {
+  it('case-only differences on Windows still resolve to a shared bind across designs', async () => {
     await withMockedPlatform('win32', async () => {
       const db = initInMemoryDb();
       const design = createDesign(db);
       const otherDesign = createDesign(db);
-      updateDesignWorkspace(db, otherDesign.id, normalizeWorkspacePath('/Users/Roy/Workspace'));
+      const stored = normalizeWorkspacePath('/Users/Roy/Workspace');
+      updateDesignWorkspace(db, otherDesign.id, stored);
 
-      await expect(bindWorkspace(db, design.id, '/users/roy/workspace', false)).rejects.toThrow(
-        'Workspace path is already bound to another design',
-      );
+      const bound = await bindWorkspace(db, design.id, '/users/roy/workspace', false);
+      expect(bound.workspacePath).toBe(normalizeWorkspacePath('/users/roy/workspace'));
     });
   });
 

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -137,8 +137,14 @@ export async function bindWorkspace(
     logger.info('workspace.bind.noop', { designId, workspacePath: normalizedPath });
     return current;
   }
+  // Upstream rejected binding the same folder to two designs. Their own v0.2
+  // doc explicitly says multiple sessions can share a workspace, so the
+  // conflict guard is over-zealous: it forces the user to either duplicate
+  // the folder or shuffle bindings just to spin up a second design view of
+  // the same project. We log the overlap (so the issue is auditable) but
+  // let the bind proceed.
   if (checkWorkspaceConflict(db, designId, normalizedPath)) {
-    throw new Error('Workspace path is already bound to another design');
+    logger.info('workspace.bind.shared', { designId, workspacePath: normalizedPath });
   }
 
   logger.info('workspace.bind.start', {

--- a/apps/desktop/src/main/done-verify.ts
+++ b/apps/desktop/src/main/done-verify.ts
@@ -66,7 +66,7 @@ export function makeRuntimeVerifier(): DoneRuntimeVerifier {
     const onConsole = (...args: unknown[]) => {
       // Electron 35+ emits a single Event-like object; older majors emit
       // positional (event, level, message, line, sourceId). Detect by
-      // arity — a single object argument means the new shape.
+      // arity: a single object argument means the new shape.
       let level: ConsoleMessageEvent['level'];
       let message: string;
       let line: number | undefined;
@@ -99,7 +99,7 @@ export function makeRuntimeVerifier(): DoneRuntimeVerifier {
     };
 
     try {
-      // Cast through `any` for the event-name overloads — Electron's WebContents
+      // Cast through `any` for the event-name overloads: Electron's WebContents
       // event union doesn't include 'did-fail-load' / 'preload-error' in the
       // overload set this TS lib resolves, even though the events fire at runtime.
       const wc = win.webContents as unknown as {

--- a/apps/desktop/src/main/electron-runtime.ts
+++ b/apps/desktop/src/main/electron-runtime.ts
@@ -4,4 +4,5 @@ const require = createRequire(import.meta.url);
 
 export const electron = require('electron') as typeof import('electron');
 
-export const { app, BrowserWindow, clipboard, dialog, ipcMain, safeStorage, shell } = electron;
+export const { app, BrowserWindow, clipboard, dialog, ipcMain, protocol, safeStorage, shell } =
+  electron;

--- a/apps/desktop/src/main/files-ipc.test.ts
+++ b/apps/desktop/src/main/files-ipc.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { walkWorkspaceFiles } from './files-ipc';
+
+describe('walkWorkspaceFiles', () => {
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'oc-files-ipc-'));
+  });
+
+  it('returns empty array for an empty workspace', async () => {
+    const files = await walkWorkspaceFiles(workspaceDir);
+    expect(files).toEqual([]);
+  });
+
+  it('lists html and asset files at the root', async () => {
+    await writeFile(path.join(workspaceDir, 'index.html'), '<html></html>');
+    await writeFile(path.join(workspaceDir, 'styles.css'), 'body{}');
+    await writeFile(path.join(workspaceDir, 'app.js'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('index.html');
+    expect(paths).toContain('styles.css');
+    expect(paths).toContain('app.js');
+  });
+
+  it('marks .html and .htm as kind=html', async () => {
+    await writeFile(path.join(workspaceDir, 'a.html'), '');
+    await writeFile(path.join(workspaceDir, 'b.htm'), '');
+    await writeFile(path.join(workspaceDir, 'c.css'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    const byPath = Object.fromEntries(files.map((f) => [f.path, f.kind]));
+    expect(byPath['a.html']).toBe('html');
+    expect(byPath['b.htm']).toBe('html');
+    expect(byPath['c.css']).toBe('asset');
+  });
+
+  it('sorts html files first, then assets, both alphabetical', async () => {
+    await writeFile(path.join(workspaceDir, 'zzz.html'), '');
+    await writeFile(path.join(workspaceDir, 'aaa.css'), '');
+    await writeFile(path.join(workspaceDir, 'bbb.html'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    expect(files.map((f) => f.path)).toEqual(['bbb.html', 'zzz.html', 'aaa.css']);
+  });
+
+  it('walks nested directories', async () => {
+    await mkdir(path.join(workspaceDir, 'sub'));
+    await writeFile(path.join(workspaceDir, 'sub', 'page.html'), '');
+    await writeFile(path.join(workspaceDir, 'sub', 'logo.svg'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('sub/page.html');
+    expect(paths).toContain('sub/logo.svg');
+  });
+
+  it('skips standard heavy/build directories', async () => {
+    for (const dir of ['node_modules', '.git', 'dist', 'build', '.next']) {
+      await mkdir(path.join(workspaceDir, dir));
+      await writeFile(path.join(workspaceDir, dir, 'inside.html'), '');
+    }
+    await writeFile(path.join(workspaceDir, 'visible.html'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    const paths = files.map((f) => f.path);
+    expect(paths).toEqual(['visible.html']);
+  });
+
+  it('skips hidden (dotfile) entries', async () => {
+    await writeFile(path.join(workspaceDir, '.env'), 'SECRET=1');
+    await writeFile(path.join(workspaceDir, '.hidden.html'), '');
+    await writeFile(path.join(workspaceDir, 'visible.html'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    expect(files.map((f) => f.path)).toEqual(['visible.html']);
+  });
+
+  it('skips files without an allowed extension', async () => {
+    await writeFile(path.join(workspaceDir, 'binary.exe'), '');
+    await writeFile(path.join(workspaceDir, 'Makefile'), '');
+    await writeFile(path.join(workspaceDir, 'page.html'), '');
+    const files = await walkWorkspaceFiles(workspaceDir);
+    expect(files.map((f) => f.path)).toEqual(['page.html']);
+  });
+
+  it('returns size and ISO mtime per entry', async () => {
+    const content = 'hello world';
+    await writeFile(path.join(workspaceDir, 'page.html'), content);
+    const files = await walkWorkspaceFiles(workspaceDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.size).toBe(content.length);
+    expect(files[0]?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('respects the max-files cap', async () => {
+    for (let i = 0; i < 10; i++) {
+      await writeFile(path.join(workspaceDir, `file-${i}.html`), '');
+    }
+    const files = await walkWorkspaceFiles(workspaceDir, 3);
+    expect(files).toHaveLength(3);
+  });
+
+  it('handles unreadable directories gracefully', async () => {
+    // Walking a non-existent path returns [] rather than throwing -- the
+    // workspace folder might have been deleted between the bind and the
+    // list call and the panel should just go empty.
+    const files = await walkWorkspaceFiles(path.join(workspaceDir, 'does-not-exist'));
+    expect(files).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/files-ipc.ts
+++ b/apps/desktop/src/main/files-ipc.ts
@@ -1,31 +1,16 @@
+import type { Dirent } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
+import type { CoreLogger } from '@open-codesign/core';
 import { CodesignError } from '@open-codesign/shared';
 import type Database from 'better-sqlite3';
 import { ipcMain } from './electron-runtime';
-import type { Logger as CoreLogger } from './logger';
 import { getDesign } from './snapshots-db';
-
-// Hard cap so a workspace pointed at a huge tree (a node_modules-less but
-// otherwise giant repo) doesn't lock the renderer with a 50k-file payload.
-// Skipped dirs already prune most offenders; this is the last line of defence.
-const FILES_LIST_MAX = 500;
-
-const FILES_LIST_SKIP_DIRS = new Set([
-  '.git',
-  'node_modules',
-  '.next',
-  '.turbo',
-  '.cache',
-  '.pnpm-store',
-  'dist',
-  'build',
-  'out',
-  '.idea',
-  '.vscode',
-  'coverage',
-  '.codesign',
-]);
+import {
+  WORKSPACE_WALK_MAX_FILES,
+  shouldSkipDirEntry,
+  shouldSkipFileEntry,
+} from './workspace-walk';
 
 const HTML_EXTS = new Set(['.html', '.htm']);
 // Anything renderable in an iframe directly (or useful to surface in the
@@ -73,13 +58,13 @@ export interface FilesIpcEntry {
 
 export async function walkWorkspaceFiles(
   workspacePath: string,
-  max: number = FILES_LIST_MAX,
+  max: number = WORKSPACE_WALK_MAX_FILES,
 ): Promise<FilesIpcEntry[]> {
   const out: FilesIpcEntry[] = [];
 
   async function walk(absDir: string, relDir: string): Promise<void> {
     if (out.length >= max) return;
-    let entries: Awaited<ReturnType<typeof readdir>>;
+    let entries: Dirent[];
     try {
       entries = await readdir(absDir, { withFileTypes: true });
     } catch {
@@ -93,12 +78,11 @@ export async function walkWorkspaceFiles(
       const relPath = relDir === '' ? entry.name : `${relDir}/${entry.name}`;
 
       if (entry.isDirectory()) {
-        if (FILES_LIST_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+        if (shouldSkipDirEntry(entry.name)) continue;
         await walk(absPath, relPath);
         continue;
       }
-      if (!entry.isFile()) continue;
-      if (entry.name.startsWith('.')) continue;
+      if (!entry.isFile() || shouldSkipFileEntry(entry.name)) continue;
 
       const ext = path.extname(entry.name).toLowerCase();
       const kind: FilesIpcEntryKind | null = HTML_EXTS.has(ext)

--- a/apps/desktop/src/main/files-ipc.ts
+++ b/apps/desktop/src/main/files-ipc.ts
@@ -1,0 +1,192 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { CodesignError } from '@open-codesign/shared';
+import type Database from 'better-sqlite3';
+import { ipcMain } from './electron-runtime';
+import type { Logger as CoreLogger } from './logger';
+import { getDesign } from './snapshots-db';
+
+// Hard cap so a workspace pointed at a huge tree (a node_modules-less but
+// otherwise giant repo) doesn't lock the renderer with a 50k-file payload.
+// Skipped dirs already prune most offenders; this is the last line of defence.
+const FILES_LIST_MAX = 500;
+
+const FILES_LIST_SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  '.next',
+  '.turbo',
+  '.cache',
+  '.pnpm-store',
+  'dist',
+  'build',
+  'out',
+  '.idea',
+  '.vscode',
+  'coverage',
+  '.codesign',
+]);
+
+const HTML_EXTS = new Set(['.html', '.htm']);
+// Anything renderable in an iframe directly (or useful to surface in the
+// Files panel) gets an entry. Non-listed extensions are skipped to keep
+// the panel uncluttered -- if the agent or user needs a niche file type
+// they can edit the list here.
+const ASSET_EXTS = new Set([
+  '.css',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.json',
+  '.svg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.ico',
+  '.bmp',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.md',
+  '.txt',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.toml',
+]);
+
+export type FilesIpcEntryKind = 'html' | 'asset';
+
+export interface FilesIpcEntry {
+  path: string;
+  kind: FilesIpcEntryKind;
+  size: number;
+  updatedAt: string;
+}
+
+export async function walkWorkspaceFiles(
+  workspacePath: string,
+  max: number = FILES_LIST_MAX,
+): Promise<FilesIpcEntry[]> {
+  const out: FilesIpcEntry[] = [];
+
+  async function walk(absDir: string, relDir: string): Promise<void> {
+    if (out.length >= max) return;
+    let entries: Awaited<ReturnType<typeof readdir>>;
+    try {
+      entries = await readdir(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (out.length >= max) return;
+      const absPath = path.join(absDir, entry.name);
+      const relPath = relDir === '' ? entry.name : `${relDir}/${entry.name}`;
+
+      if (entry.isDirectory()) {
+        if (FILES_LIST_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+        await walk(absPath, relPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (entry.name.startsWith('.')) continue;
+
+      const ext = path.extname(entry.name).toLowerCase();
+      const kind: FilesIpcEntryKind | null = HTML_EXTS.has(ext)
+        ? 'html'
+        : ASSET_EXTS.has(ext)
+          ? 'asset'
+          : null;
+      if (kind === null) continue;
+
+      try {
+        const st = await stat(absPath);
+        out.push({
+          path: relPath,
+          kind,
+          size: st.size,
+          updatedAt: st.mtime.toISOString(),
+        });
+      } catch {
+        // unreadable entries are skipped silently; the Files panel doesn't
+        // surface them and the user already has read access via the picker.
+      }
+    }
+  }
+
+  await walk(workspacePath, '');
+  // HTML files first (the user-visible focus), then everything else.
+  // Stable secondary sort by path keeps the order deterministic.
+  out.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'html' ? -1 : 1;
+    return a.path.localeCompare(b.path);
+  });
+  return out;
+}
+
+export interface RegisterFilesIpcOptions {
+  db: Database.Database;
+  logger: Pick<CoreLogger, 'error' | 'warn' | 'info'>;
+}
+
+export function registerFilesIpc(opts: RegisterFilesIpcOptions): void {
+  const { db, logger } = opts;
+
+  ipcMain.handle(
+    'files:list:v1',
+    async (_e: unknown, raw: unknown): Promise<{ files: FilesIpcEntry[] }> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError('files:list:v1 expects an object payload', 'IPC_BAD_INPUT');
+      }
+      const r = raw as Record<string, unknown>;
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+      const designId = r['designId'] as string;
+
+      let design: ReturnType<typeof getDesign>;
+      try {
+        design = getDesign(db, designId);
+      } catch (err) {
+        logger.error('files.list.db.fail', {
+          designId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        throw new CodesignError('files lookup failed', 'IPC_DB_ERROR', {
+          cause: err instanceof Error ? err : undefined,
+        });
+      }
+
+      if (design === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+      if (design.workspacePath === null) {
+        // No workspace bound -- renderer falls back to virtual index.html.
+        return { files: [] };
+      }
+
+      try {
+        const files = await walkWorkspaceFiles(design.workspacePath);
+        return { files };
+      } catch (err) {
+        logger.error('files.list.walk.fail', {
+          designId,
+          workspacePath: design.workspacePath,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        throw new CodesignError('Failed to scan workspace folder', 'IPC_DB_ERROR', {
+          cause: err instanceof Error ? err : undefined,
+        });
+      }
+    },
+  );
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -91,6 +91,11 @@ import {
 } from './snapshots-ipc';
 import { initStorageSettings } from './storage-settings';
 import { registerWorkspaceProtocolHandler, registerWorkspaceScheme } from './workspace-protocol';
+import {
+  WORKSPACE_WALK_MAX_FILES,
+  shouldSkipDirEntry,
+  shouldSkipFileEntry,
+} from './workspace-walk';
 
 // ESM shim: package.json "type": "module" means the built bundle is ESM and
 // __dirname/__filename don't exist. Derive them from import.meta.url so the
@@ -277,9 +282,11 @@ function allocateAssetPath(
 // text files into fsMap so the agent's view/list_files tools see what the
 // user already has. Without this, the workspace mirror is write-only and the
 // agent thinks the folder is empty even when it isn't.
-const WORKSPACE_SEED_MAX_FILES = 500;
+//
+// Cap per file so a stray multi-MB log inside the workspace can't blow up
+// the agent's context window or stall the main thread on a single read.
 const WORKSPACE_SEED_MAX_FILE_BYTES = 1_000_000;
-const WORKSPACE_SEED_TEXT_EXTENSIONS = new Set([
+const WORKSPACE_SEED_TEXT_EXTENSIONS: ReadonlySet<string> = new Set([
   '.html',
   '.htm',
   '.css',
@@ -297,20 +304,6 @@ const WORKSPACE_SEED_TEXT_EXTENSIONS = new Set([
   '.yaml',
   '.yml',
   '.toml',
-]);
-const WORKSPACE_SEED_SKIP_DIRS = new Set([
-  '.git',
-  'node_modules',
-  '.next',
-  '.turbo',
-  '.cache',
-  '.pnpm-store',
-  'dist',
-  'build',
-  'out',
-  '.idea',
-  '.vscode',
-  'coverage',
 ]);
 
 export function seedFsMapFromWorkspace(
@@ -337,7 +330,7 @@ export function seedFsMapFromWorkspace(
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
-      if (filesLoaded >= WORKSPACE_SEED_MAX_FILES) {
+      if (filesLoaded >= WORKSPACE_WALK_MAX_FILES) {
         truncated = true;
         return;
       }
@@ -345,7 +338,7 @@ export function seedFsMapFromWorkspace(
       const relPath = relDir === '' ? entry.name : `${relDir}/${entry.name}`;
 
       if (entry.isDirectory()) {
-        if (WORKSPACE_SEED_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) {
+        if (shouldSkipDirEntry(entry.name)) {
           filesSkipped += 1;
           continue;
         }
@@ -353,12 +346,7 @@ export function seedFsMapFromWorkspace(
         continue;
       }
 
-      if (!entry.isFile()) {
-        filesSkipped += 1;
-        continue;
-      }
-
-      if (entry.name.startsWith('.')) {
+      if (!entry.isFile() || shouldSkipFileEntry(entry.name)) {
         filesSkipped += 1;
         continue;
       }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import path_module from 'node:path';
 import { basename, dirname, join } from 'node:path';
@@ -99,7 +99,7 @@ const __dirname = dirname(__filename);
 let mainWindow: ElectronBrowserWindow | null = null;
 // Cached update-available payload so a window opened after the event still
 // shows the banner. Cleared only on app quit (matching the one-shot nature
-// of autoUpdater — a new check will re-emit if still applicable).
+// of autoUpdater -- a new check will re-emit if still applicable).
 let pendingUpdateAvailable: unknown = null;
 
 const defaultUserDataDir = app.getPath('userData');
@@ -111,7 +111,7 @@ if (storageLocations.dataDir !== undefined) {
 
 /**
  * Workstream B Phase 1 feature flag. When truthy, `codesign:*:generate` routes
- * through `generateViaAgent()` (pi-agent-core, zero tools). Default off — any
+ * through `generateViaAgent()` (pi-agent-core, zero tools). Default off -- any
  * other value (including unset / empty) keeps the legacy `generate()` path.
  *
  * Read once at module init: changing the env var mid-session requires an app
@@ -169,7 +169,7 @@ function createWindow(): void {
 
   // Replay any update event that fired before this window was ready
   // (macOS: user closed window, triggered a manual Check for Updates from
-  // the app menu, then reopened — the event would otherwise be lost).
+  // the app menu, then reopened -- the event would otherwise be lost).
   mainWindow.webContents.on('did-finish-load', () => {
     if (pendingUpdateAvailable !== null) {
       mainWindow?.webContents.send('codesign:update-available', pendingUpdateAvailable);
@@ -187,7 +187,7 @@ type Database = BetterSqlite3.Database;
 
 /**
  * Pull an HTTP status code out of a caught provider error. Mirrors
- * `packages/providers/src/retry.ts::extractStatus` intentionally — we don't
+ * `packages/providers/src/retry.ts::extractStatus` intentionally -- we don't
  * import from retry.ts to avoid coupling main to a retry-internal helper
  * that might get reshaped. Used by the generate catch block to tag the
  * thrown err with `upstream_status` so the renderer's diagnose pipeline
@@ -271,6 +271,140 @@ function allocateAssetPath(
   return path;
 }
 
+// Workspace seeding: when a design is bound to a folder, load its existing
+// text files into fsMap so the agent's view/list_files tools see what the
+// user already has. Without this, the workspace mirror is write-only and the
+// agent thinks the folder is empty even when it isn't.
+const WORKSPACE_SEED_MAX_FILES = 500;
+const WORKSPACE_SEED_MAX_FILE_BYTES = 1_000_000;
+const WORKSPACE_SEED_TEXT_EXTENSIONS = new Set([
+  '.html',
+  '.htm',
+  '.css',
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+  '.md',
+  '.txt',
+  '.svg',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.toml',
+]);
+const WORKSPACE_SEED_SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  '.next',
+  '.turbo',
+  '.cache',
+  '.pnpm-store',
+  'dist',
+  'build',
+  'out',
+  '.idea',
+  '.vscode',
+  'coverage',
+]);
+
+export function seedFsMapFromWorkspace(
+  workspacePath: string,
+  fsMap: Map<string, string>,
+  logger: Pick<CoreLogger, 'error'>,
+): { filesLoaded: number; filesSkipped: number; truncated: boolean } {
+  let filesLoaded = 0;
+  let filesSkipped = 0;
+  let truncated = false;
+
+  const walk = (absDir: string, relDir: string): void => {
+    if (truncated) return;
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch (err) {
+      logger.error('workspace.seed.readdir.fail', {
+        path: absDir,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (filesLoaded >= WORKSPACE_SEED_MAX_FILES) {
+        truncated = true;
+        return;
+      }
+      const absPath = path_module.join(absDir, entry.name);
+      const relPath = relDir === '' ? entry.name : `${relDir}/${entry.name}`;
+
+      if (entry.isDirectory()) {
+        if (WORKSPACE_SEED_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) {
+          filesSkipped += 1;
+          continue;
+        }
+        walk(absPath, relPath);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        filesSkipped += 1;
+        continue;
+      }
+
+      if (entry.name.startsWith('.')) {
+        filesSkipped += 1;
+        continue;
+      }
+
+      const ext = path_module.extname(entry.name).toLowerCase();
+      if (!WORKSPACE_SEED_TEXT_EXTENSIONS.has(ext)) {
+        filesSkipped += 1;
+        continue;
+      }
+
+      let size: number;
+      try {
+        size = statSync(absPath).size;
+      } catch (err) {
+        logger.error('workspace.seed.stat.fail', {
+          path: absPath,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        filesSkipped += 1;
+        continue;
+      }
+
+      if (size > WORKSPACE_SEED_MAX_FILE_BYTES) {
+        filesSkipped += 1;
+        continue;
+      }
+
+      let content: string;
+      try {
+        content = readFileSync(absPath, 'utf8');
+      } catch (err) {
+        logger.error('workspace.seed.read.fail', {
+          path: absPath,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        filesSkipped += 1;
+        continue;
+      }
+
+      fsMap.set(relPath, content);
+      filesLoaded += 1;
+    }
+  };
+
+  walk(workspacePath, '');
+  return { filesLoaded, filesSkipped, truncated };
+}
+
 interface CreateRuntimeTextEditorFsOptions {
   db: BetterSqlite3.Database | null;
   generationId: string;
@@ -298,6 +432,25 @@ export function createRuntimeTextEditorFs({
   }
   for (const [name, content] of DESIGN_SKILLS) {
     fsMap.set(`skills/${name}`, content);
+  }
+
+  // Workspace folder, when bound, is the source of truth for what's "in" the
+  // design. Seed fsMap with its current text files so the agent's first
+  // list_files / view sees the user's actual content, not just the bundled
+  // frames/skills. Failures are logged and non-fatal -- generation still runs
+  // with whatever was successfully loaded.
+  if (designId !== null && db !== null) {
+    try {
+      const design = getDesign(db, designId);
+      if (design?.workspacePath) {
+        seedFsMapFromWorkspace(design.workspacePath, fsMap, logger);
+      }
+    } catch (err) {
+      logger.error('workspace.seed.fail', {
+        designId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   function emitFsUpdated(filePath: string, content: string): void {
@@ -377,15 +530,19 @@ export function createRuntimeTextEditorFs({
       return { path };
     },
     listDir(dir: string) {
+      // Recursive listing: return every file path under `dir`, not just the
+      // first segment. The agent reads the full tree in a single tool call
+      // instead of recursing one directory at a time -- critical when the
+      // workspace contains a real project with nested folders.
       const prefix = dir.length === 0 || dir === '.' ? '' : `${dir.replace(/\/+$/, '')}/`;
-      const entries = new Set<string>();
+      const entries: string[] = [];
       for (const p of fsMap.keys()) {
         if (!p.startsWith(prefix)) continue;
         const rest = p.slice(prefix.length);
-        const firstSegment = rest.split('/')[0];
-        if (firstSegment) entries.add(firstSegment);
+        if (rest.length === 0) continue;
+        entries.push(rest);
       }
-      return [...entries].sort();
+      return entries.sort();
     },
   };
 
@@ -397,7 +554,7 @@ function registerIpcHandlers(db: Database | null): void {
 
   // Cache of the last NormalizedProviderError seen per run, so recordFinalError
   // can attach it to the final (non-transient) row. Without this, the row the
-  // user actually reports lacks upstream_request_id / status — those fields
+  // user actually reports lacks upstream_request_id / status -- those fields
   // lived only on the hidden transient sibling row emitted by retry.ts.
   // Implementation + LRU eviction lives in ./provider-context.ts.
   const providerContext = createProviderContextStore(50);
@@ -434,7 +591,7 @@ function registerIpcHandlers(db: Database | null): void {
    *
    * Only `provider.error` (retry in flight, transient=true) is persisted from
    * this adapter; the `provider.error.final` event is NOT recorded because the
-   * outer handler's catch block calls `recordFinalError` — recording both
+   * outer handler's catch block calls `recordFinalError` -- recording both
    * would double-count the same failure with two distinct fingerprints. */
   const coreLoggerFor = (id: string): CoreLogger => ({
     info: (event, data) => logIpc.info(event, { generationId: id, ...(data ?? {}) }),
@@ -447,7 +604,7 @@ function registerIpcHandlers(db: Database | null): void {
             ? (data['upstream_message'] as string)
             : event;
         // Fingerprint basis: errorCode + synthetic frame containing the two
-        // fields that truly differentiate provider errors — upstream_status
+        // fields that truly differentiate provider errors -- upstream_status
         // and upstream_code. JSON-stringifying `data` and passing it as
         // `stack` would produce an identical 8-hex for every provider error
         // because `extractTopFrames` requires lines starting with "at ".
@@ -457,7 +614,7 @@ function registerIpcHandlers(db: Database | null): void {
           typeof data?.['upstream_code'] === 'string' ? data['upstream_code'] : 'unknown';
         const syntheticFrame = `    at provider (${status}:${upstreamCode})`;
         // Stash the normalized context so recordFinalError can attach it to
-        // the final non-transient row — otherwise the reported row loses
+        // the final non-transient row -- otherwise the reported row loses
         // upstream_request_id / upstream_status, which lived only on this
         // hidden transient sibling.
         if (data !== undefined) providerContext.remember(id, data);
@@ -652,14 +809,14 @@ function registerIpcHandlers(db: Database | null): void {
             )
             .map((c) => c.text)
             .join('');
-          // Strip <artifact ...>...</artifact> blocks — artifact content is
+          // Strip <artifact ...>...</artifact> blocks -- artifact content is
           // delivered via fs_updated / artifact_delivered, not the chat text.
           const finalText = rawText.replace(/<artifact[\s\S]*?<\/artifact>/g, '').trim();
           sendEvent({ ...baseCtx, type: 'turn_end', finalText });
           return;
         }
         if (event.type === 'agent_end') {
-          // Final boundary of an agent run — renderer uses this to persist a
+          // Final boundary of an agent run -- renderer uses this to persist a
           // SQLite snapshot from the in-memory previewHtml so the design
           // survives an app restart. Without this the next switchDesign() at
           // boot finds no snapshot and falls back to the empty welcome state.
@@ -676,7 +833,7 @@ function registerIpcHandlers(db: Database | null): void {
     }));
   };
 
-  /** In-flight requests: generationId → AbortController */
+  /** In-flight requests: generationId -> AbortController */
   const inFlight = new Map<string, AbortController>();
 
   const armTimeout = (id: string, controller: AbortController) =>
@@ -698,7 +855,7 @@ function registerIpcHandlers(db: Database | null): void {
   // directly to dry-run an artifact without going through the agent loop.
   // The agent itself uses the same verifier as an injected callback (see
   // runGenerate above), so this handler is NOT in the hot path. Hidden
-  // BrowserWindow + Babel makes vitest unworkable here — manual verification
+  // BrowserWindow + Babel makes vitest unworkable here -- manual verification
   // path documented in done-verify.ts.
   const sharedRuntimeVerifier = makeRuntimeVerifier();
   ipcMain.handle('done:verify:v1', async (_e, raw: unknown) => {
@@ -787,8 +944,8 @@ function registerIpcHandlers(db: Database | null): void {
           'CONFIG_MISSING',
         );
       }
-      // Snap to the canonical active provider in cachedConfig — the SAME source
-      // the Settings UI uses for the Active badge — so the actual call cannot
+      // Snap to the canonical active provider in cachedConfig -- the SAME source
+      // the Settings UI uses for the Active badge -- so the actual call cannot
       // diverge from what the user sees.
       const active = resolveActiveModel(cfg, payload.model);
       const allowKeyless = active.allowKeyless;
@@ -800,7 +957,7 @@ function registerIpcHandlers(db: Database | null): void {
         throw err;
       }
       // Once we've snapped to the canonical active provider, the renderer-supplied
-      // baseUrl can no longer be trusted — it may belong to a different (stale)
+      // baseUrl can no longer be trusted -- it may belong to a different (stale)
       // provider and would route the active provider's API key to the wrong host.
       // Always use the per-provider baseUrl from cached config, and mutate the
       // payload itself so any downstream reader cannot accidentally pick up the
@@ -903,7 +1060,7 @@ function registerIpcHandlers(db: Database | null): void {
         return result;
       } catch (err) {
         // Attach upstream metadata to the thrown err so the renderer's
-        // diagnostic pipeline (store.ts::applyGenerateError →
+        // diagnostic pipeline (store.ts::applyGenerateError ->
         // diagnoseGenerateFailure) can map this failure to a "most likely
         // cause + suggested fix" hypothesis. Without this, renderer only
         // sees err.message + err.code and cannot offer actionable hints
@@ -949,7 +1106,7 @@ function registerIpcHandlers(db: Database | null): void {
     });
   });
 
-  // Legacy shim — kept for one minor release while older renderer builds still
+  // Legacy shim -- kept for one minor release while older renderer builds still
   // send codesign:generate without schemaVersion. Remove after v0.3.
   ipcMain.handle('codesign:generate', async (_e, raw: unknown) => {
     logIpc.warn('legacy codesign:generate channel used, schedule removal next minor');
@@ -978,7 +1135,7 @@ function registerIpcHandlers(db: Database | null): void {
         inFlight.delete(id);
         throw err;
       }
-      // See codesign:v1:generate above — renderer baseUrl is ignored post-snap.
+      // See codesign:v1:generate above -- renderer baseUrl is ignored post-snap.
       const baseUrl = active.baseUrl ?? undefined;
       if (active.overridden) {
         payload.baseUrl = baseUrl;
@@ -1289,8 +1446,8 @@ if (!IS_VITEST) {
       initLogger();
       // Single-instance lock. Two simultaneous Electron instances would race
       // `cleanupStaleTmps` vs `writeAtomic` (B's cleanup unlinks A's in-flight
-      // tmp → ENOENT rename) and collide on the SQLite WAL. macOS usually
-      // enforces this at the OS level, but `open -n` defeats that — so we
+      // tmp -> ENOENT rename) and collide on the SQLite WAL. macOS usually
+      // enforces this at the OS level, but `open -n` defeats that -- so we
       // acquire the lock explicitly before touching any shared files.
       const gotLock = app.requestSingleInstanceLock();
       if (!gotLock) {
@@ -1313,7 +1470,7 @@ if (!IS_VITEST) {
       // crashes. pid changes across restarts so without this the config dir
       // accumulates 0o600 litter forever.
       cleanupStaleTmps(join(configDir(), 'reported-fingerprints.json'));
-      // Snapshot persistence is best-effort at boot — a failure here (corrupt DB,
+      // Snapshot persistence is best-effort at boot -- a failure here (corrupt DB,
       // permission denied, missing native binding) must NOT block the BrowserWindow
       // from opening. Surface it via an error dialog and skip registering the
       // snapshots IPC channels; the rest of the app stays usable.
@@ -1339,7 +1496,7 @@ if (!IS_VITEST) {
         });
         // Install stub handlers so renderer-side calls reject with a typed
         // SNAPSHOTS_UNAVAILABLE CodesignError instead of Electron's opaque
-        // "No handler registered" rejection — see snapshots-ipc.ts.
+        // "No handler registered" rejection -- see snapshots-ipc.ts.
         registerSnapshotsUnavailableIpc(dbResult.error.message);
         registerChatMessagesUnavailableIpc(dbResult.error.message);
         registerCommentsUnavailableIpc(dbResult.error.message);
@@ -1374,7 +1531,7 @@ if (!IS_VITEST) {
     } catch (err) {
       // Last-resort boot-phase handler. Reached when something before
       // `initLogger()` finishes (or during the first few setup calls)
-      // throws — our electron-log sink might not exist yet, so write a
+      // throws -- our electron-log sink might not exist yet, so write a
       // best-effort sync log and show a native three-button dialog.
       handleBootFailure(
         err,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -46,6 +46,7 @@ import { registerDiagnosticsIpc } from './diagnostics-ipc';
 import { makeRuntimeVerifier } from './done-verify';
 import { BrowserWindow, app, clipboard, dialog, ipcMain, shell } from './electron-runtime';
 import { registerExporterIpc } from './exporter-ipc';
+import { registerFilesIpc } from './files-ipc';
 import {
   armGenerationTimeout,
   cancelGenerationRequest,
@@ -1500,6 +1501,10 @@ if (!IS_VITEST) {
         registerWorkspaceProtocolHandler({
           db: dbResult.db,
           logger: getLogger('workspace-protocol'),
+        });
+        registerFilesIpc({
+          db: dbResult.db,
+          logger: getLogger('files-ipc'),
         });
         try {
           pruneDiagnosticEvents(dbResult.db, 500);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -658,7 +658,17 @@ function registerIpcHandlers(db: Database | null): void {
     };
     const baseCtx = { designId: designId ?? '', generationId: id } as const;
     const toolStartedAt = new Map<string, number>();
-    const runtimeVerify = makeRuntimeVerifier();
+    // The runtime verifier wraps the artifact in buildSrcdoc(), which expects
+    // a JSX module (TWEAK_DEFAULTS + ReactDOM.createRoot). Real workspace
+    // files are plain HTML / framework code that doesn't fit that mold, so
+    // the verifier flags them as broken and the agent self-heals by flatten-
+    // ing the user's actual project into a self-contained doc -- silently
+    // destroying real source files. Skip verification when a workspace is
+    // bound; the user's tooling (their dev server, linters, browser) is the
+    // source of truth in that mode.
+    const designHasWorkspace =
+      designId !== null && db !== null ? (getDesign(db, designId)?.workspacePath ?? null) : null;
+    const runtimeVerify = designHasWorkspace !== null ? undefined : makeRuntimeVerifier();
     const { fs, fsMap } = createRuntimeTextEditorFs({
       db,
       designId,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -89,6 +89,7 @@ import {
   registerWorkspaceIpc,
 } from './snapshots-ipc';
 import { initStorageSettings } from './storage-settings';
+import { registerWorkspaceProtocolHandler, registerWorkspaceScheme } from './workspace-protocol';
 
 // ESM shim: package.json "type": "module" means the built bundle is ESM and
 // __dirname/__filename don't exist. Derive them from import.meta.url so the
@@ -1409,6 +1410,11 @@ async function scheduleStartupUpdateCheck(): Promise<void> {
 }
 
 if (!IS_VITEST) {
+  // Privileged scheme registration must happen synchronously before
+  // app.whenReady so Chromium picks it up during process init. Calling it
+  // later raises "Schemes can only be registered while the app is initializing".
+  registerWorkspaceScheme();
+
   void app.whenReady().then(async () => {
     // Extracted so the outer try/catch AND post-init listeners (whose callbacks
     // fire outside this block) can route failures through the same boot-fallback
@@ -1481,6 +1487,10 @@ if (!IS_VITEST) {
         registerWorkspaceIpc(dbResult.db, () => mainWindow);
         registerChatMessagesIpc(dbResult.db);
         registerCommentsIpc(dbResult.db);
+        registerWorkspaceProtocolHandler({
+          db: dbResult.db,
+          logger: getLogger('workspace-protocol'),
+        });
         try {
           pruneDiagnosticEvents(dbResult.db, 500);
         } catch (err) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { mkdirSync } from 'node:fs';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import path_module from 'node:path';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -286,6 +286,7 @@ function allocateAssetPath(
 // Cap per file so a stray multi-MB log inside the workspace can't blow up
 // the agent's context window or stall the main thread on a single read.
 const WORKSPACE_SEED_MAX_FILE_BYTES = 1_000_000;
+export const WORKSPACE_SEED_MAX_TOTAL_BYTES = 5_000_000;
 const WORKSPACE_SEED_TEXT_EXTENSIONS: ReadonlySet<string> = new Set([
   '.html',
   '.htm',
@@ -306,20 +307,30 @@ const WORKSPACE_SEED_TEXT_EXTENSIONS: ReadonlySet<string> = new Set([
   '.toml',
 ]);
 
-export function seedFsMapFromWorkspace(
+type WorkspaceSeedLogger = Pick<CoreLogger, 'error'> & Partial<Pick<CoreLogger, 'info'>>;
+
+export interface WorkspaceSeedResult {
+  filesLoaded: number;
+  filesSkipped: number;
+  bytesLoaded: number;
+  truncated: boolean;
+}
+
+export async function seedFsMapFromWorkspace(
   workspacePath: string,
   fsMap: Map<string, string>,
-  logger: Pick<CoreLogger, 'error'>,
-): { filesLoaded: number; filesSkipped: number; truncated: boolean } {
+  logger: WorkspaceSeedLogger,
+): Promise<WorkspaceSeedResult> {
   let filesLoaded = 0;
   let filesSkipped = 0;
+  let bytesLoaded = 0;
   let truncated = false;
 
-  const walk = (absDir: string, relDir: string): void => {
+  const walk = async (absDir: string, relDir: string): Promise<void> => {
     if (truncated) return;
     let entries: import('node:fs').Dirent[];
     try {
-      entries = readdirSync(absDir, { withFileTypes: true });
+      entries = await readdir(absDir, { withFileTypes: true });
     } catch (err) {
       logger.error('workspace.seed.readdir.fail', {
         path: absDir,
@@ -342,7 +353,7 @@ export function seedFsMapFromWorkspace(
           filesSkipped += 1;
           continue;
         }
-        walk(absPath, relPath);
+        await walk(absPath, relPath);
         continue;
       }
 
@@ -359,7 +370,7 @@ export function seedFsMapFromWorkspace(
 
       let size: number;
       try {
-        size = statSync(absPath).size;
+        size = (await stat(absPath)).size;
       } catch (err) {
         logger.error('workspace.seed.stat.fail', {
           path: absPath,
@@ -373,10 +384,15 @@ export function seedFsMapFromWorkspace(
         filesSkipped += 1;
         continue;
       }
+      if (bytesLoaded + size > WORKSPACE_SEED_MAX_TOTAL_BYTES) {
+        filesSkipped += 1;
+        truncated = true;
+        return;
+      }
 
       let content: string;
       try {
-        content = readFileSync(absPath, 'utf8');
+        content = await readFile(absPath, 'utf8');
       } catch (err) {
         logger.error('workspace.seed.read.fail', {
           path: absPath,
@@ -386,13 +402,21 @@ export function seedFsMapFromWorkspace(
         continue;
       }
 
+      const contentBytes = Buffer.byteLength(content, 'utf8');
+      if (bytesLoaded + contentBytes > WORKSPACE_SEED_MAX_TOTAL_BYTES) {
+        filesSkipped += 1;
+        truncated = true;
+        return;
+      }
+
       fsMap.set(relPath, content);
       filesLoaded += 1;
+      bytesLoaded += contentBytes;
     }
   };
 
-  walk(workspacePath, '');
-  return { filesLoaded, filesSkipped, truncated };
+  await walk(workspacePath, '');
+  return { filesLoaded, filesSkipped, bytesLoaded, truncated };
 }
 
 interface CreateRuntimeTextEditorFsOptions {
@@ -401,10 +425,10 @@ interface CreateRuntimeTextEditorFsOptions {
   designId: string | null;
   previousHtml: string | null;
   sendEvent: (event: AgentStreamEvent) => void;
-  logger: Pick<CoreLogger, 'error'>;
+  logger: WorkspaceSeedLogger;
 }
 
-export function createRuntimeTextEditorFs({
+export async function createRuntimeTextEditorFs({
   db,
   generationId,
   designId,
@@ -433,7 +457,15 @@ export function createRuntimeTextEditorFs({
     try {
       const design = getDesign(db, designId);
       if (design?.workspacePath) {
-        seedFsMapFromWorkspace(design.workspacePath, fsMap, logger);
+        const seed = await seedFsMapFromWorkspace(design.workspacePath, fsMap, logger);
+        logger.info?.('workspace.seed.ok', {
+          designId,
+          workspacePath: design.workspacePath,
+          filesLoaded: seed.filesLoaded,
+          filesSkipped: seed.filesSkipped,
+          bytesLoaded: seed.bytesLoaded,
+          truncated: seed.truncated,
+        });
       }
     } catch (err) {
       logger.error('workspace.seed.fail', {
@@ -635,7 +667,7 @@ function registerIpcHandlers(db: Database | null): void {
    * `agent:event:v1` so the sidebar chat can render incremental output
    * instead of waiting for the full final message.
    */
-  const runGenerate = (
+  const runGenerate = async (
     input: Parameters<typeof generate>[0],
     id: string,
     designId: string | null,
@@ -658,7 +690,7 @@ function registerIpcHandlers(db: Database | null): void {
     const designHasWorkspace =
       designId !== null && db !== null ? (getDesign(db, designId)?.workspacePath ?? null) : null;
     const runtimeVerify = designHasWorkspace !== null ? undefined : makeRuntimeVerifier();
-    const { fs, fsMap } = createRuntimeTextEditorFs({
+    const { fs, fsMap } = await createRuntimeTextEditorFs({
       db,
       designId,
       generationId: id,

--- a/apps/desktop/src/main/index.workspace.test.ts
+++ b/apps/desktop/src/main/index.workspace.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { existsSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -11,6 +11,7 @@ import {
   updateDesignWorkspace,
   viewDesignFile,
 } from './snapshots-db';
+import { WORKSPACE_WALK_MAX_FILES } from './workspace-walk';
 
 vi.mock('electron', () => ({
   dialog: {
@@ -69,7 +70,11 @@ vi.mock('./storage-settings', () => ({
   initStorageSettings: vi.fn(() => ({})),
 }));
 
-import { createRuntimeTextEditorFs } from './index';
+import {
+  WORKSPACE_SEED_MAX_TOTAL_BYTES,
+  createRuntimeTextEditorFs,
+  seedFsMapFromWorkspace,
+} from './index';
 
 function makeTempDir(prefix: string): string {
   return mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -95,7 +100,7 @@ describe('createRuntimeTextEditorFs', () => {
     const design = createDesign(db, 'Workspaceless');
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-create-db-only',
@@ -120,7 +125,7 @@ describe('createRuntimeTextEditorFs', () => {
     updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-create-workspace',
@@ -152,7 +157,7 @@ describe('createRuntimeTextEditorFs', () => {
     updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceFile));
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-create-workspace-fail',
@@ -182,7 +187,7 @@ describe('createRuntimeTextEditorFs', () => {
     updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-replace-workspace',
@@ -219,7 +224,7 @@ describe('createRuntimeTextEditorFs', () => {
     writeFileSync(workspaceFile, 'occupied', 'utf8');
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-replace-workspace-fail',
@@ -253,7 +258,7 @@ describe('createRuntimeTextEditorFs', () => {
     writeFileSync(workspaceFile, 'occupied', 'utf8');
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-insert-workspace-fail',
@@ -286,7 +291,7 @@ describe('createRuntimeTextEditorFs', () => {
     updateDesignWorkspace(db, design.id, normalizeWorkspacePath(workspaceDir));
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-insert-workspace',
@@ -323,7 +328,7 @@ describe('createRuntimeTextEditorFs', () => {
     const workspaceDir = makeTempDir('ocd-runtime-null-workspace-');
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db,
       designId: design.id,
       generationId: 'gen-null-workspace',
@@ -351,7 +356,7 @@ describe('createRuntimeTextEditorFs', () => {
   it('emits fs_updated for anonymous mutations without db persistence', async () => {
     const sendEvent = vi.fn();
     const logger = { error: vi.fn() };
-    const { fs } = createRuntimeTextEditorFs({
+    const { fs } = await createRuntimeTextEditorFs({
       db: initInMemoryDb(),
       designId: null,
       generationId: 'gen-anon',
@@ -366,5 +371,65 @@ describe('createRuntimeTextEditorFs', () => {
 
     expect(listFsUpdatedEvents(sendEvent)).toHaveLength(0);
     expect(logger.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('seedFsMapFromWorkspace', () => {
+  it('truncates after the workspace file-count cap', async () => {
+    const workspaceDir = makeTempDir('ocd-runtime-seed-file-cap-');
+    const fsMap = new Map<string, string>();
+    const logger = { error: vi.fn(), info: vi.fn() };
+
+    try {
+      for (let i = 0; i < WORKSPACE_WALK_MAX_FILES + 1; i += 1) {
+        writeFileSync(path.join(workspaceDir, `${String(i).padStart(3, '0')}.html`), 'ok', 'utf8');
+      }
+
+      const result = await seedFsMapFromWorkspace(workspaceDir, fsMap, logger);
+
+      expect(result.filesLoaded).toBe(WORKSPACE_WALK_MAX_FILES);
+      expect(result.filesSkipped).toBe(0);
+      expect(result.bytesLoaded).toBe(WORKSPACE_WALK_MAX_FILES * 2);
+      expect(result.truncated).toBe(true);
+      expect(fsMap.size).toBe(WORKSPACE_WALK_MAX_FILES);
+      expect(fsMap.has('500.html')).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+    } finally {
+      cleanupDir(workspaceDir);
+    }
+  });
+
+  it('caps seeded workspace text by per-file bytes and total bytes', async () => {
+    const workspaceDir = makeTempDir('ocd-runtime-seed-caps-');
+    const fsMap = new Map<string, string>();
+    const logger = { error: vi.fn(), info: vi.fn() };
+
+    try {
+      writeFileSync(path.join(workspaceDir, '0-oversize.json'), 'o'.repeat(1_000_001), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'a.html'), 'a'.repeat(1_000_000), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'b.css'), 'b'.repeat(1_000_000), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'c.js'), 'c'.repeat(1_000_000), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'd.ts'), 'd'.repeat(1_000_000), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'e.md'), 'e'.repeat(1_000_000), 'utf8');
+      writeFileSync(path.join(workspaceDir, 'f.txt'), 'f', 'utf8');
+      mkdirSync(path.join(workspaceDir, 'node_modules'));
+      writeFileSync(path.join(workspaceDir, 'node_modules', 'ignored.js'), 'ignored', 'utf8');
+
+      const result = await seedFsMapFromWorkspace(workspaceDir, fsMap, logger);
+
+      expect(result).toEqual({
+        filesLoaded: 5,
+        filesSkipped: 2,
+        bytesLoaded: WORKSPACE_SEED_MAX_TOTAL_BYTES,
+        truncated: true,
+      });
+      expect(fsMap.size).toBe(5);
+      expect(fsMap.has('f.txt')).toBe(false);
+      expect(fsMap.has('0-oversize.json')).toBe(false);
+      expect(fsMap.has('node_modules/ignored.js')).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+    } finally {
+      cleanupDir(workspaceDir);
+    }
   });
 });

--- a/apps/desktop/src/main/workspace-protocol.test.ts
+++ b/apps/desktop/src/main/workspace-protocol.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveWorkspaceUrl } from './workspace-protocol';
+import { resolveWorkspaceRealPath, resolveWorkspaceUrl } from './workspace-protocol';
 
 describe('resolveWorkspaceUrl', () => {
   let workspaceDir: string;
@@ -162,5 +162,33 @@ describe('resolveWorkspaceUrl', () => {
     const r = resolveWorkspaceUrl(`workspace://${designId}/My%20File.html`, resolveWorkspace);
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.value.relPath).toBe('My File.html');
+  });
+
+  it('rejects symlinks that resolve outside the workspace', async () => {
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), 'oc-wsproto-outside-'));
+    const outsideFile = path.join(outsideDir, 'secret.html');
+    await writeFile(outsideFile, '<html>secret</html>');
+    await symlink(outsideFile, path.join(workspaceDir, 'linked.html'));
+
+    const r = resolveWorkspaceUrl(`workspace://${designId}/linked.html`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const checked = await resolveWorkspaceRealPath(r.value);
+    expect(checked).toEqual({ ok: false, error: 'traversal' });
+  });
+
+  it('accepts symlinks that stay inside the workspace', async () => {
+    await writeFile(path.join(workspaceDir, 'target.html'), '<html>target</html>');
+    await symlink(path.join(workspaceDir, 'target.html'), path.join(workspaceDir, 'inside.html'));
+
+    const r = resolveWorkspaceUrl(`workspace://${designId}/inside.html`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const checked = await resolveWorkspaceRealPath(r.value);
+    expect(checked.ok).toBe(true);
+    if (checked.ok)
+      expect(checked.value.absPath).toBe(await realpath(path.join(workspaceDir, 'target.html')));
   });
 });

--- a/apps/desktop/src/main/workspace-protocol.test.ts
+++ b/apps/desktop/src/main/workspace-protocol.test.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveWorkspaceUrl } from './workspace-protocol';
+
+describe('resolveWorkspaceUrl', () => {
+  let workspaceDir: string;
+  const designId = 'abc123';
+  const resolveWorkspace = (id: string): string | null => {
+    if (id === designId) return workspaceDir;
+    return null;
+  };
+
+  beforeEach(async () => {
+    workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'oc-wsproto-'));
+    await writeFile(path.join(workspaceDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(async () => {
+    // best-effort -- vitest cleans tmp eventually
+  });
+
+  it('resolves a basic workspace url to the file inside the workspace', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/index.html`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.absPath).toBe(path.resolve(workspaceDir, 'index.html'));
+      expect(r.value.mime).toMatch(/^text\/html/);
+      expect(r.value.designId).toBe(designId);
+      expect(r.value.relPath).toBe('index.html');
+    }
+  });
+
+  it('defaults empty path to index.html', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.relPath).toBe('index.html');
+  });
+
+  it('defaults trailing-slash directory path to <dir>/index.html', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/sub/`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.relPath).toBe('sub/index.html');
+  });
+
+  it('rejects non-workspace scheme', () => {
+    const r = resolveWorkspaceUrl(`https://${designId}/index.html`, resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('bad_url');
+  });
+
+  it('rejects empty designId', () => {
+    const r = resolveWorkspaceUrl('workspace:///index.html', resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('bad_url');
+  });
+
+  it('rejects designId with invalid characters', () => {
+    const r = resolveWorkspaceUrl('workspace://bad..id/index.html', resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('bad_url');
+  });
+
+  it('rejects designId not in DB', () => {
+    const r = resolveWorkspaceUrl('workspace://unknown_id/index.html', resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('unknown_design');
+  });
+
+  it('cannot escape workspace via plain ../ (URL parser normalizes)', () => {
+    // WHATWG URL normalizes `..` segments inside the path before our code
+    // sees them, so `..` collapses against the host root rather than walking
+    // above the workspace. The final path is always inside the workspace.
+    const r = resolveWorkspaceUrl(`workspace://${designId}/../etc/passwd.html`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.relPath).toBe('etc/passwd.html');
+      expect(r.value.absPath.startsWith(workspaceDir)).toBe(true);
+    }
+  });
+
+  it('cannot escape workspace via deeply nested ../', () => {
+    const r = resolveWorkspaceUrl(
+      `workspace://${designId}/sub/../../../etc/passwd.html`,
+      resolveWorkspace,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.relPath).toBe('etc/passwd.html');
+      expect(r.value.absPath.startsWith(workspaceDir)).toBe(true);
+    }
+  });
+
+  it('cannot escape workspace via URL-encoded ../ (parser collapses %2e%2e too)', () => {
+    // WHATWG URL normalizes both plain and percent-encoded double-dot
+    // segments, so even `%2e%2e` cannot walk above the host. Defense-in-depth
+    // path.resolve guard remains in place for any future parser quirks.
+    const r = resolveWorkspaceUrl(
+      `workspace://${designId}/%2e%2e/%2e%2e/etc/passwd.html`,
+      resolveWorkspace,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.relPath).toBe('etc/passwd.html');
+      expect(r.value.absPath.startsWith(workspaceDir)).toBe(true);
+    }
+  });
+
+  it('rejects null byte injection', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/index.html%00.png`, resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('bad_url');
+  });
+
+  it('rejects unsupported MIME types (.exe)', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/malware.exe`, resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('unsupported_mime');
+  });
+
+  it('rejects files without an extension', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/Makefile`, resolveWorkspace);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe('unsupported_mime');
+  });
+
+  it('accepts common static assets', () => {
+    const cases = [
+      ['styles.css', 'text/css'],
+      ['app.js', 'application/javascript'],
+      ['module.mjs', 'application/javascript'],
+      ['logo.png', 'image/png'],
+      ['photo.jpg', 'image/jpeg'],
+      ['icon.svg', 'image/svg+xml'],
+      ['font.woff2', 'font/woff2'],
+      ['data.json', 'application/json'],
+    ] as const;
+    for (const [file, mimePrefix] of cases) {
+      const r = resolveWorkspaceUrl(`workspace://${designId}/${file}`, resolveWorkspace);
+      expect(r.ok, `${file} should resolve`).toBe(true);
+      if (r.ok) expect(r.value.mime.startsWith(mimePrefix)).toBe(true);
+    }
+  });
+
+  it('preserves nested paths', () => {
+    const r = resolveWorkspaceUrl(
+      `workspace://${designId}/assets/icons/check.svg`,
+      resolveWorkspace,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.relPath).toBe('assets/icons/check.svg');
+  });
+
+  it('strips query string when resolving (cache busters do not change path)', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/index.html?v=abc123`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.relPath).toBe('index.html');
+  });
+
+  it('handles URL-encoded spaces in filenames', () => {
+    const r = resolveWorkspaceUrl(`workspace://${designId}/My%20File.html`, resolveWorkspace);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.relPath).toBe('My File.html');
+  });
+});

--- a/apps/desktop/src/main/workspace-protocol.ts
+++ b/apps/desktop/src/main/workspace-protocol.ts
@@ -47,6 +47,18 @@ const ALLOWED_MIME_BY_EXT = new Map<string, string>([
 
 const VALID_DESIGN_ID = /^[a-zA-Z0-9_-]+$/;
 
+// Injected at the end of every HTML response served from a workspace. Its
+// job is to convert in-iframe navigations (a user clicking a `<a href="...">`
+// that resolves to another file in the same workspace) into a postMessage
+// to the parent renderer, which then opens that file in its own canvas tab.
+// Without this, clicking a link inside, say, "Aide Sketch.html" would silently
+// repoint the iframe at "Profil Sketch.html" while the tab still showed
+// "Aide Sketch.html" -- one tab, two files, total confusion.
+//
+// Only `.html` / `.htm` workspace links are intercepted. Hash links, JS URLs,
+// external schemes, and asset links pass through to the browser default.
+export const WORKSPACE_NAV_INTERCEPT_SCRIPT = `<script>(function(){var s=function(e){try{var t=e.target&&e.target.closest&&e.target.closest('a[href]');if(!t){return;}var h=t.getAttribute('href');if(!h){return;}if(h.charAt(0)==='#'||h.toLowerCase().indexOf('javascript:')===0){return;}var u;try{u=new URL(h,location.href);}catch(_){return;}if(u.protocol!=='workspace:'||u.host!==location.host){return;}var p=decodeURIComponent(u.pathname).replace(/^\\/+/,'');if(!/\\.(html?|htm)$/i.test(p)){return;}e.preventDefault();try{window.parent.postMessage({__codesign:true,type:'OPEN_FILE_TAB',path:p},'*');}catch(_){}}catch(_){}};document.addEventListener('click',s,true);})();</script>`;
+
 export type WorkspaceProtocolError =
   | 'bad_url'
   | 'unknown_design'
@@ -188,7 +200,11 @@ export function registerWorkspaceProtocolHandler(opts: RegisterWorkspaceProtocol
 
     try {
       const data = await readFile(result.value.absPath);
-      return new Response(data, {
+      const isHtml = result.value.mime.startsWith('text/html');
+      const body: BodyInit = isHtml
+        ? `${data.toString('utf8')}${WORKSPACE_NAV_INTERCEPT_SCRIPT}`
+        : (data as unknown as Uint8Array);
+      return new Response(body, {
         status: 200,
         headers: {
           'Content-Type': result.value.mime,

--- a/apps/desktop/src/main/workspace-protocol.ts
+++ b/apps/desktop/src/main/workspace-protocol.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import path_module from 'node:path';
 import type { CoreLogger } from '@open-codesign/core';
 import type Database from 'better-sqlite3';
@@ -97,6 +97,7 @@ export interface WorkspaceResolution {
   mime: string;
   designId: string;
   relPath: string;
+  workspacePath: string;
 }
 
 export interface WorkspaceResolveResult {
@@ -163,7 +164,31 @@ export function resolveWorkspaceUrl(
     return { ok: false, error: 'unsupported_mime' };
   }
 
-  return { ok: true, value: { absPath, mime, designId, relPath } };
+  return {
+    ok: true,
+    value: { absPath, mime, designId, relPath, workspacePath: normalizedWorkspace },
+  };
+}
+
+export async function resolveWorkspaceRealPath(
+  resolution: WorkspaceResolution,
+): Promise<WorkspaceResolveResult | WorkspaceResolveFailure> {
+  const realWorkspace = await realpath(resolution.workspacePath);
+  const realAbsPath = await realpath(resolution.absPath);
+  const sep = path_module.sep;
+  const isInside =
+    realAbsPath === realWorkspace || realAbsPath.startsWith(`${realWorkspace}${sep}`);
+  if (!isInside) {
+    return { ok: false, error: 'traversal' };
+  }
+  return {
+    ok: true,
+    value: {
+      ...resolution,
+      absPath: realAbsPath,
+      workspacePath: realWorkspace,
+    },
+  };
 }
 
 export function registerWorkspaceScheme(): void {
@@ -225,15 +250,24 @@ export function registerWorkspaceProtocolHandler(opts: RegisterWorkspaceProtocol
     }
 
     try {
-      const data = await readFile(result.value.absPath);
-      const isHtml = result.value.mime.startsWith('text/html');
+      const realPathResult = await resolveWorkspaceRealPath(result.value);
+      if (!realPathResult.ok) {
+        logger.warn('workspace.protocol.reject', { url: request.url, error: realPathResult.error });
+        return new Response(realPathResult.error, {
+          status: 403,
+          headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+      }
+
+      const data = await readFile(realPathResult.value.absPath);
+      const isHtml = realPathResult.value.mime.startsWith('text/html');
       const body: string | Uint8Array = isHtml
         ? `${data.toString('utf8')}${WORKSPACE_NAV_INTERCEPT_SCRIPT}`
         : (data as unknown as Uint8Array);
       return new Response(body, {
         status: 200,
         headers: {
-          'Content-Type': result.value.mime,
+          'Content-Type': realPathResult.value.mime,
           // Iframe is sandboxed (opaque origin); permissive CORS keeps fetch()
           // and dynamic <script> imports working when pages need them.
           'Access-Control-Allow-Origin': '*',

--- a/apps/desktop/src/main/workspace-protocol.ts
+++ b/apps/desktop/src/main/workspace-protocol.ts
@@ -14,6 +14,12 @@ const ALLOWED_MIME_BY_EXT = new Map<string, string>([
   ['.js', 'application/javascript; charset=utf-8'],
   ['.mjs', 'application/javascript; charset=utf-8'],
   ['.cjs', 'application/javascript; charset=utf-8'],
+  // Source files often referenced by `<script type="text/babel">` for in-browser
+  // transpilation. We hand them out as application/javascript regardless of
+  // extension; Babel inspects the script type, not the response Content-Type.
+  ['.jsx', 'application/javascript; charset=utf-8'],
+  ['.ts', 'application/javascript; charset=utf-8'],
+  ['.tsx', 'application/javascript; charset=utf-8'],
   ['.json', 'application/json; charset=utf-8'],
   ['.svg', 'image/svg+xml'],
   ['.png', 'image/png'],

--- a/apps/desktop/src/main/workspace-protocol.ts
+++ b/apps/desktop/src/main/workspace-protocol.ts
@@ -1,0 +1,216 @@
+import { readFile } from 'node:fs/promises';
+import path_module from 'node:path';
+import type Database from 'better-sqlite3';
+import { protocol } from './electron-runtime';
+import type { Logger as CoreLogger } from './logger';
+import { getDesign } from './snapshots-db';
+
+export const WORKSPACE_SCHEME = 'workspace';
+
+const ALLOWED_MIME_BY_EXT = new Map<string, string>([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.htm', 'text/html; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.js', 'application/javascript; charset=utf-8'],
+  ['.mjs', 'application/javascript; charset=utf-8'],
+  ['.cjs', 'application/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.gif', 'image/gif'],
+  ['.webp', 'image/webp'],
+  ['.avif', 'image/avif'],
+  ['.ico', 'image/x-icon'],
+  ['.bmp', 'image/bmp'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+  ['.ttf', 'font/ttf'],
+  ['.otf', 'font/otf'],
+  ['.eot', 'application/vnd.ms-fontobject'],
+  ['.txt', 'text/plain; charset=utf-8'],
+  ['.md', 'text/markdown; charset=utf-8'],
+  ['.map', 'application/json; charset=utf-8'],
+  ['.mp4', 'video/mp4'],
+  ['.webm', 'video/webm'],
+  ['.mp3', 'audio/mpeg'],
+  ['.wav', 'audio/wav'],
+  ['.ogg', 'audio/ogg'],
+]);
+
+const VALID_DESIGN_ID = /^[a-zA-Z0-9_-]+$/;
+
+export type WorkspaceProtocolError =
+  | 'bad_url'
+  | 'unknown_design'
+  | 'no_workspace'
+  | 'traversal'
+  | 'unsupported_mime';
+
+export interface WorkspaceResolution {
+  absPath: string;
+  mime: string;
+  designId: string;
+  relPath: string;
+}
+
+export interface WorkspaceResolveResult {
+  ok: true;
+  value: WorkspaceResolution;
+}
+
+export interface WorkspaceResolveFailure {
+  ok: false;
+  error: WorkspaceProtocolError;
+}
+
+export function resolveWorkspaceUrl(
+  rawUrl: string,
+  resolveWorkspacePath: (designId: string) => string | null,
+): WorkspaceResolveResult | WorkspaceResolveFailure {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, error: 'bad_url' };
+  }
+  if (url.protocol !== `${WORKSPACE_SCHEME}:`) {
+    return { ok: false, error: 'bad_url' };
+  }
+
+  const designId = url.hostname;
+  if (!designId || !VALID_DESIGN_ID.test(designId)) {
+    return { ok: false, error: 'bad_url' };
+  }
+
+  const workspacePath = resolveWorkspacePath(designId);
+  if (workspacePath === null) {
+    return { ok: false, error: 'unknown_design' };
+  }
+
+  let relPath: string;
+  try {
+    relPath = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+  } catch {
+    return { ok: false, error: 'bad_url' };
+  }
+
+  if (relPath === '' || relPath.endsWith('/')) {
+    relPath = `${relPath}index.html`;
+  }
+
+  if (relPath.includes('\0')) {
+    return { ok: false, error: 'bad_url' };
+  }
+
+  const normalizedWorkspace = path_module.resolve(workspacePath);
+  const absPath = path_module.resolve(normalizedWorkspace, relPath);
+  const sep = path_module.sep;
+  const isInside =
+    absPath === normalizedWorkspace || absPath.startsWith(`${normalizedWorkspace}${sep}`);
+  if (!isInside) {
+    return { ok: false, error: 'traversal' };
+  }
+
+  const ext = path_module.extname(absPath).toLowerCase();
+  const mime = ALLOWED_MIME_BY_EXT.get(ext);
+  if (mime === undefined) {
+    return { ok: false, error: 'unsupported_mime' };
+  }
+
+  return { ok: true, value: { absPath, mime, designId, relPath } };
+}
+
+export function registerWorkspaceScheme(): void {
+  // Must be called BEFORE app.whenReady so Chromium treats workspace:// as a
+  // standard, secure scheme. Without standard:true, relative URL resolution
+  // (./styles.css from index.html) breaks. Without secure:true, the iframe
+  // is treated as mixed content and Chromium blocks subresource loads.
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: WORKSPACE_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+        stream: true,
+      },
+    },
+  ]);
+}
+
+export interface RegisterWorkspaceProtocolOptions {
+  db: Database.Database;
+  logger: Pick<CoreLogger, 'error' | 'warn' | 'info'>;
+}
+
+export function registerWorkspaceProtocolHandler(opts: RegisterWorkspaceProtocolOptions): void {
+  const { db, logger } = opts;
+
+  const resolveWorkspacePath = (designId: string): string | null => {
+    try {
+      const design = getDesign(db, designId);
+      return design?.workspacePath ?? null;
+    } catch (err) {
+      logger.error('workspace.protocol.db.fail', {
+        designId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  };
+
+  protocol.handle(WORKSPACE_SCHEME, async (request) => {
+    const result = resolveWorkspaceUrl(request.url, resolveWorkspacePath);
+
+    if (!result.ok) {
+      const status: Record<WorkspaceProtocolError, number> = {
+        bad_url: 400,
+        unknown_design: 404,
+        no_workspace: 404,
+        traversal: 403,
+        unsupported_mime: 415,
+      };
+      logger.warn('workspace.protocol.reject', { url: request.url, error: result.error });
+      return new Response(result.error, {
+        status: status[result.error],
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    try {
+      const data = await readFile(result.value.absPath);
+      return new Response(data, {
+        status: 200,
+        headers: {
+          'Content-Type': result.value.mime,
+          // Iframe is sandboxed (opaque origin); permissive CORS keeps fetch()
+          // and dynamic <script> imports working when pages need them.
+          'Access-Control-Allow-Origin': '*',
+          // Don't let Chromium cache aggressively -- workspaces change while
+          // the user is editing and we want fs_updated reloads to actually
+          // re-fetch from disk.
+          'Cache-Control': 'no-store',
+        },
+      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return new Response('Not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+      }
+      logger.error('workspace.protocol.read.fail', {
+        path: result.value.absPath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return new Response('Read failed', {
+        status: 500,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+  });
+}

--- a/apps/desktop/src/main/workspace-protocol.ts
+++ b/apps/desktop/src/main/workspace-protocol.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import path_module from 'node:path';
+import type { CoreLogger } from '@open-codesign/core';
 import type Database from 'better-sqlite3';
 import { protocol } from './electron-runtime';
-import type { Logger as CoreLogger } from './logger';
 import { getDesign } from './snapshots-db';
 
 export const WORKSPACE_SCHEME = 'workspace';
@@ -57,7 +57,33 @@ const VALID_DESIGN_ID = /^[a-zA-Z0-9_-]+$/;
 //
 // Only `.html` / `.htm` workspace links are intercepted. Hash links, JS URLs,
 // external schemes, and asset links pass through to the browser default.
-export const WORKSPACE_NAV_INTERCEPT_SCRIPT = `<script>(function(){var s=function(e){try{var t=e.target&&e.target.closest&&e.target.closest('a[href]');if(!t){return;}var h=t.getAttribute('href');if(!h){return;}if(h.charAt(0)==='#'||h.toLowerCase().indexOf('javascript:')===0){return;}var u;try{u=new URL(h,location.href);}catch(_){return;}if(u.protocol!=='workspace:'||u.host!==location.host){return;}var p=decodeURIComponent(u.pathname).replace(/^\\/+/,'');if(!/\\.(html?|htm)$/i.test(p)){return;}e.preventDefault();try{window.parent.postMessage({__codesign:true,type:'OPEN_FILE_TAB',path:p},'*');}catch(_){}}catch(_){}};document.addEventListener('click',s,true);})();</script>`;
+export const WORKSPACE_NAV_INTERCEPT_SCRIPT = `<script>
+(function () {
+  function onClick(e) {
+    try {
+      var anchor = e.target && e.target.closest && e.target.closest('a[href]');
+      if (!anchor) return;
+      var href = anchor.getAttribute('href');
+      if (!href) return;
+      if (href.charAt(0) === '#') return;
+      if (href.toLowerCase().indexOf('javascript:') === 0) return;
+      var url;
+      try { url = new URL(href, location.href); } catch (_) { return; }
+      if (url.protocol !== 'workspace:' || url.host !== location.host) return;
+      var relPath = decodeURIComponent(url.pathname).replace(/^\\/+/, '');
+      if (!/\\.html?$/i.test(relPath)) return;
+      e.preventDefault();
+      try {
+        window.parent.postMessage(
+          { __codesign: true, type: 'OPEN_FILE_TAB', path: relPath },
+          '*',
+        );
+      } catch (_) {}
+    } catch (_) {}
+  }
+  document.addEventListener('click', onClick, true);
+})();
+</script>`;
 
 export type WorkspaceProtocolError =
   | 'bad_url'
@@ -201,7 +227,7 @@ export function registerWorkspaceProtocolHandler(opts: RegisterWorkspaceProtocol
     try {
       const data = await readFile(result.value.absPath);
       const isHtml = result.value.mime.startsWith('text/html');
-      const body: BodyInit = isHtml
+      const body: string | Uint8Array = isHtml
         ? `${data.toString('utf8')}${WORKSPACE_NAV_INTERCEPT_SCRIPT}`
         : (data as unknown as Uint8Array);
       return new Response(body, {

--- a/apps/desktop/src/main/workspace-walk.ts
+++ b/apps/desktop/src/main/workspace-walk.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared filtering rules for the two workspace walkers in the main process:
+ * `seedFsMapFromWorkspace` (sync, loads file content for the agent) and
+ * `walkWorkspaceFiles` (async, lists metadata for the Files panel). Keep
+ * them in lockstep -- diverging would mean the agent and the panel disagree
+ * on what counts as a workspace file.
+ */
+
+export const WORKSPACE_WALK_MAX_FILES = 500;
+
+export const WORKSPACE_SKIP_DIRS: ReadonlySet<string> = new Set([
+  '.git',
+  'node_modules',
+  '.next',
+  '.turbo',
+  '.cache',
+  '.pnpm-store',
+  'dist',
+  'build',
+  'out',
+  '.idea',
+  '.vscode',
+  'coverage',
+  '.codesign',
+]);
+
+export function shouldSkipDirEntry(name: string): boolean {
+  return WORKSPACE_SKIP_DIRS.has(name) || name.startsWith('.');
+}
+
+export function shouldSkipFileEntry(name: string): boolean {
+  return name.startsWith('.');
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -33,11 +33,13 @@ import type {
   ModelsListResponse,
   TestEndpointResponse,
 } from '../main/connection-ipc';
+import type { FilesIpcEntry, FilesIpcEntryKind } from '../main/files-ipc';
 import type { ImageGenerationSettingsView } from '../main/image-generation-settings';
 
 export type { ConnectionTestError, ConnectionTestResult, ModelsListResponse, TestEndpointResponse };
 export type { ClaudeCodeUserType, ExternalConfigsDetection };
 export type { CodexOAuthStatus };
+export type { FilesIpcEntry, FilesIpcEntryKind };
 export type { ImageGenerationSettingsView };
 
 export interface ValidateKeyResult {
@@ -63,7 +65,7 @@ export interface ProviderRow {
   baseUrl: string | null;
   isActive: boolean;
   label: string;
-  /** Stored entry name — differs from `label` for codex-imported rows
+  /** Stored entry name -- differs from `label` for codex-imported rows
    *  where `label` is the localized alias "Codex (imported)". */
   name: string;
   builtin: boolean;
@@ -75,7 +77,7 @@ export interface ProviderRow {
 }
 
 // `ClaudeCodeUserType` and `ExternalConfigsDetection` now live in
-// `packages/shared/src/detection.ts` so main and preload stay in lockstep —
+// `packages/shared/src/detection.ts` so main and preload stay in lockstep --
 // see that file for the drift-risk background. The inline definitions that
 // used to live here are gone; re-exports above keep downstream imports
 // from breaking.
@@ -121,7 +123,7 @@ export interface Preferences {
  * Streaming events emitted by the (future) Agent runtime. Phase 1 emits
  * turn_start / text_delta / turn_end. Phase 2 adds tool_call_*. Kept
  * deliberately loose so Workstream B can evolve the shape without a
- * lockstep change here — useAgentStream in the renderer tolerates unknown
+ * lockstep change here -- useAgentStream in the renderer tolerates unknown
  * event types by ignoring them.
  */
 export interface AgentStreamEvent {
@@ -136,7 +138,7 @@ export interface AgentStreamEvent {
     | 'error';
   designId: string;
   /** Trace ID linking this event to the main-process generation log entry.
-   *  Matches the generationId from the codesign:v1:generate payload — always
+   *  Matches the generationId from the codesign:v1:generate payload -- always
    *  present because the main process supplies it from baseCtx. */
   generationId: string;
   // turn_start
@@ -154,7 +156,7 @@ export interface AgentStreamEvent {
   // tool_call_result
   result?: unknown;
   durationMs?: number;
-  // fs_updated — emitted whenever the agent's text_editor mutates a file in the
+  // fs_updated -- emitted whenever the agent's text_editor mutates a file in the
   // virtual fs. Renderer uses this to re-render the iframe live during
   // generation so the user can watch the design take shape.
   path?: string;
@@ -461,6 +463,13 @@ const api = {
         schemaVersion: 1,
         designId,
       }) as Promise<{ exists: boolean }>,
+  },
+  files: {
+    list: (designId: string) =>
+      ipcRenderer.invoke('files:list:v1', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<{ files: FilesIpcEntry[] }>,
   },
   chat: {
     list: (designId: string) =>

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -198,7 +198,7 @@ export function FilesTabView() {
   // (rendered by PreviewPane above us) stays the way to switch between
   // already-opened tabs.
   const collapsedRail = (
-    <aside className="w-[36px] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] flex flex-col items-center pt-[var(--space-3)]">
+    <aside className="w-[var(--size-files-rail)] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] flex flex-col items-center pt-[var(--space-3)]">
       <button
         type="button"
         onClick={() => setCollapsed(false)}

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { buildSrcdoc } from '@open-codesign/runtime';
-import { FileCode2, Folder, FolderOpen } from 'lucide-react';
+import { ChevronLeft, ChevronRight, FileCode2, Folder, FolderOpen } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDesignFiles } from '../hooks/useDesignFiles';
 import { workspacePathComparisonKey } from '../lib/workspace-path';
@@ -168,6 +168,8 @@ export function FilesTabView() {
   const openFileTab = useCodesignStore((s) => s.openCanvasFileTab);
   const interactionMode = useCodesignStore((s) => s.interactionMode);
   const pushIframeError = useCodesignStore((s) => s.pushIframeError);
+  const collapsed = useCodesignStore((s) => s.filesPanelCollapsed);
+  const setCollapsed = useCodesignStore((s) => s.setFilesPanelCollapsed);
   const { files } = useDesignFiles(currentDesignId);
 
   const defaultPath = useMemo(() => {
@@ -191,15 +193,52 @@ export function FilesTabView() {
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  // Thin column shown in place of the full aside when the user collapses
+  // the file list. Carries only the expand button so the canvas tab bar
+  // (rendered by PreviewPane above us) stays the way to switch between
+  // already-opened tabs.
+  const collapsedRail = (
+    <aside className="w-[36px] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] flex flex-col items-center pt-[var(--space-3)]">
+      <button
+        type="button"
+        onClick={() => setCollapsed(false)}
+        title={t('canvas.files.expand')}
+        aria-label={t('canvas.files.expand')}
+        className="w-6 h-6 inline-flex items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+      >
+        <ChevronRight className="w-3.5 h-3.5" aria-hidden />
+      </button>
+    </aside>
+  );
+
+  const collapseButton = (
+    <button
+      type="button"
+      onClick={() => setCollapsed(true)}
+      title={t('canvas.files.collapse')}
+      aria-label={t('canvas.files.collapse')}
+      className="ml-auto w-6 h-6 inline-flex items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-hover)] transition-colors"
+    >
+      <ChevronLeft className="w-3.5 h-3.5" aria-hidden />
+    </button>
+  );
+
   if (files.length === 0) {
     return (
       <div className="flex h-full min-h-0">
-        <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
-          <WorkspaceSection />
-          <div className="flex-1 flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)] px-[var(--space-6)]">
-            {t('canvas.filesTabEmpty')}
-          </div>
-        </aside>
+        {collapsed ? (
+          collapsedRail
+        ) : (
+          <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
+            <WorkspaceSection />
+            <div className="flex items-center px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)]">
+              {collapseButton}
+            </div>
+            <div className="flex-1 flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)] px-[var(--space-6)]">
+              {t('canvas.filesTabEmpty')}
+            </div>
+          </aside>
+        )}
         <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
           {t('canvas.filesTabEmpty')}
         </div>
@@ -208,6 +247,59 @@ export function FilesTabView() {
   }
 
   const selectedFile = selectedPath ? (files.find((f) => f.path === selectedPath) ?? null) : null;
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full min-h-0">
+        {collapsedRail}
+        <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex flex-col min-h-0">
+          <div className="shrink-0 h-[36px] px-[var(--space-4)] flex items-center justify-between gap-[var(--space-3)] border-b border-[var(--color-border-muted)] bg-[var(--color-background)]">
+            <span
+              className="truncate text-[12px] text-[var(--color-text-secondary)]"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              {selectedFile?.path ?? selectedPath ?? ''}
+            </span>
+            <button
+              type="button"
+              onClick={() => selectedPath && openFileTab(selectedPath)}
+              className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
+            >
+              {t('canvas.openInTab')}
+            </button>
+          </div>
+          <div className="flex-1 min-h-0 bg-[var(--color-background-secondary)]">
+            {srcDoc ? (
+              <iframe
+                ref={iframeRef}
+                title={`design-preview-${selectedPath ?? ''}`}
+                sandbox="allow-scripts"
+                srcDoc={srcDoc}
+                onLoad={() => {
+                  const win = iframeRef.current?.contentWindow;
+                  if (!win) return;
+                  try {
+                    win.postMessage(
+                      { __codesign: true, type: 'SET_MODE', mode: interactionMode },
+                      '*',
+                    );
+                  } catch (err) {
+                    const reason = err instanceof Error ? err.message : String(err);
+                    pushIframeError(`SET_MODE postMessage failed: ${reason}`);
+                  }
+                }}
+                className="w-full h-full bg-white border-0 block"
+              />
+            ) : (
+              <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
+                {t('canvas.filesTabEmpty')}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full min-h-0">
@@ -224,6 +316,7 @@ export function FilesTabView() {
             >
               {files.length}
             </span>
+            {collapseButton}
           </div>
 
           <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-1)]">

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -10,7 +10,7 @@ function truncatePath(path: string, maxLength = 40): string {
   if (path.length <= maxLength) return path;
   const start = path.substring(0, maxLength / 2 - 2);
   const end = path.substring(path.length - maxLength / 2 + 2);
-  return `${start}…${end}`;
+  return `${start}...${end}`;
 }
 
 function WorkspaceSection() {

--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { useCodesignStore } from '../store';
 import {
+  getTrustedWorkspaceFileTabPath,
   handlePreviewMessage,
+  isSafeWorkspaceHtmlPath,
   isTrustedPreviewMessageSource,
   postModeToPreviewWindow,
   scaleRectForZoom,
@@ -16,6 +18,65 @@ describe('isTrustedPreviewMessageSource', () => {
     expect(isTrustedPreviewMessageSource(previewWindow, previewWindow)).toBe(true);
     expect(isTrustedPreviewMessageSource(otherWindow, previewWindow)).toBe(false);
     expect(isTrustedPreviewMessageSource(null, previewWindow)).toBe(false);
+  });
+});
+
+describe('getTrustedWorkspaceFileTabPath', () => {
+  const previewWindow = {} as Window;
+  const otherWindow = {} as Window;
+
+  it('accepts file-tab requests only from the active workspace iframe and safe HTML paths', () => {
+    const path = getTrustedWorkspaceFileTabPath(
+      { __codesign: true, type: 'OPEN_FILE_TAB', path: 'pages/about.html' },
+      previewWindow,
+      {
+        previewWindow,
+        currentDesignId: 'design-1',
+        workspacePath: '/tmp/workspace',
+      },
+    );
+
+    expect(path).toBe('pages/about.html');
+  });
+
+  it('rejects inactive frames, unbound workspaces, and unsafe paths', () => {
+    const msg = { __codesign: true, type: 'OPEN_FILE_TAB', path: 'assets/app.html' };
+    expect(
+      getTrustedWorkspaceFileTabPath(msg, otherWindow, {
+        previewWindow,
+        currentDesignId: 'design-1',
+        workspacePath: '/tmp/workspace',
+      }),
+    ).toBeNull();
+    expect(
+      getTrustedWorkspaceFileTabPath(msg, previewWindow, {
+        previewWindow,
+        currentDesignId: 'design-1',
+        workspacePath: null,
+      }),
+    ).toBeNull();
+    expect(
+      getTrustedWorkspaceFileTabPath(
+        { __codesign: true, type: 'OPEN_FILE_TAB', path: '../secret.html' },
+        previewWindow,
+        {
+          previewWindow,
+          currentDesignId: 'design-1',
+          workspacePath: '/tmp/workspace',
+        },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('isSafeWorkspaceHtmlPath', () => {
+  it('allows relative HTML files and rejects traversal, absolute, and asset paths', () => {
+    expect(isSafeWorkspaceHtmlPath('index.html')).toBe(true);
+    expect(isSafeWorkspaceHtmlPath('pages/about.htm')).toBe(true);
+    expect(isSafeWorkspaceHtmlPath('../index.html')).toBe(false);
+    expect(isSafeWorkspaceHtmlPath('/index.html')).toBe(false);
+    expect(isSafeWorkspaceHtmlPath('pages//index.html')).toBe(false);
+    expect(isSafeWorkspaceHtmlPath('assets/app.css')).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -434,11 +434,30 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     }
   }, [comments, currentSnapshotId, commentBubble, currentDesignId, iframeLoadTick]);
 
+  const openCanvasFileTab = useCodesignStore((s) => s.openCanvasFileTab);
+
   useEffect(() => {
     function onMessage(event: MessageEvent): void {
-      // Only accept messages from the ACTIVE iframe -- background pool members
-      // are inert from the user's POV and their messages would race with the
-      // foreground design's state.
+      // Workspace nav-intercept: handled BEFORE the trust check because the
+      // injected script lives inside a sandboxed workspace:// iframe (already
+      // limited to files we serve) and the trust check's contentWindow
+      // comparison is unreliable across iframe re-navigation. Each accepted
+      // file tab is pinned to a single file so the user can never confuse
+      // what they are looking at.
+      if (
+        typeof event.data === 'object' &&
+        event.data !== null &&
+        (event.data as { __codesign?: unknown }).__codesign === true &&
+        (event.data as { type?: unknown }).type === 'OPEN_FILE_TAB'
+      ) {
+        const path = (event.data as { path?: unknown }).path;
+        if (typeof path === 'string' && path.length > 0) openCanvasFileTab(path);
+        return;
+      }
+
+      // Only accept overlay/element messages from the ACTIVE iframe --
+      // background pool members are inert from the user's POV and their
+      // messages would race with the foreground design's state.
       if (!isTrustedPreviewMessageSource(event.source, iframeRef.current?.contentWindow)) return;
 
       const outcome = handlePreviewMessage(event.data, {
@@ -474,7 +493,14 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [pushIframeError, selectCanvasElement, openCommentBubble, previewZoom, applyLiveRects]);
+  }, [
+    pushIframeError,
+    selectCanvasElement,
+    openCommentBubble,
+    previewZoom,
+    applyLiveRects,
+    openCanvasFileTab,
+  ]);
 
   // Pool entries: active design first (using the freshest in-memory
   // previewHtml), then any other recently-visited designs that still have a

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -154,8 +154,8 @@ interface PreviewSlotProps {
 }
 
 // One iframe per pool entry. Hidden (display:none) when not active, but kept
-// in the DOM so its document — already parsed HTML, executed scripts, laid
-// out — survives design switches. That's the whole point of the pool. The
+// in the DOM so its document -- already parsed HTML, executed scripts, laid
+// out -- survives design switches. That's the whole point of the pool. The
 // srcDocStableKey trick is per-slot so token-only tweaks via postMessage
 // don't rebuild the document (~300-500ms blank on JSX cards).
 function PreviewSlot({
@@ -194,7 +194,7 @@ function PreviewSlot({
       srcDoc={srcDoc}
       onLoad={(e) => {
         // Once the iframe's document has actually loaded, its in-page message
-        // handler is ready — this is the reliable moment to (re)post SET_MODE.
+        // handler is ready -- this is the reliable moment to (re)post SET_MODE.
         // The parent's currentDesignId useEffect can fire before the document
         // loads, so that post may be dropped. Only re-post for the active
         // slot so we don't redirect background iframes into comment mode.
@@ -311,7 +311,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   // submit; explicit close (Esc / ×) deliberately preserves.
   const bubbleDraftsRef = useRef<Map<string, string>>(new Map());
   const iframesByDesign = useRef<Map<string, HTMLIFrameElement>>(new Map());
-  // Bumped every time the active iframe fires onLoad — used to re-trigger
+  // Bumped every time the active iframe fires onLoad -- used to re-trigger
   // the WATCH_SELECTORS effect so we don't race past overlay installation
   // on first mount.
   const [iframeLoadTick, setIframeLoadTick] = useState(0);
@@ -332,7 +332,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   );
 
   // When the active design changes, retarget iframeRef and re-broadcast the
-  // current interaction mode. Background iframes keep their last mode — fine,
+  // current interaction mode. Background iframes keep their last mode -- fine,
   // they're inert until reactivated.
   useEffect(() => {
     if (currentDesignId === null) {
@@ -344,7 +344,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     if (el) {
       postModeToPreviewWindow(el.contentWindow, interactionMode, pushIframeError);
     }
-    // New iframe / new design → liveRects from the old one are stale.
+    // New iframe / new design -> liveRects from the old one are stale.
     clearLiveRects();
   }, [currentDesignId, interactionMode, pushIframeError, clearLiveRects]);
 
@@ -353,7 +353,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   // Selectors: all comments on the current snapshot + the active bubble's
   // selector (usually the freshly-pinned one, included for the moment
   // between click and save).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: currentDesignId and iframeLoadTick are deliberate triggers — iframeRef.current is a ref so biome can't see it swap when the active design changes, and we must wait for the iframe's onLoad before the overlay's message listener exists (otherwise the post is dropped).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentDesignId and iframeLoadTick are deliberate triggers -- iframeRef.current is a ref so biome can't see it swap when the active design changes, and we must wait for the iframe's onLoad before the overlay's message listener exists (otherwise the post is dropped).
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
@@ -370,13 +370,13 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         '*',
       );
     } catch {
-      /* sandbox gone — retry happens next render */
+      /* sandbox gone -- retry happens next render */
     }
   }, [comments, currentSnapshotId, commentBubble, currentDesignId, iframeLoadTick]);
 
   useEffect(() => {
     function onMessage(event: MessageEvent): void {
-      // Only accept messages from the ACTIVE iframe — background pool members
+      // Only accept messages from the ACTIVE iframe -- background pool members
       // are inert from the user's POV and their messages would race with the
       // foreground design's state.
       if (!isTrustedPreviewMessageSource(event.source, iframeRef.current?.contentWindow)) return;
@@ -469,7 +469,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     currentDesignId !== null && poolEntries.some((e) => e.id === currentDesignId);
 
   // When a design already has persisted content (thumbnail from a prior save,
-  // or chat history), the preview IS coming — we're just waiting on the IPC
+  // or chat history), the preview IS coming -- we're just waiting on the IPC
   // round-trip for the snapshot. Show a skeleton instead of the new-design
   // welcome screen so users don't read the transient state as "load failed".
   const currentDesign = currentDesignId ? designs.find((d) => d.id === currentDesignId) : undefined;
@@ -482,7 +482,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   // Only take over the whole pane with ErrorState when there's nothing to
   // show yet. If the agent produced a preview before failing on the last
   // step (common with token-overflow / validation errors), keep the preview
-  // visible — the user can still inspect and tweak what did generate.
+  // visible -- the user can still inspect and tweak what did generate.
   // A small dismissible error banner surfaces via CanvasErrorBar / toast.
   if (errorMessage && !previewHtml) {
     body = (
@@ -494,10 +494,10 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
         onDismiss={clearError}
       />
     );
-  } else if (activeTab?.kind === 'files' && previewHtml) {
+  } else if (activeTab?.kind === 'files') {
     body = <FilesTabView />;
   } else {
-    // Pool slots stay mounted even when the current design has no preview —
+    // Pool slots stay mounted even when the current design has no preview --
     // background iframes for recently-visited designs keep their documents
     // alive for instant switch-back. EmptyState is overlaid in the same
     // stacking context when the active design has no content yet.
@@ -607,7 +607,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
                     // bubble open so the user's draft survives. A toast has
                     // already been surfaced by the store layer.
                     if (!row) return;
-                    // Persisted — wipe the stashed draft so the next open
+                    // Persisted -- wipe the stashed draft so the next open
                     // starts clean (a reopened chip re-reads from DB).
                     bubbleDraftsRef.current.delete(bubbleKey);
                     const win = iframeRef.current?.contentWindow;
@@ -619,7 +619,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
                       }
                     }
                     closeCommentBubble();
-                    // Stage only — user clicks the "Apply" button on the chip bar
+                    // Stage only -- user clicks the "Apply" button on the chip bar
                     // to send all accumulated edits in one go.
                   }}
                 />

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -42,6 +42,35 @@ export function isTrustedPreviewMessageSource(
   return source !== null && source === previewWindow;
 }
 
+export function isSafeWorkspaceHtmlPath(path: string): boolean {
+  if (path.length === 0 || path.startsWith('/') || path.startsWith('\\')) return false;
+  if (path.includes('\0') || path.includes('\\')) return false;
+  const parts = path.split('/');
+  if (parts.some((part) => part.length === 0 || part === '.' || part === '..')) return false;
+  return /\.html?$/i.test(path);
+}
+
+export function getTrustedWorkspaceFileTabPath(
+  data: unknown,
+  source: MessageEventSource | null,
+  opts: {
+    previewWindow: Window | null | undefined;
+    currentDesignId: string | null;
+    workspacePath: string | null | undefined;
+  },
+): string | null {
+  if (!isTrustedPreviewMessageSource(source, opts.previewWindow)) return null;
+  if (opts.currentDesignId === null || opts.workspacePath == null) return null;
+  if (typeof data !== 'object' || data === null) return null;
+
+  const envelope = data as { __codesign?: unknown; type?: unknown; path?: unknown };
+  if (envelope.__codesign !== true || envelope.type !== 'OPEN_FILE_TAB') return null;
+  if (typeof envelope.path !== 'string' || envelope.path.length === 0) return null;
+  if (!isSafeWorkspaceHtmlPath(envelope.path)) return null;
+
+  return envelope.path;
+}
+
 export function postModeToPreviewWindow(
   win: Window | null | undefined,
   mode: string,
@@ -360,6 +389,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   const applyLiveRects = useCodesignStore((s) => s.applyLiveRects);
   const clearLiveRects = useCodesignStore((s) => s.clearLiveRects);
   const liveRects = useCodesignStore((s) => s.liveRects);
+  const currentDesign = currentDesignId ? designs.find((d) => d.id === currentDesignId) : undefined;
 
   // Active iframe ref consumed by TweakPanel (postMessage target) and by the
   // window.message guard. We re-point this whenever the active design changes
@@ -438,20 +468,13 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
 
   useEffect(() => {
     function onMessage(event: MessageEvent): void {
-      // Workspace nav-intercept: handled BEFORE the trust check because the
-      // injected script lives inside a sandboxed workspace:// iframe (already
-      // limited to files we serve) and the trust check's contentWindow
-      // comparison is unreliable across iframe re-navigation. Each accepted
-      // file tab is pinned to a single file so the user can never confuse
-      // what they are looking at.
-      if (
-        typeof event.data === 'object' &&
-        event.data !== null &&
-        (event.data as { __codesign?: unknown }).__codesign === true &&
-        (event.data as { type?: unknown }).type === 'OPEN_FILE_TAB'
-      ) {
-        const path = (event.data as { path?: unknown }).path;
-        if (typeof path === 'string' && path.length > 0) openCanvasFileTab(path);
+      const workspaceFileTabPath = getTrustedWorkspaceFileTabPath(event.data, event.source, {
+        previewWindow: iframeRef.current?.contentWindow,
+        currentDesignId,
+        workspacePath: currentDesign?.workspacePath,
+      });
+      if (workspaceFileTabPath !== null) {
+        openCanvasFileTab(workspaceFileTabPath);
         return;
       }
 
@@ -500,6 +523,8 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     previewZoom,
     applyLiveRects,
     openCanvasFileTab,
+    currentDesignId,
+    currentDesign?.workspacePath,
   ]);
 
   // Pool entries: active design first (using the freshest in-memory
@@ -568,7 +593,6 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   // or chat history), the preview IS coming -- we're just waiting on the IPC
   // round-trip for the snapshot. Show a skeleton instead of the new-design
   // welcome screen so users don't read the transient state as "load failed".
-  const currentDesign = currentDesignId ? designs.find((d) => d.id === currentDesignId) : undefined;
   const designHasContent =
     currentDesign !== undefined &&
     ((currentDesign.thumbnailText !== null && currentDesign.thumbnailText.length > 0) ||

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -141,6 +141,14 @@ const COMMENT_HINT_CLASS =
 interface PreviewSlotProps {
   designId: string;
   html: string;
+  /**
+   * When non-null, the design has a bound workspace folder and the iframe
+   * loads `workspace://designId/index.html` instead of injecting `srcdoc`.
+   * That gives the page a real URL so relative imports (./styles.css,
+   * /assets/logo.png, fonts, JS modules) resolve against the workspace
+   * root via the registered Electron protocol handler.
+   */
+  workspacePath: string | null;
   active: boolean;
   viewport: 'mobile' | 'tablet' | 'desktop';
   zoom: number;
@@ -153,6 +161,20 @@ interface PreviewSlotProps {
   onIframeLoaded: (designId: string) => void;
 }
 
+// FNV-1a 32-bit. Cheap, no deps, deterministic. Used to build a cache-buster
+// query string so the iframe re-fetches workspace://...index.html every time
+// the agent rewrites the file (Cache-Control: no-store on the protocol side
+// already kills disk cache, but a stable URL lets Chromium short-circuit the
+// load entirely).
+export function fnv1a32Hex(s: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36);
+}
+
 // One iframe per pool entry. Hidden (display:none) when not active, but kept
 // in the DOM so its document -- already parsed HTML, executed scripts, laid
 // out -- survives design switches. That's the whole point of the pool. The
@@ -161,6 +183,7 @@ interface PreviewSlotProps {
 function PreviewSlot({
   designId,
   html,
+  workspacePath,
   active,
   viewport,
   zoom,
@@ -177,6 +200,15 @@ function PreviewSlot({
   // biome-ignore lint/correctness/useExhaustiveDependencies: srcDocStableKey is the intentional dependency. html flows through naturally because the factory closes over it and re-runs whenever the stable key flips, which is exactly when structural changes (anything outside EDITMODE / TWEAK_SCHEMA markers) are present.
   const srcDoc = useMemo(() => buildSrcdoc(html), [srcDocStableKey]);
 
+  // Workspace mode: load the actual file from disk via workspace:// so
+  // relative imports resolve. The cache-buster is derived from a content
+  // hash so the iframe reloads exactly when the agent has rewritten the
+  // file (and not on every unrelated re-render).
+  const workspaceUrl = useMemo(() => {
+    if (workspacePath === null) return null;
+    return `workspace://${designId}/index.html?v=${fnv1a32Hex(srcDocStableKey)}`;
+  }, [workspacePath, designId, srcDocStableKey]);
+
   const setRef = useCallback(
     (el: HTMLIFrameElement | null) => registerIframe(designId, el),
     [designId, registerIframe],
@@ -186,7 +218,25 @@ function PreviewSlot({
   const scale = zoom / 100;
   const inversePct = `${10000 / zoom}%`;
 
-  const rawIframe = (
+  const rawIframe = workspaceUrl ? (
+    <iframe
+      ref={setRef}
+      title={`design-preview-${designId}`}
+      sandbox="allow-scripts"
+      src={workspaceUrl}
+      onLoad={(e) => {
+        if (!active) return;
+        const target = e.currentTarget as HTMLIFrameElement;
+        postModeToPreviewWindow(target.contentWindow, interactionMode, onIframeError);
+        onIframeLoaded(designId);
+      }}
+      className={
+        isMobile
+          ? 'block w-full h-full bg-transparent border-0'
+          : 'w-full h-full bg-transparent border-0'
+      }
+    />
+  ) : (
     <iframe
       ref={setRef}
       title={`design-preview-${designId}`}
@@ -422,11 +472,13 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   // handed to us.
   const poolEntries = useMemo(() => {
     const seen = new Set<string>();
-    const out: Array<{ id: string; html: string }> = [];
+    const out: Array<{ id: string; html: string; workspacePath: string | null }> = [];
+    const workspaceFor = (id: string): string | null =>
+      designs.find((d) => d.id === id)?.workspacePath ?? null;
     if (currentDesignId !== null) {
       const html = previewHtml ?? previewHtmlByDesign[currentDesignId];
       if (typeof html === 'string' && html.length > 0) {
-        out.push({ id: currentDesignId, html });
+        out.push({ id: currentDesignId, html, workspacePath: workspaceFor(currentDesignId) });
         seen.add(currentDesignId);
       }
     }
@@ -434,12 +486,12 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
       if (seen.has(id)) continue;
       const html = previewHtmlByDesign[id];
       if (typeof html === 'string' && html.length > 0) {
-        out.push({ id, html });
+        out.push({ id, html, workspacePath: workspaceFor(id) });
         seen.add(id);
       }
     }
     return out;
-  }, [currentDesignId, previewHtml, previewHtmlByDesign, recentDesignIds]);
+  }, [currentDesignId, previewHtml, previewHtmlByDesign, recentDesignIds, designs]);
 
   const activeTab = canvasTabs[activeCanvasTab];
   const showCommentUi = interactionMode === 'comment';
@@ -508,6 +560,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
             key={entry.id}
             designId={entry.id}
             html={entry.html}
+            workspacePath={entry.workspacePath}
             active={entry.id === currentDesignId}
             viewport={previewViewport}
             zoom={previewZoom}

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -143,12 +143,18 @@ interface PreviewSlotProps {
   html: string;
   /**
    * When non-null, the design has a bound workspace folder and the iframe
-   * loads `workspace://designId/index.html` instead of injecting `srcdoc`.
-   * That gives the page a real URL so relative imports (./styles.css,
-   * /assets/logo.png, fonts, JS modules) resolve against the workspace
-   * root via the registered Electron protocol handler.
+   * loads `workspace://designId/<previewFilePath>` instead of injecting
+   * `srcdoc`. That gives the page a real URL so relative imports resolve
+   * against the workspace root via the registered Electron protocol handler.
    */
   workspacePath: string | null;
+  /**
+   * Workspace-relative path to load in the iframe when in workspace mode.
+   * Defaults to `index.html`. The active design uses the path from the
+   * currently-active file tab so clicking a file in the Files panel
+   * actually previews that file.
+   */
+  previewFilePath: string;
   active: boolean;
   viewport: 'mobile' | 'tablet' | 'desktop';
   zoom: number;
@@ -184,6 +190,7 @@ function PreviewSlot({
   designId,
   html,
   workspacePath,
+  previewFilePath,
   active,
   viewport,
   zoom,
@@ -201,13 +208,16 @@ function PreviewSlot({
   const srcDoc = useMemo(() => buildSrcdoc(html), [srcDocStableKey]);
 
   // Workspace mode: load the actual file from disk via workspace:// so
-  // relative imports resolve. The cache-buster is derived from a content
-  // hash so the iframe reloads exactly when the agent has rewritten the
-  // file (and not on every unrelated re-render).
+  // relative imports resolve. The cache-buster keys off both the file path
+  // (so switching tabs reloads) and the html stable key (so an agent edit
+  // to the same file reloads). Path segments are encoded individually so
+  // names like "Dashboard V1 Hi-Fi.html" survive without breaking slashes.
   const workspaceUrl = useMemo(() => {
     if (workspacePath === null) return null;
-    return `workspace://${designId}/index.html?v=${fnv1a32Hex(srcDocStableKey)}`;
-  }, [workspacePath, designId, srcDocStableKey]);
+    const encodedPath = previewFilePath.split('/').map(encodeURIComponent).join('/');
+    const v = fnv1a32Hex(`${previewFilePath}|${srcDocStableKey}`);
+    return `workspace://${designId}/${encodedPath}?v=${v}`;
+  }, [workspacePath, designId, previewFilePath, srcDocStableKey]);
 
   const setRef = useCallback(
     (el: HTMLIFrameElement | null) => registerIframe(designId, el),
@@ -475,18 +485,26 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
     const out: Array<{ id: string; html: string; workspacePath: string | null }> = [];
     const workspaceFor = (id: string): string | null =>
       designs.find((d) => d.id === id)?.workspacePath ?? null;
+    // A design is renderable in the preview pool if EITHER:
+    //   - it has in-memory html (legacy single-doc generation flow), OR
+    //   - it has a bound workspace (workspace:// loads files straight off
+    //     disk; previewHtml may be null because the agent hasn't run yet).
+    // The second branch is what makes "click a workspace file in the Files
+    // tab and see it" work without first having to prompt the agent.
     if (currentDesignId !== null) {
-      const html = previewHtml ?? previewHtmlByDesign[currentDesignId];
-      if (typeof html === 'string' && html.length > 0) {
-        out.push({ id: currentDesignId, html, workspacePath: workspaceFor(currentDesignId) });
+      const html = previewHtml ?? previewHtmlByDesign[currentDesignId] ?? '';
+      const wsp = workspaceFor(currentDesignId);
+      if (html.length > 0 || wsp !== null) {
+        out.push({ id: currentDesignId, html, workspacePath: wsp });
         seen.add(currentDesignId);
       }
     }
     for (const id of recentDesignIds) {
       if (seen.has(id)) continue;
-      const html = previewHtmlByDesign[id];
-      if (typeof html === 'string' && html.length > 0) {
-        out.push({ id, html, workspacePath: workspaceFor(id) });
+      const html = previewHtmlByDesign[id] ?? '';
+      const wsp = workspaceFor(id);
+      if (html.length > 0 || wsp !== null) {
+        out.push({ id, html, workspacePath: wsp });
         seen.add(id);
       }
     }
@@ -561,6 +579,11 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
             designId={entry.id}
             html={entry.html}
             workspacePath={entry.workspacePath}
+            previewFilePath={
+              entry.id === currentDesignId && activeTab?.kind === 'file'
+                ? activeTab.path
+                : 'index.html'
+            }
             active={entry.id === currentDesignId}
             viewport={previewViewport}
             zoom={previewZoom}
@@ -587,7 +610,12 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   }
 
   const hasTabs = canvasTabs.length > 0;
-  const isWelcome = !errorMessage && !previewHtml && !designHasContent;
+  // A design with a bound workspace is never "welcome" -- it already has
+  // content the user can browse via the Files panel even before any agent
+  // turn. Hiding the toolbar/tab bar in that case makes the preview look
+  // dead and stops the user from clicking back to the Files tab.
+  const hasWorkspace = currentDesign?.workspacePath != null;
+  const isWelcome = !errorMessage && !previewHtml && !designHasContent && !hasWorkspace;
 
   return (
     <div className="flex min-h-0 flex-1">

--- a/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
@@ -16,30 +16,71 @@ export interface UseDesignFilesResult {
   backend: 'snapshots' | 'files-ipc';
 }
 
-// TODO: Workstream E — swap the implementation of this hook to call
-// `window.codesign.files.list(designId)` once the files-ipc namespace lands.
-// The hook signature (DesignFileEntry[]) stays stable, so consumers do not
-// change. Until then we derive a single virtual `index.html` file from the
-// latest snapshot in `design_snapshots`.
+// Two backends:
+//   - files-ipc: design has a bound workspace folder. Main walks it and
+//     returns real files (html + assets). Refreshed whenever previewHtml
+//     flips so freshly-written files appear without a manual refresh.
+//   - snapshots: legacy / no-workspace mode. Synthesize a single virtual
+//     `index.html` row from the in-memory previewHtml + the latest snapshot
+//     timestamp.
 export function useDesignFiles(designId: string | null): UseDesignFilesResult {
   const previewHtml = useCodesignStore((s) => s.previewHtml);
   const designs = useCodesignStore((s) => s.designs);
-  const [latestSnapshotAt, setLatestSnapshotAt] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const filesIpcAvailable =
-    typeof window !== 'undefined' &&
-    Boolean((window.codesign as unknown as { files?: unknown })?.files);
+  const currentDesign = designId ? designs.find((d) => d.id === designId) : undefined;
+  const useWorkspaceBackend = currentDesign?.workspacePath != null;
 
-  // Look up the latest snapshot timestamp for the current design so the Files
-  // panel can show "N minutes ago" next to the sole `index.html` row. We
-  // debounce on designId + previewHtml so a fresh generation refreshes it.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: previewHtml is intentionally listed as a fresh-generation signal
+  const [latestSnapshotAt, setLatestSnapshotAt] = useState<string | null>(null);
+  const [workspaceFiles, setWorkspaceFiles] = useState<DesignFileEntry[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  // Workspace-backed listing.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: previewHtml is intentionally a fresh-write signal
   useEffect(() => {
+    if (!useWorkspaceBackend || !designId || !window.codesign?.files?.list) {
+      setWorkspaceFiles([]);
+      return;
+    }
     let cancelled = false;
+    setLoading(true);
+    window.codesign.files
+      .list(designId)
+      .then((res) => {
+        if (cancelled) return;
+        setWorkspaceFiles(
+          res.files.map((f) => ({
+            path: f.path,
+            kind: f.kind,
+            updatedAt: f.updatedAt,
+            size: f.size,
+          })),
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setWorkspaceFiles([]);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [designId, useWorkspaceBackend, previewHtml]);
+
+  // Snapshots-backed timestamp -- only run in fallback mode to skip a wasted
+  // IPC round-trip when the workspace backend already ships per-file mtimes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: previewHtml is intentionally a fresh-generation signal
+  useEffect(() => {
+    if (useWorkspaceBackend) {
+      setLatestSnapshotAt(null);
+      return;
+    }
     if (!designId || !window.codesign) {
       setLatestSnapshotAt(null);
       return;
     }
+    let cancelled = false;
     setLoading(true);
     window.codesign.snapshots
       .list(designId)
@@ -58,20 +99,19 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
     return () => {
       cancelled = true;
     };
-  }, [designId, previewHtml]);
+  }, [designId, useWorkspaceBackend, previewHtml]);
+
+  if (useWorkspaceBackend) {
+    return { files: workspaceFiles, loading, backend: 'files-ipc' };
+  }
 
   const files: DesignFileEntry[] = [];
   if (designId && previewHtml) {
-    const design = designs.find((d) => d.id === designId);
-    const updatedAt = latestSnapshotAt ?? design?.updatedAt ?? new Date().toISOString();
+    const updatedAt = latestSnapshotAt ?? currentDesign?.updatedAt ?? new Date().toISOString();
     files.push({ path: 'index.html', kind: 'html', updatedAt, size: previewHtml.length });
   }
 
-  return {
-    files,
-    loading,
-    backend: filesIpcAvailable ? 'files-ipc' : 'snapshots',
-  };
+  return { files, loading, backend: 'snapshots' };
 }
 
 // Format an ISO timestamp as "22h ago" / "3d ago". Pure for testability.

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -229,6 +229,11 @@ interface CodesignState {
    *  only persisted to SQLite when the result arrives (done/error). */
   pendingToolCalls: ChatToolCallPayload[];
   sidebarCollapsed: boolean;
+  /** Collapses the central file-list area inside the Files tab so the
+   *  preview can use the full canvas width. The CanvasTabBar at the top
+   *  stays visible, so the user can keep navigating between already-open
+   *  file tabs. */
+  filesPanelCollapsed: boolean;
 
   // Workstream D — comments
   comments: CommentRow[];
@@ -415,6 +420,7 @@ interface CodesignState {
    *  panel to write a re-serialized EDITMODE block back into the artifact. */
   setPreviewHtml: (content: string) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  setFilesPanelCollapsed: (collapsed: boolean) => void;
 
   // Workstream D — comments
   loadCommentsForCurrentDesign: () => Promise<void>;
@@ -1383,6 +1389,7 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
   chatMessages: [],
   chatLoaded: false,
   sidebarCollapsed: false,
+  filesPanelCollapsed: false,
 
   comments: [],
   commentsLoaded: false,
@@ -2546,6 +2553,10 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   setSidebarCollapsed(collapsed: boolean) {
     set({ sidebarCollapsed: collapsed });
+  },
+
+  setFilesPanelCollapsed(collapsed: boolean) {
+    set({ filesPanelCollapsed: collapsed });
   },
 
   async loadCommentsForCurrentDesign() {

--- a/packages/core/src/tools/list-files.ts
+++ b/packages/core/src/tools/list-files.ts
@@ -1,5 +1,5 @@
 /**
- * list_files — show the agent the contents of its virtual FS so it can
+ * list_files -- show the agent the contents of its virtual FS so it can
  * decide what to view/edit next without guessing at filenames.
  */
 
@@ -23,8 +23,11 @@ export function makeListFilesTool(
     name: 'list_files',
     label: 'List files',
     description:
-      'List files in the design virtual filesystem. Pass an optional `dir` ' +
-      '(defaults to the design root). Returns one filename per line, sorted.',
+      'List files in the design virtual filesystem, recursively. Pass an ' +
+      'optional `dir` (defaults to the design root). Returns every file path ' +
+      'under that directory, one per line, sorted -- not just the first level. ' +
+      'Call this once at the start of a turn to see the whole project tree ' +
+      'instead of recursing one directory at a time.',
     parameters: ListFilesParams,
     async execute(_id, params): Promise<AgentToolResult<ListFilesDetails>> {
       const dir = (params.dir ?? '').replace(/^\/+|\/+$/g, '');

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -47,7 +47,9 @@
     "files": {
       "sectionTitle": "Design files",
       "sectionSubtitle": "{{count}} files",
-      "empty": "No files yet. Send a prompt to have the agent generate a design — files will show up here."
+      "empty": "No files yet. Send a prompt to have the agent generate a design — files will show up here.",
+      "collapse": "Hide file list",
+      "expand": "Show file list"
     },
     "newDesignDialog": {
       "title": "New design",

--- a/packages/providers/src/claude-code-compat.test.ts
+++ b/packages/providers/src/claude-code-compat.test.ts
@@ -29,7 +29,7 @@ describe('isOfficialAnthropicBaseUrl', () => {
   });
   it('strips default ports so :443 / :80 still count as official', () => {
     // WHATWG URL already strips :443 from https:// and :80 from http://,
-    // but cross-scheme typos (http://…:443) would otherwise leak the port
+    // but cross-scheme typos (http://...:443) would otherwise leak the port
     // into host and misclassify the endpoint as custom.
     expect(isOfficialAnthropicBaseUrl('https://api.anthropic.com:443')).toBe(true);
     expect(isOfficialAnthropicBaseUrl('http://api.anthropic.com:443')).toBe(true);
@@ -37,7 +37,7 @@ describe('isOfficialAnthropicBaseUrl', () => {
   });
   it('preserves non-default ports as custom proxies', () => {
     // A user pointing at api.anthropic.com:8443 is running a local proxy,
-    // not the canonical endpoint — inject CC identity headers.
+    // not the canonical endpoint: inject CC identity headers.
     expect(isOfficialAnthropicBaseUrl('https://api.anthropic.com:8443')).toBe(false);
   });
 });

--- a/packages/providers/src/gateway-compat.ts
+++ b/packages/providers/src/gateway-compat.ts
@@ -1,7 +1,7 @@
 /**
  * Gateway compatibility detection.
  *
- * Third-party Anthropic-compatible relays (sub2api, claude2api, anyrouter…)
+ * Third-party Anthropic-compatible relays (sub2api, claude2api, anyrouter...)
  * frequently implement GET /v1/models (which is what our connection test
  * hits) but stub out POST /v1/messages with "not implemented" / 501. That
  * combination passes the onboarding check but explodes on the first real

--- a/packages/runtime/src/iframe-errors.ts
+++ b/packages/runtime/src/iframe-errors.ts
@@ -1,12 +1,12 @@
 /**
- * Iframe runtime error reporting — types + guard.
+ * Iframe runtime error reporting: types + guard.
  *
  * The overlay script (see `overlay.ts`) installs `window.onerror` and
  * `unhandledrejection` listeners inside the sandbox iframe and forwards
  * captured errors to the parent via postMessage. This file is the contract
  * the parent uses to type-narrow incoming messages.
  *
- * Hard rule (PRINCIPLES §10): never swallow these errors. The parent must
+ * Hard rule (PRINCIPLES 10): never swallow these errors. The parent must
  * surface every `IFRAME_ERROR` message in the UI (e.g. CanvasErrorBar).
  */
 

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -138,6 +138,9 @@
   /* Hub sidebar (Designs hub left rail) */
   --size-hub-sidebar: 360px;
 
+  /* Files panel collapsed rail */
+  --size-files-rail: 36px;
+
   /* Modal widths */
   --size-modal-md: 560px;
 


### PR DESCRIPTION
## Summary

When a design is bound to a workspace folder, the agent and the renderer now treat that folder as the source of truth for what's "in" the design instead of acting like the folder is empty.

- **Agent seeding** -- `seedFsMapFromWorkspace` loads the folder's existing text files (HTML/CSS/JS/TS/JSON/MD/SVG/...) into the runtime fsMap before the first turn, so `list_files` and `view` see the user's real content. Capped at 500 files / 1MB per file with a skip-list for `node_modules`, `.git`, build outputs, etc.
- **`workspace://` protocol** -- a privileged Electron scheme serves real assets directly from disk for iframe preview, with path-traversal hardening, an explicit MIME allowlist, no-store caching, and a designId regex check before any DB lookup. Subresources (`./styles.css`, fonts, images) resolve relative to the served HTML the way the user expects.
- **Files panel** -- `files:list:v1` IPC walks the bound folder and returns `{path, kind: 'html'|'asset', size, updatedAt}` to the renderer. Same skip-list and 500-file cap as the agent walker, factored into a shared `workspace-walk` module so the agent and the panel can never disagree on what counts as a workspace file. The panel itself is collapsible.
- **In-iframe nav interception** -- clicking a workspace `<a href>` to another `.html` in the same folder posts `OPEN_FILE_TAB` up to the renderer instead of silently swapping the iframe under a tab still labelled with the previous file.
- **`list_files` recursion** -- the agent's `list_files` tool now returns the full recursive tree under `dir`, not just the first directory level, so a single call gives a complete project map. The tool description was updated to match.
- **Bug fixes** -- the `done` verifier is skipped when the design has a bound workspace (the verifier's HTML-blob assumption doesn't hold once the agent edits real files), and the same folder can now be bound to multiple designs without the unique-constraint failure.

## Hard constraints checked

- No new SQLite tables for v0.2 session/design data
- No bundled model runtimes, no `console.*` in `apps/desktop/src/main/**`, no provider SDK imports
- No `any`, strict mode passes, `verbatimModuleSyntax` respected
- Path-traversal, null-byte, and bad-URL cases covered by `workspace-protocol.test.ts` (18 tests)

## Test plan

- [x] `pnpm typecheck` -- clean
- [x] `pnpm lint` (Biome) -- clean
- [x] `pnpm test` -- 1054 / 1054 pass, including new `files-ipc.test.ts` and `workspace-protocol.test.ts`
- [ ] Manual: bind a folder containing a multi-file static site, verify the Files panel lists every HTML/asset, click between HTML files (each opens its own canvas tab), let the agent edit a real file and confirm the iframe re-fetches via `workspace://`

## Notes for reviewers

The two cleanup commits at the tip (`refactor(main): share workspace walk...` and `chore(workspace-protocol): ...`) are post-feature polish: dedup of the skip-rules between the two walkers, expansion of the inlined nav-intercept script for readability, and a fix for two pre-existing `tsc` errors (`Logger as CoreLogger` import that was never exported, and a `BodyInit` annotation missing from this tsconfig's lib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)