### PR TITLE
[codex] fix default workspace storage path

### DIFF
--- a/.changeset/default-workspaces-follow-data.md
+++ b/.changeset/default-workspaces-follow-data.md
@@ -1,0 +1,6 @@
+---
+"@open-codesign/desktop": patch
+"@open-codesign/i18n": patch
+---
+
+Make default workspaces for new designs follow the active data directory and clarify that existing workspaces remain per-design bindings.

--- a/apps/desktop/src/main/snapshots-ipc.create-design.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.create-design.test.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Design } from '@open-codesign/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initSnapshotsDb } from './snapshots-db';
+import { registerSnapshotsIpc } from './snapshots-ipc';
+import { normalizeWorkspacePath } from './workspace-path';
+
+type Handler = (event: unknown, raw: unknown) => unknown;
+
+const testState = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  appPaths: {
+    documents: '',
+    userData: '',
+  },
+}));
+
+vi.mock('./electron-runtime', () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'documents') return testState.appPaths.documents;
+      if (name === 'userData') return testState.appPaths.userData;
+      return testState.appPaths.userData;
+    }),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      testState.handlers.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('./logger', () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const tempDirs: string[] = [];
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function getHandler(channel: string): Handler {
+  const handler = testState.handlers.get(channel);
+  if (!handler) throw new Error(`Missing IPC handler: ${channel}`);
+  return handler;
+}
+
+describe('snapshots create-design workspace allocation', () => {
+  beforeEach(() => {
+    testState.handlers.clear();
+    testState.appPaths.documents = '';
+    testState.appPaths.userData = '';
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('auto-binds new designs inside the active data directory', async () => {
+    const userDataRoot = await makeTempRoot('ocd-data-root-');
+    const documentsRoot = await makeTempRoot('ocd-documents-root-');
+    testState.appPaths.userData = userDataRoot;
+    testState.appPaths.documents = documentsRoot;
+
+    const db = initSnapshotsDb(path.join(userDataRoot, 'design-store.json'));
+    registerSnapshotsIpc(db);
+
+    const createDesign = getHandler('snapshots:v1:create-design');
+    const design = (await createDesign(null, {
+      schemaVersion: 1,
+      name: 'Poster Study',
+    })) as Design;
+
+    const expectedWorkspacePath = normalizeWorkspacePath(
+      path.join(userDataRoot, 'workspaces', 'Poster-Study'),
+    );
+    expect(design.workspacePath).toBe(expectedWorkspacePath);
+    expect(existsSync(expectedWorkspacePath)).toBe(true);
+    expect(design.workspacePath).not.toContain(normalizeWorkspacePath(documentsRoot));
+  });
+
+  it('allocates duplicated design workspaces inside the active data directory', async () => {
+    const userDataRoot = await makeTempRoot('ocd-data-root-');
+    const documentsRoot = await makeTempRoot('ocd-documents-root-');
+    testState.appPaths.userData = userDataRoot;
+    testState.appPaths.documents = documentsRoot;
+
+    const db = initSnapshotsDb(path.join(userDataRoot, 'design-store.json'));
+    registerSnapshotsIpc(db);
+    const createDesign = getHandler('snapshots:v1:create-design');
+    const duplicateDesign = getHandler('snapshots:v1:duplicate-design');
+    const source = (await createDesign(null, {
+      schemaVersion: 1,
+      name: 'Source Design',
+    })) as Design;
+    if (source.workspacePath === null) throw new Error('Expected source workspace');
+    await writeFile(path.join(source.workspacePath, 'index.html'), '<main>copy me</main>', 'utf8');
+
+    const cloned = (await duplicateDesign(null, {
+      schemaVersion: 1,
+      id: source.id,
+      name: 'Source copy',
+    })) as Design;
+
+    const expectedWorkspacePath = normalizeWorkspacePath(
+      path.join(userDataRoot, 'workspaces', 'Source-copy'),
+    );
+    expect(cloned.workspacePath).toBe(expectedWorkspacePath);
+    expect(existsSync(expectedWorkspacePath)).toBe(true);
+    await expect(readFile(path.join(expectedWorkspacePath, 'index.html'), 'utf8')).resolves.toBe(
+      '<main>copy me</main>',
+    );
+    expect(cloned.workspacePath).not.toContain(normalizeWorkspacePath(documentsRoot));
+  });
+});

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -87,8 +87,15 @@ function isAlreadyExists(err: unknown): boolean {
   return (err as NodeJS.ErrnoException).code === 'EEXIST';
 }
 
-async function allocateDefaultWorkspacePath(name: string): Promise<string> {
-  const defaultRoot = path.join(app.getPath('documents'), 'CoDesign');
+function resolveDefaultWorkspaceRoot(db: Database): string {
+  if (path.isAbsolute(db.dataDir)) {
+    return path.join(db.dataDir, 'workspaces');
+  }
+  return path.join(app.getPath('documents'), 'CoDesign');
+}
+
+async function allocateDefaultWorkspacePath(db: Database, name: string): Promise<string> {
+  const defaultRoot = resolveDefaultWorkspaceRoot(db);
   await mkdir(defaultRoot, { recursive: true });
   const slug = defaultDesignSlug(name);
 
@@ -421,13 +428,14 @@ export function registerSnapshotsIpc(db: Database): void {
       const name = (r['name'] as string).trim();
       const requestedWorkspacePath = parseCreateDesignWorkspacePath(r);
       const design = runDb('create-design', () => createDesign(db, name));
-      // v0.2: every design MUST have a workspace — per docs/v0.2-plan.md §2.3.
-      // When the user hasn't picked one explicitly, seed
-      //   <Documents>/CoDesign/<slug(name)>[-N]/
-      // and bind it. Collision suffix handles duplicate names.
+      // v0.2: every design must have a workspace. When the user has not picked
+      // one explicitly, seed it under the active data directory so Storage >
+      // Data applies to future default workspaces. Existing designs keep their
+      // explicit binding until the user changes or migrates it from Files.
       let autoWorkspacePath: string | null = null;
       try {
-        const workspacePath = requestedWorkspacePath ?? (await allocateDefaultWorkspacePath(name));
+        const workspacePath =
+          requestedWorkspacePath ?? (await allocateDefaultWorkspacePath(db, name));
         if (requestedWorkspacePath === undefined) {
           autoWorkspacePath = workspacePath;
         }
@@ -549,7 +557,7 @@ export function registerSnapshotsIpc(db: Database): void {
       }
       let autoWorkspacePath: string | null = null;
       try {
-        const workspacePath = await allocateDefaultWorkspacePath(name);
+        const workspacePath = await allocateDefaultWorkspacePath(db, name);
         autoWorkspacePath = workspacePath;
         await copyTrackedWorkspaceFiles(db, sourceId, sourceWorkspacePath, workspacePath);
         const bound = await bindWorkspace(db, cloned.id, workspacePath, false);

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -419,7 +419,7 @@
       "data": "Data directory",
       "change": "Change",
       "restartHint": "Choose where open-codesign stores config, logs, and local design data. Changes are saved permanently and take effect after restarting the app.",
-      "workspaceHint": "Design workspace folders are managed per design from the Files panel. Changing these storage paths does not move or rebind existing workspace files.",
+      "workspaceHint": "The data directory seeds default workspaces for new designs after restart. Existing design workspace folders stay bound per design; change or migrate them from the Files panel.",
       "locationSavedToast": "Storage location saved. Restart the app to apply it.",
       "locationSaveFailed": "Could not save storage location",
       "onboardingTitle": "Onboarding",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -384,7 +384,7 @@
       "data": "Diretório de dados",
       "change": "Alterar",
       "restartHint": "Escolha onde o open-codesign guarda configuração, logs e dados locais de design. As alterações são salvas permanentemente e se aplicam depois de reiniciar o app.",
-      "workspaceHint": "Pastas de workspace são gerenciadas por design no painel Arquivos. Alterar estes caminhos de armazenamento não move nem revincula arquivos de workspace existentes.",
+      "workspaceHint": "O diretório de dados cria os workspaces padrão de novos designs depois da reinicialização. Workspaces existentes continuam vinculados por design; altere ou migre pelo painel Arquivos.",
       "locationSavedToast": "Local de armazenamento salvo. Reinicie o app para aplicar.",
       "locationSaveFailed": "Não foi possível salvar o local de armazenamento",
       "onboardingTitle": "Onboarding",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -419,7 +419,7 @@
       "data": "数据目录",
       "change": "更改",
       "restartHint": "选择 open-codesign 保存配置、日志和本地设计数据的位置。更改会永久保存，重启应用后生效。",
-      "workspaceHint": "设计工作区按单个设计在文件面板中管理。修改这些存储路径不会移动或重新绑定已有工作区文件。",
+      "workspaceHint": "数据目录会在重启后作为新建设计默认工作区的根目录。已有设计的工作区仍按单个设计绑定；如需更改或迁移，请在文件面板操作。",
       "locationSavedToast": "存储位置已保存。重启应用后生效。",
       "locationSaveFailed": "无法保存存储位置",
       "onboardingTitle": "首次引导",


### PR DESCRIPTION
﻿## Summary
- Make auto-created workspaces for new and duplicated designs follow the active data directory under `workspaces/<design-slug>`.
- Keep existing workspace bindings explicit and update Storage settings copy to explain migration happens from the Files panel.
- Add regression coverage for create-design and duplicate-design workspace allocation.
- Add a patch changeset.

## Root Cause
Bug #3 was only partially addressed by explanatory copy and auto-binding. The default workspace root was still hard-coded to `<Documents>/CoDesign`, so changing the app data directory could leave future default workspace files outside the configured data location.

## Validation
- `corepack pnpm lint`
- `corepack pnpm exec turbo run typecheck --force`
- `corepack pnpm exec turbo run test --force`
- `corepack pnpm --filter @open-codesign/desktop build`

Notes:
- `lint` exits 0 with an existing Biome schema version informational note (`2.4.14` schema vs `2.4.13` CLI).
- desktop build exits 0 with existing `INEFFECTIVE_DYNAMIC_IMPORT` warnings for `smol-toml` and `packages/exporters/src/markdown.ts`.

Part of #254.
