### PR TITLE
[codex] fix provider no-model translations

### DIFF
--- a/.changeset/provider-no-model-i18n.md
+++ b/.changeset/provider-no-model-i18n.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/i18n": patch
+---
+
+Fix missing `settings.providers.noModel` translations for provider settings UI and cover the key across supported locales.

--- a/packages/i18n/src/i18n.test.ts
+++ b/packages/i18n/src/i18n.test.ts
@@ -77,6 +77,27 @@ describe('initI18n + setLocale (live switching)', () => {
     warn.mockRestore();
   });
 
+  it('serves provider no-model copy in every supported locale', async () => {
+    const { i18n } = await import('./index');
+    await initI18n('en');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    for (const locale of availableLocales) {
+      await setLocale(locale);
+      const value = i18n.t('settings.providers.noModel');
+      expect(value, `${locale} should translate settings.providers.noModel`).not.toContain(
+        'settings.providers.noModel',
+      );
+      expect(
+        value.trim().length,
+        `${locale} provider no-model copy should not be empty`,
+      ).toBeGreaterThan(0);
+    }
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('setLocale updates getCurrentLocale and i18n.t() immediately (no restart needed)', async () => {
     const { i18n } = await import('./index');
     await initI18n('en');

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -241,6 +241,7 @@
       "empty": "No providers configured yet. Add one to start generating.",
       "active": "Active",
       "activeNotInList": "(active, not in provider list)",
+      "noModel": "No model selected",
       "decryptionFailed": "Decryption failed",
       "setActive": "Set active",
       "reEnterKey": "Re-enter key",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -212,6 +212,7 @@
       "addCustom": "Adicionar personalizado",
       "empty": "Nenhum provedor configurado ainda. Adicione um para começar a gerar.",
       "active": "Ativo",
+      "noModel": "Nenhum modelo selecionado",
       "decryptionFailed": "Falha na descriptografia",
       "setActive": "Definir como ativo",
       "reEnterKey": "Redigitar chave",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -241,6 +241,7 @@
       "empty": "还没有配置任何服务，添加一个即可开始生成。",
       "active": "当前",
       "activeNotInList": "（当前，不在服务返回的列表中）",
+      "noModel": "未选择模型",
       "decryptionFailed": "解密失败",
       "setActive": "设为当前",
       "reEnterKey": "重新输入 Key",


### PR DESCRIPTION
﻿## Summary
- Add the missing `settings.providers.noModel` translation key for `en`, `zh-CN`, and `pt-BR`.
- Add i18n regression coverage so every supported locale must serve non-empty provider no-model copy without missing-key warnings.
- Add a patch changeset for `@open-codesign/i18n`.

## Root Cause
Provider settings UI reads `settings.providers.noModel`, but locale resources only had equivalent copy under `sidebar.chat.noModel`, so the provider/settings path could surface the raw missing i18n key.

## Validation
Passed:
- `corepack pnpm lint`
- `corepack pnpm exec turbo run typecheck --force`
- `corepack pnpm --filter @open-codesign/i18n test`
- `corepack pnpm --filter @open-codesign/desktop test -- Settings.test.ts`
- `corepack pnpm --filter @open-codesign/desktop build`

Known current failure outside this i18n change:
- `corepack pnpm exec turbo run test --force` fails in `@open-codesign/desktop` on Windows with 4 existing path-related assertions in `src/main/snapshots-db.test.ts` and `src/main/workspace-watcher.test.ts`.

Part of #254.
