### PR TITLE
fix(exporters): preserve local assets in exports

### DIFF
--- a/.changeset/export-fidelity-assets.md
+++ b/.changeset/export-fidelity-assets.md
@@ -1,0 +1,6 @@
+---
+"@open-codesign/desktop": patch
+"@open-codesign/exporters": patch
+---
+
+Improve exporter fidelity by resolving workspace-local assets, bundling ZIP resources, preserving Markdown tables, supporting PDF header/footer options, and rendering PPTX slides from Chrome screenshots.

--- a/apps/desktop/src/main/exporter-ipc.test.ts
+++ b/apps/desktop/src/main/exporter-ipc.test.ts
@@ -1,6 +1,6 @@
 import { CodesignError } from '@open-codesign/shared';
 import { describe, expect, it } from 'vitest';
-import { parseRequest } from './exporter-ipc';
+import { exportAssetOptions, parseRequest } from './exporter-ipc';
 
 describe('parseRequest', () => {
   it('rejects a null payload with IPC_BAD_INPUT', () => {
@@ -31,5 +31,20 @@ describe('parseRequest', () => {
     expect(result.format).toBe('pdf');
     expect(result.htmlContent).toBe('<html/>');
     expect(result.defaultFilename).toBe('report.pdf');
+  });
+
+  it('accepts workspace source context for local asset exports', () => {
+    const result = parseRequest({
+      format: 'zip',
+      htmlContent: '<img src="assets/logo.svg">',
+      workspacePath: '/workspace',
+      sourcePath: 'screens/home/index.html',
+    });
+
+    expect(result.workspacePath).toBe('/workspace');
+    expect(result.sourcePath).toBe('screens/home/index.html');
+    expect(exportAssetOptions(result)).toMatchObject({
+      assetRootPath: '/workspace',
+    });
   });
 });

--- a/apps/desktop/src/main/exporter-ipc.ts
+++ b/apps/desktop/src/main/exporter-ipc.ts
@@ -1,4 +1,5 @@
-import { type ExporterFormat, exportArtifact } from '@open-codesign/exporters';
+import path from 'node:path';
+import { type ExporterFormat, type ExportOptions, exportArtifact } from '@open-codesign/exporters';
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
 import type { BrowserWindow } from 'electron';
 import { dialog, ipcMain } from './electron-runtime';
@@ -15,6 +16,8 @@ export interface ExportRequest {
   format: ExporterFormat;
   htmlContent: string;
   defaultFilename?: string;
+  workspacePath?: string;
+  sourcePath?: string;
 }
 
 export interface ExportResponse {
@@ -31,6 +34,8 @@ export function parseRequest(raw: unknown): ExportRequest {
   const format = r['format'];
   const html = r['htmlContent'];
   const defaultFilename = r['defaultFilename'];
+  const workspacePath = r['workspacePath'];
+  const sourcePath = r['sourcePath'];
   if (
     format !== 'html' &&
     format !== 'pdf' &&
@@ -50,7 +55,22 @@ export function parseRequest(raw: unknown): ExportRequest {
   if (typeof defaultFilename === 'string' && defaultFilename.length > 0) {
     out.defaultFilename = defaultFilename;
   }
+  if (typeof workspacePath === 'string' && workspacePath.length > 0) {
+    out.workspacePath = workspacePath;
+  }
+  if (typeof sourcePath === 'string' && sourcePath.length > 0) {
+    out.sourcePath = sourcePath;
+  }
   return out;
+}
+
+export function exportAssetOptions(req: ExportRequest): ExportOptions {
+  if (!req.workspacePath) return {};
+  const sourceDir = path.dirname(req.sourcePath ?? 'index.html');
+  return {
+    assetRootPath: req.workspacePath,
+    assetBasePath: path.resolve(req.workspacePath, sourceDir),
+  };
 }
 
 export function registerExporterIpc(getWindow: () => BrowserWindow | null): void {
@@ -68,9 +88,14 @@ export function registerExporterIpc(getWindow: () => BrowserWindow | null): void
       return { status: 'cancelled' };
     }
 
-    // All four formats ship in tier 1; the heavy deps load lazily inside
+    // Export formats load their heavy deps lazily inside
     // exportArtifact. Errors propagate to the renderer as toasts (PRINCIPLES §10).
-    const result = await exportArtifact(req.format, req.htmlContent, picked.filePath);
+    const result = await exportArtifact(
+      req.format,
+      req.htmlContent,
+      picked.filePath,
+      exportAssetOptions(req),
+    );
     return { status: 'saved', path: result.path, bytes: result.bytes };
   });
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -72,6 +72,13 @@ export interface ExportInvokeResponse {
   path?: string;
   bytes?: number;
 }
+export interface ExportInvokePayload {
+  format: ExportFormat;
+  htmlContent: string;
+  defaultFilename?: string;
+  workspacePath?: string;
+  sourcePath?: string;
+}
 
 export interface ProviderRow {
   provider: string;
@@ -291,7 +298,7 @@ const api = {
     ipcRenderer.invoke('codesign:pick-design-system-directory') as Promise<OnboardingState>,
   clearDesignSystem: () =>
     ipcRenderer.invoke('codesign:clear-design-system') as Promise<OnboardingState>,
-  export: (payload: { format: ExportFormat; htmlContent: string; defaultFilename?: string }) =>
+  export: (payload: ExportInvokePayload) =>
     ipcRenderer.invoke('codesign:export', payload) as Promise<ExportInvokeResponse>,
   locale: {
     getSystem: () => ipcRenderer.invoke('locale:get-system') as Promise<string>,

--- a/apps/desktop/src/renderer/src/store/slices/generation.ts
+++ b/apps/desktop/src/renderer/src/store/slices/generation.ts
@@ -879,10 +879,16 @@ export function makeGenerationSlice(set: SetState, get: GetState): GenerationSli
         }
         const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
         const ext = format === 'markdown' ? 'md' : format;
+        const activeDesign =
+          designId === null
+            ? null
+            : (get().designs.find((design) => design.id === designId) ?? null);
         const res = await window.codesign.export({
           format,
           htmlContent,
           defaultFilename: `codesign-${stamp}.${ext}`,
+          ...(activeDesign?.workspacePath ? { workspacePath: activeDesign.workspacePath } : {}),
+          sourcePath: resolved.path,
         });
         if (res.status === 'saved' && res.path) {
           set({ toastMessage: tr('notifications.exportedTo', { path: res.path }) });

--- a/packages/exporters/src/assets.test.ts
+++ b/packages/exporters/src/assets.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  collectLocalAssetsFromHtml,
+  inlineLocalAssetsInHtml,
+  rewriteHtmlLocalAssetReferences,
+} from './assets';
+
+let tempDir = '';
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'codesign-assets-test-'));
+  mkdirSync(join(tempDir, 'assets', 'fonts'), { recursive: true });
+  writeFileSync(join(tempDir, 'assets', 'logo.svg'), '<svg><title>Logo</title></svg>');
+  writeFileSync(join(tempDir, 'assets', 'fonts', 'demo.woff2'), Buffer.from([1, 2, 3]));
+  writeFileSync(
+    join(tempDir, 'assets', 'site.css'),
+    '@font-face{src:url("./fonts/demo.woff2")} body{background:url("/assets/logo.svg")}',
+  );
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('local exporter assets', () => {
+  it('inlines local HTML and nested CSS assets as data URIs', async () => {
+    const out = await inlineLocalAssetsInHtml(
+      '<link rel="stylesheet" href="assets/site.css"><img src="assets/logo.svg">',
+      { assetBasePath: tempDir, assetRootPath: tempDir },
+    );
+
+    expect(out).toContain('href="data:text/css;charset=utf-8,');
+    expect(decodeURIComponent(out)).toContain('data:font/woff2;base64,AQID');
+    expect(out).toContain('src="data:image/svg+xml;charset=utf-8,');
+  });
+
+  it('collects local HTML and nested CSS references for ZIP exports', async () => {
+    const assets = await collectLocalAssetsFromHtml(
+      '<link rel="stylesheet" href="assets/site.css"><img src="/assets/logo.svg">',
+      { assetBasePath: tempDir, assetRootPath: tempDir },
+    );
+
+    expect(assets.map((asset) => asset.path)).toEqual([
+      'assets/fonts/demo.woff2',
+      'assets/logo.svg',
+      'assets/site.css',
+    ]);
+  });
+
+  it('rewrites root-relative local paths to archive-relative paths', () => {
+    const out = rewriteHtmlLocalAssetReferences('<img src="/assets/logo.svg?v=1">', {
+      assetBasePath: tempDir,
+      assetRootPath: tempDir,
+    });
+
+    expect(out).toContain('src="assets/logo.svg?v=1"');
+  });
+});

--- a/packages/exporters/src/assets.ts
+++ b/packages/exporters/src/assets.ts
@@ -1,0 +1,488 @@
+import path from 'node:path';
+
+export interface LocalAssetOptions {
+  /** Directory used to resolve relative HTML references. */
+  assetBasePath?: string | undefined;
+  /** Workspace/root directory used for root-relative references and containment. */
+  assetRootPath?: string | undefined;
+}
+
+export interface CollectedAsset {
+  path: string;
+  content: Buffer;
+}
+
+interface ResolvedAssetReference {
+  suffix: string;
+  absolutePath: string;
+  archivePath: string;
+}
+
+interface Replacement {
+  start: number;
+  end: number;
+  value: string;
+}
+
+const URL_FUNC_RE = /url\(\s*(["']?)([^"')]+)\1\s*\)/gi;
+const RESOURCE_ATTR_RE = /\b(src|href|poster)\s*=\s*(["'])([^"']+)\2/gi;
+const SRCSET_ATTR_RE = /\bsrcset\s*=\s*(["'])([^"']+)\1/gi;
+
+const TEXT_ENCODINGS = new Set([
+  '.css',
+  '.csv',
+  '.html',
+  '.htm',
+  '.js',
+  '.json',
+  '.mjs',
+  '.svg',
+  '.txt',
+  '.xml',
+]);
+
+export async function inlineLocalAssetsInHtml(
+  html: string,
+  opts: LocalAssetOptions = {},
+): Promise<string> {
+  const root = resolveRoot(opts);
+  if (root === null) return html;
+
+  const replacements: Replacement[] = [];
+  await collectAttributeInlineReplacements(html, root, replacements);
+  await collectSrcsetInlineReplacements(html, root, replacements);
+  await collectCssUrlReplacements(html, root, root.basePath, replacements, new Set());
+  return applyReplacements(html, replacements);
+}
+
+export async function collectLocalAssetsFromHtml(
+  html: string,
+  opts: LocalAssetOptions = {},
+): Promise<CollectedAsset[]> {
+  const fs = await import('node:fs/promises');
+  const root = resolveRoot(opts);
+  if (root === null) return [];
+
+  const refs = collectHtmlReferences(html, root, root.basePath);
+  const assets = new Map<string, CollectedAsset>();
+  const seenCss = new Set<string>();
+
+  for (const ref of refs) {
+    await collectAssetTree(ref, root, assets, seenCss);
+  }
+
+  return [...assets.values()].sort((a, b) => a.path.localeCompare(b.path));
+
+  async function collectAssetTree(
+    ref: ResolvedAssetReference,
+    rootPaths: ResolvedRoot,
+    out: Map<string, CollectedAsset>,
+    cssSeen: Set<string>,
+  ): Promise<void> {
+    if (out.has(ref.archivePath)) return;
+    try {
+      const content = await fs.readFile(ref.absolutePath);
+      out.set(ref.archivePath, { path: ref.archivePath, content });
+      if (
+        path.extname(ref.absolutePath).toLowerCase() === '.css' &&
+        !cssSeen.has(ref.absolutePath)
+      ) {
+        cssSeen.add(ref.absolutePath);
+        const css = content.toString('utf8');
+        const nested = collectCssReferences(css, rootPaths, path.dirname(ref.absolutePath));
+        for (const child of nested) {
+          await collectAssetTree(child, rootPaths, out, cssSeen);
+        }
+      }
+    } catch {
+      // Missing local references are left as-is in the exported HTML/ZIP.
+    }
+  }
+}
+
+export function rewriteHtmlLocalAssetReferences(
+  html: string,
+  opts: LocalAssetOptions = {},
+): string {
+  const root = resolveRoot(opts);
+  if (root === null) return html;
+
+  const replacements: Replacement[] = [];
+
+  const attrRe = cloneGlobalRe(RESOURCE_ATTR_RE);
+  let attr: RegExpExecArray | null = attrRe.exec(html);
+  while (attr !== null) {
+    const raw = attr[3] ?? '';
+    const resolved = resolveAssetReference(raw, root, root.basePath);
+    if (resolved !== null) {
+      const valueStart = attr.index + (attr[0]?.lastIndexOf(raw) ?? -1);
+      if (valueStart >= attr.index) {
+        replacements.push({
+          start: valueStart,
+          end: valueStart + raw.length,
+          value: `${resolved.archivePath}${resolved.suffix}`,
+        });
+      }
+    }
+    attr = attrRe.exec(html);
+  }
+
+  const srcsetRe = cloneGlobalRe(SRCSET_ATTR_RE);
+  let srcset: RegExpExecArray | null = srcsetRe.exec(html);
+  while (srcset !== null) {
+    const raw = srcset[2] ?? '';
+    const rewritten = rewriteSrcset(raw, root, root.basePath);
+    if (rewritten !== raw) {
+      const valueStart = srcset.index + (srcset[0]?.lastIndexOf(raw) ?? -1);
+      if (valueStart >= srcset.index) {
+        replacements.push({ start: valueStart, end: valueStart + raw.length, value: rewritten });
+      }
+    }
+    srcset = srcsetRe.exec(html);
+  }
+
+  const urlRe = cloneGlobalRe(URL_FUNC_RE);
+  let css: RegExpExecArray | null = urlRe.exec(html);
+  while (css !== null) {
+    const raw = (css[2] ?? '').trim();
+    const resolved = resolveAssetReference(raw, root, root.basePath);
+    if (resolved !== null) {
+      replacements.push({
+        start: css.index,
+        end: css.index + (css[0]?.length ?? 0),
+        value: `url("${resolved.archivePath}${resolved.suffix}")`,
+      });
+    }
+    css = urlRe.exec(html);
+  }
+
+  return applyReplacements(html, replacements);
+}
+
+interface ResolvedRoot {
+  rootPath: string;
+  basePath: string;
+}
+
+function resolveRoot(opts: LocalAssetOptions): ResolvedRoot | null {
+  const base = opts.assetBasePath ?? opts.assetRootPath;
+  if (!base) return null;
+  const root = opts.assetRootPath ?? base;
+  const rootPath = path.resolve(root);
+  const basePath = path.resolve(base);
+  if (!isInsideRoot(basePath, rootPath)) return null;
+  return { rootPath, basePath };
+}
+
+function collectHtmlReferences(
+  html: string,
+  root: ResolvedRoot,
+  contextDir: string,
+): ResolvedAssetReference[] {
+  const refs: ResolvedAssetReference[] = [];
+
+  const attrRe = cloneGlobalRe(RESOURCE_ATTR_RE);
+  let attr: RegExpExecArray | null = attrRe.exec(html);
+  while (attr !== null) {
+    const ref = resolveAssetReference(attr[3] ?? '', root, contextDir);
+    if (ref !== null) refs.push(ref);
+    attr = attrRe.exec(html);
+  }
+
+  const srcsetRe = cloneGlobalRe(SRCSET_ATTR_RE);
+  let srcset: RegExpExecArray | null = srcsetRe.exec(html);
+  while (srcset !== null) {
+    refs.push(...resolveSrcset(srcset[2] ?? '', root, contextDir));
+    srcset = srcsetRe.exec(html);
+  }
+
+  refs.push(...collectCssReferences(html, root, contextDir));
+  return refs;
+}
+
+function collectCssReferences(
+  css: string,
+  root: ResolvedRoot,
+  contextDir: string,
+): ResolvedAssetReference[] {
+  const refs: ResolvedAssetReference[] = [];
+  const urlRe = cloneGlobalRe(URL_FUNC_RE);
+  let match: RegExpExecArray | null = urlRe.exec(css);
+  while (match !== null) {
+    const ref = resolveAssetReference((match[2] ?? '').trim(), root, contextDir);
+    if (ref !== null) refs.push(ref);
+    match = urlRe.exec(css);
+  }
+  return refs;
+}
+
+async function collectAttributeInlineReplacements(
+  html: string,
+  root: ResolvedRoot,
+  replacements: Replacement[],
+): Promise<void> {
+  const attrRe = cloneGlobalRe(RESOURCE_ATTR_RE);
+  let attr: RegExpExecArray | null = attrRe.exec(html);
+  while (attr !== null) {
+    const raw = attr[3] ?? '';
+    const valueStart = attr.index + (attr[0]?.lastIndexOf(raw) ?? -1);
+    const dataUri = await readReferenceAsDataUri(raw, root, root.basePath, new Set());
+    if (valueStart >= attr.index && dataUri !== null) {
+      replacements.push({
+        start: valueStart,
+        end: valueStart + raw.length,
+        value: dataUri,
+      });
+    }
+    attr = attrRe.exec(html);
+  }
+}
+
+async function collectSrcsetInlineReplacements(
+  html: string,
+  root: ResolvedRoot,
+  replacements: Replacement[],
+): Promise<void> {
+  const srcsetRe = cloneGlobalRe(SRCSET_ATTR_RE);
+  let srcset: RegExpExecArray | null = srcsetRe.exec(html);
+  while (srcset !== null) {
+    const raw = srcset[2] ?? '';
+    const valueStart = srcset.index + (srcset[0]?.lastIndexOf(raw) ?? -1);
+    const rewritten = await rewriteSrcsetToDataUri(raw, root, root.basePath, new Set());
+    if (valueStart >= srcset.index && rewritten !== raw) {
+      replacements.push({ start: valueStart, end: valueStart + raw.length, value: rewritten });
+    }
+    srcset = srcsetRe.exec(html);
+  }
+}
+
+async function collectCssUrlReplacements(
+  input: string,
+  root: ResolvedRoot,
+  contextDir: string,
+  replacements: Replacement[],
+  seen: Set<string>,
+): Promise<void> {
+  const urlRe = cloneGlobalRe(URL_FUNC_RE);
+  let match: RegExpExecArray | null = urlRe.exec(input);
+  while (match !== null) {
+    const raw = (match[2] ?? '').trim();
+    const dataUri = await readReferenceAsDataUri(raw, root, contextDir, seen);
+    if (dataUri !== null) {
+      replacements.push({
+        start: match.index,
+        end: match.index + (match[0]?.length ?? 0),
+        value: `url("${dataUri}")`,
+      });
+    }
+    match = urlRe.exec(input);
+  }
+}
+
+async function readReferenceAsDataUri(
+  raw: string,
+  root: ResolvedRoot,
+  contextDir: string,
+  seen: Set<string>,
+): Promise<string | null> {
+  const fs = await import('node:fs/promises');
+  const ref = resolveAssetReference(raw, root, contextDir);
+  if (ref === null) return null;
+  try {
+    const ext = path.extname(ref.absolutePath).toLowerCase();
+    let content = await fs.readFile(ref.absolutePath);
+    if (ext === '.css' && !seen.has(ref.absolutePath)) {
+      seen.add(ref.absolutePath);
+      const css = await inlineCssUrls(
+        content.toString('utf8'),
+        root,
+        path.dirname(ref.absolutePath),
+        seen,
+      );
+      content = Buffer.from(css, 'utf8');
+    }
+    return toDataUri(content, mimeForPath(ref.absolutePath), shouldEncodeAsText(ref.absolutePath));
+  } catch {
+    return null;
+  }
+}
+
+async function inlineCssUrls(
+  css: string,
+  root: ResolvedRoot,
+  contextDir: string,
+  seen: Set<string>,
+): Promise<string> {
+  const replacements: Replacement[] = [];
+  await collectCssUrlReplacements(css, root, contextDir, replacements, seen);
+  return applyReplacements(css, replacements);
+}
+
+function resolveSrcset(
+  raw: string,
+  root: ResolvedRoot,
+  contextDir: string,
+): ResolvedAssetReference[] {
+  return parseSrcset(raw)
+    .map((candidate) => resolveAssetReference(candidate.url, root, contextDir))
+    .filter((ref): ref is ResolvedAssetReference => ref !== null);
+}
+
+async function rewriteSrcsetToDataUri(
+  raw: string,
+  root: ResolvedRoot,
+  contextDir: string,
+  seen: Set<string>,
+): Promise<string> {
+  const candidates = parseSrcset(raw);
+  const rewritten: string[] = [];
+  for (const candidate of candidates) {
+    const dataUri = await readReferenceAsDataUri(candidate.url, root, contextDir, seen);
+    rewritten.push(`${dataUri ?? candidate.url}${candidate.descriptor}`);
+  }
+  return rewritten.join(', ');
+}
+
+function rewriteSrcset(raw: string, root: ResolvedRoot, contextDir: string): string {
+  return parseSrcset(raw)
+    .map((candidate) => {
+      const ref = resolveAssetReference(candidate.url, root, contextDir);
+      return `${ref ? `${ref.archivePath}${ref.suffix}` : candidate.url}${candidate.descriptor}`;
+    })
+    .join(', ');
+}
+
+function parseSrcset(raw: string): Array<{ url: string; descriptor: string }> {
+  return raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const firstSpace = part.search(/\s/u);
+      if (firstSpace < 0) return { url: part, descriptor: '' };
+      return {
+        url: part.slice(0, firstSpace),
+        descriptor: part.slice(firstSpace),
+      };
+    });
+}
+
+function resolveAssetReference(
+  rawInput: string,
+  root: ResolvedRoot,
+  contextDir: string,
+): ResolvedAssetReference | null {
+  const raw = rawInput.trim();
+  if (!isLocalReference(raw)) return null;
+
+  const { pathOnly, suffix } = splitReferenceSuffix(raw);
+  const decoded = safeDecodePath(pathOnly);
+  const normalizedPath = decoded.replace(/\\/g, '/');
+  const relativePath = normalizedPath.replace(/^\/+/, '');
+  const absolutePath = path.resolve(
+    normalizedPath.startsWith('/') ? root.rootPath : contextDir,
+    relativePath,
+  );
+  if (!isInsideRoot(absolutePath, root.rootPath)) return null;
+  const archivePath = path.relative(root.rootPath, absolutePath).replace(/\\/g, '/');
+  if (!archivePath || archivePath.startsWith('../')) return null;
+  return { suffix, absolutePath, archivePath };
+}
+
+function isLocalReference(raw: string): boolean {
+  const value = raw.trim();
+  if (!value || value.startsWith('#') || value.startsWith('//')) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/u.test(value)) return false;
+  return true;
+}
+
+function splitReferenceSuffix(raw: string): { pathOnly: string; suffix: string } {
+  const query = raw.indexOf('?');
+  const hash = raw.indexOf('#');
+  const indexes = [query, hash].filter((index) => index >= 0);
+  if (indexes.length === 0) return { pathOnly: raw, suffix: '' };
+  const splitAt = Math.min(...indexes);
+  return {
+    pathOnly: raw.slice(0, splitAt),
+    suffix: raw.slice(splitAt),
+  };
+}
+
+function safeDecodePath(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function isInsideRoot(candidate: string, root: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function applyReplacements(input: string, replacements: Replacement[]): string {
+  const sorted = replacements
+    .filter((r) => r.start >= 0 && r.end >= r.start)
+    .sort((a, b) => b.start - a.start);
+  let out = input;
+  for (const replacement of sorted) {
+    out = `${out.slice(0, replacement.start)}${replacement.value}${out.slice(replacement.end)}`;
+  }
+  return out;
+}
+
+function toDataUri(content: Buffer, mime: string, encodeAsText: boolean): string {
+  if (!encodeAsText) return `data:${mime};base64,${content.toString('base64')}`;
+  return `data:${mime};charset=utf-8,${encodeURIComponent(content.toString('utf8'))}`;
+}
+
+function shouldEncodeAsText(filePath: string): boolean {
+  return TEXT_ENCODINGS.has(path.extname(filePath).toLowerCase());
+}
+
+function mimeForPath(filePath: string): string {
+  switch (path.extname(filePath).toLowerCase()) {
+    case '.avif':
+      return 'image/avif';
+    case '.bmp':
+      return 'image/bmp';
+    case '.css':
+      return 'text/css';
+    case '.gif':
+      return 'image/gif';
+    case '.html':
+    case '.htm':
+      return 'text/html';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.js':
+    case '.mjs':
+      return 'text/javascript';
+    case '.json':
+      return 'application/json';
+    case '.otf':
+      return 'font/otf';
+    case '.png':
+      return 'image/png';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.ttf':
+      return 'font/ttf';
+    case '.txt':
+      return 'text/plain';
+    case '.webp':
+      return 'image/webp';
+    case '.woff':
+      return 'font/woff';
+    case '.woff2':
+      return 'font/woff2';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function cloneGlobalRe(re: RegExp): RegExp {
+  return new RegExp(re.source, re.flags);
+}

--- a/packages/exporters/src/html.test.ts
+++ b/packages/exporters/src/html.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from 'vitest';
-import { buildHtmlDocument } from './html';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildHtmlDocument, exportHtml } from './html';
+
+let tempDir = '';
+
+beforeAll(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'codesign-html-test-'));
+  mkdirSync(join(tempDir, 'assets'), { recursive: true });
+  writeFileSync(join(tempDir, 'assets', 'logo.svg'), '<svg></svg>');
+});
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
 
 describe('buildHtmlDocument', () => {
   it('exports JSX source as browser-openable HTML with the standalone runtime', () => {
@@ -12,5 +27,18 @@ describe('buildHtmlDocument', () => {
     expect(out).toContain('window.Babel.transform');
     expect(out).toContain('https://cdn.tailwindcss.com');
     expect(out).not.toContain('CODESIGN_OVERLAY_SCRIPT');
+  });
+
+  it('writes a self-contained HTML file with local assets inlined', async () => {
+    const dest = join(tempDir, 'out.html');
+    await exportHtml('<img src="assets/logo.svg">', dest, {
+      assetBasePath: tempDir,
+      assetRootPath: tempDir,
+      prettify: false,
+    });
+
+    const out = readFileSync(dest, 'utf8');
+    expect(out).toContain('src="data:image/svg+xml;charset=utf-8,');
+    expect(out).not.toContain('src="assets/logo.svg"');
   });
 });

--- a/packages/exporters/src/html.ts
+++ b/packages/exporters/src/html.ts
@@ -5,14 +5,17 @@ import {
   insertAfterHtmlStartTag,
   transformHtmlElementBlocks,
 } from '@open-codesign/shared/html-utils';
+import { inlineLocalAssetsInHtml, type LocalAssetOptions } from './assets';
 import type { ExportResult } from './index';
 
 const TAILWIND_CDN = 'https://cdn.tailwindcss.com';
 const TAILWIND_TAG = `<script src="${TAILWIND_CDN}"></script>`;
 
-export interface ExportHtmlOptions {
+export interface ExportHtmlOptions extends LocalAssetOptions {
   /** Inject the Tailwind CDN script if missing. Defaults to true. */
   injectTailwind?: boolean;
+  /** Inline local src/href/url() references as data URIs when assetBasePath is set. */
+  inlineLocalAssets?: boolean;
   /** Prettify with two-space indentation. Defaults to true. */
   prettify?: boolean;
   /** Comment banner injected at the top of the file. */
@@ -21,12 +24,13 @@ export interface ExportHtmlOptions {
 
 /**
  * Export an HTML artifact to disk as a single self-contained file.
+ * Workspace-local src/href/url() references are inlined when the caller
+ * provides asset paths.
  *
- * Tier 1 inlines what we can do without parsing the DOM: the Tailwind CDN
- * tag, a doctype, a viewport meta, and a small comment banner. Anything that
- * needs a real HTML parser (font subsetting, SVG inlining, JS bundling) waits
- * for Tier 2 — and is loud about it: never silently skip work the caller
- * believed we did.
+ * The document shell still injects the Tailwind CDN
+ * tag, a doctype, a viewport meta, and a small comment banner. Remote assets
+ * still depend on network availability; local workspace references are handled
+ * during export.
  */
 export async function exportHtml(
   htmlContent: string,
@@ -34,7 +38,10 @@ export async function exportHtml(
   opts: ExportHtmlOptions = {},
 ): Promise<ExportResult> {
   const fs = await import('node:fs/promises');
-  const final = buildHtmlDocument(htmlContent, opts);
+  let final = buildHtmlDocument(htmlContent, opts);
+  if (opts.inlineLocalAssets ?? true) {
+    final = await inlineLocalAssetsInHtml(final, opts);
+  }
   await fs.writeFile(destinationPath, final, 'utf8');
   const stat = await fs.stat(destinationPath);
   return { bytes: stat.size, path: destinationPath };

--- a/packages/exporters/src/index.ts
+++ b/packages/exporters/src/index.ts
@@ -13,8 +13,10 @@ export const EXPORTER_FORMATS = ['html', 'pdf', 'pptx', 'zip', 'markdown'] as co
 export type ExporterFormat = (typeof EXPORTER_FORMATS)[number];
 
 export interface ExportOptions {
-  artifactId: string;
-  destinationPath: string;
+  /** Directory used to resolve relative HTML asset references during export. */
+  assetBasePath?: string | undefined;
+  /** Workspace/root directory used for root-relative references and containment. */
+  assetRootPath?: string | undefined;
 }
 
 export interface ExportResult {
@@ -26,6 +28,7 @@ export function isExporterReady(_format: ExporterFormat): boolean {
   return true;
 }
 
+export type { LocalAssetOptions } from './assets';
 export { type ChromeDiscoveryDeps, findSystemChrome } from './chrome-discovery';
 export type { ExportHtmlOptions } from './html';
 export type { ExportMarkdownOptions, MarkdownMeta } from './markdown';
@@ -47,21 +50,22 @@ export async function exportArtifact(
   format: ExporterFormat,
   htmlContent: string,
   destinationPath: string,
+  opts: ExportOptions = {},
 ): Promise<ExportResult> {
   if (format === 'html') {
-    return exportHtml(htmlContent, destinationPath);
+    return exportHtml(htmlContent, destinationPath, opts);
   }
   if (format === 'pdf') {
     const mod = await import('./pdf');
-    return mod.exportPdf(htmlContent, destinationPath);
+    return mod.exportPdf(htmlContent, destinationPath, opts);
   }
   if (format === 'pptx') {
     const mod = await import('./pptx');
-    return mod.exportPptx(htmlContent, destinationPath);
+    return mod.exportPptx(htmlContent, destinationPath, opts);
   }
   if (format === 'zip') {
     const mod = await import('./zip');
-    return mod.exportZip(htmlContent, destinationPath);
+    return mod.exportZip(htmlContent, destinationPath, opts);
   }
   if (format === 'markdown') {
     const mod = await import('./markdown');

--- a/packages/exporters/src/markdown.test.ts
+++ b/packages/exporters/src/markdown.test.ts
@@ -42,6 +42,26 @@ describe('htmlToMarkdown', () => {
     expect(ol).toContain('2. y');
   });
 
+  it('converts tables without flattening rows into paragraphs', () => {
+    const out = htmlToMarkdown(
+      '<table><tr><th>Name</th><th>Score</th></tr><tr><td>Ada</td><td>10</td></tr></table>',
+      META,
+    );
+
+    expect(out).toContain('| Name | Score |');
+    expect(out).toContain('| --- | --- |');
+    expect(out).toContain('| Ada | 10 |');
+  });
+
+  it('escapes table cell pipes and backslashes', () => {
+    const out = htmlToMarkdown(
+      '<table><tr><th>Path</th></tr><tr><td>C:\\temp|draft</td></tr></table>',
+      META,
+    );
+
+    expect(out).toContain('| C:\\\\temp\\|draft |');
+  });
+
   it('converts strong/em/code/pre', () => {
     const out = htmlToMarkdown(
       '<p><strong>bold</strong> and <em>italic</em> with <code>x</code></p><pre>line1\nline2</pre>',

--- a/packages/exporters/src/markdown.ts
+++ b/packages/exporters/src/markdown.ts
@@ -120,6 +120,10 @@ function convertBody(html: string): string {
     return safeSrc ? `![${alt}](${safeSrc})` : '';
   });
 
+  out = out.replace(/<table\b[^>]*>([\s\S]*?)<\/table>/gi, (_m, inner: string) => {
+    return renderTable(inner);
+  });
+
   out = out.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, level: string, inner: string) => {
     const hashes = '#'.repeat(Number(level));
     return `\n\n${hashes} ${decodeEntities(stripTags(inner)).trim()}\n\n`;
@@ -159,6 +163,41 @@ function renderList(inner: string, ordered: boolean): string {
     m = re.exec(inner);
   }
   return `\n\n${items.join('\n')}\n\n`;
+}
+
+function renderTable(inner: string): string {
+  const rows: string[][] = [];
+  const trRe = /<tr\b[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch: RegExpExecArray | null = trRe.exec(inner);
+  while (rowMatch !== null) {
+    const cells: string[] = [];
+    const cellRe = /<t[hd]\b[^>]*>([\s\S]*?)<\/t[hd]>/gi;
+    let cellMatch: RegExpExecArray | null = cellRe.exec(rowMatch[1] ?? '');
+    while (cellMatch !== null) {
+      const cell = escapeMarkdownTableCell(
+        collapseWhitespace(decodeEntities(stripTags(cellMatch[1] ?? ''))).trim(),
+      );
+      cells.push(cell);
+      cellMatch = cellRe.exec(rowMatch[1] ?? '');
+    }
+    if (cells.length > 0) rows.push(cells);
+    rowMatch = trRe.exec(inner);
+  }
+  if (rows.length === 0) return '';
+
+  const width = Math.max(...rows.map((row) => row.length));
+  const padded = rows.map((row) => [
+    ...row,
+    ...Array.from({ length: width - row.length }, () => ''),
+  ]);
+  const header = padded[0] ?? [];
+  const separator = Array.from({ length: width }, () => '---');
+  const body = padded.slice(1);
+  return `\n\n${[header, separator, ...body].map((row) => `| ${row.join(' | ')} |`).join('\n')}\n\n`;
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
 function stripTags(input: string): string {

--- a/packages/exporters/src/pdf.test.ts
+++ b/packages/exporters/src/pdf.test.ts
@@ -97,4 +97,26 @@ describe('exportPdf', () => {
     },
     CHROME_TEST_TIMEOUT_MS,
   );
+
+  it(
+    'passes header and footer options through to Chrome PDF rendering',
+    async () => {
+      pdfMock.mockClear();
+      const { exportPdf } = await import('./pdf');
+      await exportPdf('<p>x</p>', join(tempDir, 'header.pdf'), {
+        chromePath: '/tmp/fake-chrome',
+        headerTemplate: '<span class="title">Title</span>',
+        footerTemplate: '<span class="pageNumber"></span>',
+      });
+
+      expect(pdfMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayHeaderFooter: true,
+          headerTemplate: '<span class="title">Title</span>',
+          footerTemplate: '<span class="pageNumber"></span>',
+        }),
+      );
+    },
+    CHROME_TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/exporters/src/pdf.ts
+++ b/packages/exporters/src/pdf.ts
@@ -2,9 +2,10 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
+import { inlineLocalAssetsInHtml, type LocalAssetOptions } from './assets';
 import type { ExportResult } from './index';
 
-export interface ExportPdfOptions {
+export interface ExportPdfOptions extends LocalAssetOptions {
   /** Override the discovered Chrome binary path. Useful for tests / CI. */
   chromePath?: string;
   /**
@@ -13,14 +14,37 @@ export interface ExportPdfOptions {
    * for HTML prototypes that aren't paginated.
    */
   format?: 'Letter' | 'A4' | 'auto';
+  /** Puppeteer navigation wait strategy. Defaults to networkidle0. */
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+  /** setContent timeout in milliseconds. Defaults to 45 seconds. */
+  renderTimeoutMs?: number;
+  /** Extra delay after fonts/layout settle, useful for lazy UI. Defaults to 0. */
+  settleMs?: number;
+  /** Enable Puppeteer's header/footer rendering. */
+  displayHeaderFooter?: boolean;
+  /** HTML template for the printed header. */
+  headerTemplate?: string;
+  /** HTML template for the printed footer. */
+  footerTemplate?: string;
+  /** PDF margins. Header/footer exports get a small default margin. */
+  margin?: {
+    top?: string;
+    right?: string;
+    bottom?: string;
+    left?: string;
+  };
+  /** Inline local src/href/url() references as data URIs when assetBasePath is set. */
+  inlineLocalAssets?: boolean;
 }
 
 const DEFAULT_VIEWPORT = { width: 1280, height: 800 } as const;
 
 /**
  * Render an HTML string to PDF via the user's installed Chrome.
+ * Local workspace assets are inlined before rendering when the caller provides
+ * asset paths; optional header/footer templates are passed through to Chrome.
  *
- * Tier 1: no header/footer, no font embedding, no PDF tagging. We deliberately
+ * The remaining limitations are font embedding and PDF tagging. We deliberately
  * avoid Puppeteer's full distribution (~150 MB Chromium download) — `puppeteer-core`
  * connects to the system Chrome we discover at runtime. PRINCIPLES §1 + §10.
  */
@@ -56,18 +80,44 @@ export async function exportPdf(
     });
     const page = await browser.newPage();
     await page.setViewport(DEFAULT_VIEWPORT);
-    await page.setContent(htmlContent, { waitUntil: 'networkidle0', timeout: 30_000 });
+    const exportHtml =
+      (opts.inlineLocalAssets ?? true)
+        ? await inlineLocalAssetsInHtml(htmlContent, opts)
+        : htmlContent;
+    await page.setContent(exportHtml, {
+      waitUntil: opts.waitUntil ?? 'networkidle0',
+      timeout: opts.renderTimeoutMs ?? 45_000,
+    });
+    await page.evaluate('document.fonts?.ready ?? Promise.resolve()');
+    if (opts.settleMs && opts.settleMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, opts.settleMs));
+    }
 
     const format = opts.format ?? 'Letter';
+    const displayHeaderFooter =
+      opts.displayHeaderFooter ??
+      (opts.headerTemplate !== undefined || opts.footerTemplate !== undefined);
+    const margin =
+      opts.margin ??
+      (displayHeaderFooter
+        ? { top: '0.45in', right: '0.35in', bottom: '0.45in', left: '0.35in' }
+        : undefined);
+    const sharedPdfOptions = {
+      printBackground: true,
+      displayHeaderFooter,
+      headerTemplate: opts.headerTemplate ?? '<span></span>',
+      footerTemplate: opts.footerTemplate ?? '<span></span>',
+      ...(margin ? { margin } : {}),
+    };
     const pdfBuf =
       format === 'auto'
         ? await page.pdf({
-            printBackground: true,
+            ...sharedPdfOptions,
             width: `${DEFAULT_VIEWPORT.width}px`,
             height: `${await page.evaluate('document.documentElement.scrollHeight')}px`,
-            margin: { top: '0', right: '0', bottom: '0', left: '0' },
+            margin: margin ?? { top: '0', right: '0', bottom: '0', left: '0' },
           })
-        : await page.pdf({ printBackground: true, format, preferCSSPageSize: true });
+        : await page.pdf({ ...sharedPdfOptions, format, preferCSSPageSize: true });
 
     await fs.writeFile(destinationPath, pdfBuf);
     const stat = await fs.stat(destinationPath);

--- a/packages/exporters/src/pptx.test.ts
+++ b/packages/exporters/src/pptx.test.ts
@@ -1,13 +1,50 @@
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { exportPptx, extractSlides } from './pptx';
+
+const pngBytes = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+const launchMock = vi.fn();
+const newPageMock = vi.fn();
+const setViewportMock = vi.fn();
+const setContentMock = vi.fn();
+const evaluateMock = vi.fn();
+const screenshotMock = vi.fn();
+const closeMock = vi.fn();
+const sectionBoundingBoxMock = vi.fn();
+const querySectionsMock = vi.fn();
+
+vi.mock('puppeteer-core', () => ({
+  default: { launch: launchMock },
+}));
+
+vi.mock('./chrome-discovery', () => ({
+  findSystemChrome: vi.fn(async () => '/tmp/fake-chrome'),
+}));
 
 let tempDir = '';
 
 beforeAll(() => {
   tempDir = mkdtempSync(join(tmpdir(), 'codesign-pptx-test-'));
+  launchMock.mockResolvedValue({
+    newPage: newPageMock,
+    close: closeMock,
+  });
+  newPageMock.mockResolvedValue({
+    setViewport: setViewportMock,
+    setContent: setContentMock,
+    evaluate: evaluateMock,
+    screenshot: screenshotMock,
+    $$: querySectionsMock,
+  });
+  evaluateMock.mockResolvedValue(undefined);
+  screenshotMock.mockResolvedValue(pngBytes);
+  sectionBoundingBoxMock.mockResolvedValue({ x: 0, y: 0, width: 1280, height: 720 });
+  querySectionsMock.mockResolvedValue([{ boundingBox: sectionBoundingBoxMock }]);
 });
 
 afterAll(() => {
@@ -50,7 +87,7 @@ describe('exportPptx', () => {
     const result = await exportPptx(
       '<section><h1>你好世界</h1><p>第一张幻灯片</p></section>',
       dest,
-      { deckTitle: 'CJK smoke test' },
+      { deckTitle: 'CJK smoke test', renderMode: 'editable' },
     );
 
     expect(existsSync(dest)).toBe(true);
@@ -66,7 +103,23 @@ describe('exportPptx', () => {
 
   it('throws EXPORTER_PPTX_FAILED on writeFile errors', async () => {
     await expect(
-      exportPptx('<section>x</section>', join(tempDir, 'nope', 'missing-dir', 'fail.pptx')),
+      exportPptx('<section>x</section>', join(tempDir, 'nope', 'missing-dir', 'fail.pptx'), {
+        renderMode: 'editable',
+      }),
     ).rejects.toMatchObject({ code: 'EXPORTER_PPTX_FAILED' });
+  });
+
+  it('renders rich HTML slides as screenshots by default', async () => {
+    const dest = join(tempDir, 'visual.pptx');
+    const result = await exportPptx('<section><h1>Visual</h1><img src="hero.png"></section>', dest);
+
+    expect(result.bytes).toBeGreaterThan(1000);
+    expect(launchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ executablePath: '/tmp/fake-chrome' }),
+    );
+    expect(querySectionsMock).toHaveBeenCalled();
+    expect(screenshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'png', clip: expect.any(Object) }),
+    );
   });
 });

--- a/packages/exporters/src/pptx.ts
+++ b/packages/exporters/src/pptx.ts
@@ -1,9 +1,22 @@
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
+import { inlineLocalAssetsInHtml, type LocalAssetOptions } from './assets';
+import { buildHtmlDocument } from './html';
 import type { ExportResult } from './index';
 
-export interface ExportPptxOptions {
+export interface ExportPptxOptions extends LocalAssetOptions {
   /** Slide title shown in PowerPoint's outline view. */
   deckTitle?: string;
+  /**
+   * `image` preserves visual fidelity by rendering HTML with system Chrome.
+   * `editable` keeps the legacy title/bullet extraction path.
+   */
+  renderMode?: 'image' | 'editable';
+  /** Override the discovered Chrome binary path for image rendering. */
+  chromePath?: string;
+  /** setContent timeout in milliseconds. Defaults to 45 seconds. */
+  renderTimeoutMs?: number;
+  /** Viewport used when rasterizing slides. */
+  viewport?: { width: number; height: number };
 }
 
 interface SlideContent {
@@ -14,8 +27,9 @@ interface SlideContent {
 /**
  * Render an HTML artifact to PPTX using pptxgenjs.
  *
- * Tier 1 strategy: walk top-level `<section>` elements (one slide each); if
- * none exist, the whole document becomes a single slide. We do NOT use
+ * Default strategy: render the artifact with system Chrome and embed screenshots
+ * so visual layout, images, tables, and CSS survive the PPTX export. The
+ * `editable` mode keeps the title/bullet extraction path. We do NOT use
  * dom-to-pptx in tier 1 — the package is unmaintained and only adds
  * editability for pure-text slides we already cover.
  *
@@ -32,45 +46,60 @@ export async function exportPptx(
   const PptxGenJS = (await import('pptxgenjs')).default;
 
   try {
-    const slides = extractSlides(htmlContent);
     const pres = new PptxGenJS();
     pres.layout = 'LAYOUT_WIDE';
     if (opts.deckTitle) pres.title = opts.deckTitle;
 
-    for (const s of slides) {
-      const slide = pres.addSlide();
-      slide.background = { color: 'FFFFFF' };
-      if (s.title) {
-        slide.addText(s.title, {
-          x: 0.5,
-          y: 0.4,
-          w: 12,
-          h: 1,
-          fontSize: 32,
-          bold: true,
-          color: '111111',
-          fontFace: 'Helvetica',
-          wrap: true,
-          fit: 'shrink',
+    if ((opts.renderMode ?? 'image') === 'image') {
+      const screenshots = await renderSlideScreenshots(htmlContent, opts);
+      for (const screenshot of screenshots) {
+        const slide = pres.addSlide();
+        slide.background = { color: 'FFFFFF' };
+        slide.addImage({
+          data: `data:image/png;base64,${Buffer.from(screenshot).toString('base64')}`,
+          x: 0,
+          y: 0,
+          w: 13.333,
+          h: 7.5,
         });
       }
-      if (s.bullets.length > 0) {
-        slide.addText(
-          s.bullets.map((b) => ({ text: b, options: { bullet: true } })),
-          {
+    } else {
+      const slides = extractSlides(htmlContent);
+      for (const s of slides) {
+        const slide = pres.addSlide();
+        slide.background = { color: 'FFFFFF' };
+        if (s.title) {
+          slide.addText(s.title, {
             x: 0.5,
-            y: 1.6,
+            y: 0.4,
             w: 12,
-            h: 5.5,
-            fontSize: 18,
-            color: '333333',
+            h: 1,
+            fontSize: 32,
+            bold: true,
+            color: '111111',
             fontFace: 'Helvetica',
             wrap: true,
             fit: 'shrink',
-            valign: 'top',
-            paraSpaceAfter: 8,
-          },
-        );
+          });
+        }
+        if (s.bullets.length > 0) {
+          slide.addText(
+            s.bullets.map((b) => ({ text: b, options: { bullet: true } })),
+            {
+              x: 0.5,
+              y: 1.6,
+              w: 12,
+              h: 5.5,
+              fontSize: 18,
+              color: '333333',
+              fontFace: 'Helvetica',
+              wrap: true,
+              fit: 'shrink',
+              valign: 'top',
+              paraSpaceAfter: 8,
+            },
+          );
+        }
       }
     }
 
@@ -83,6 +112,66 @@ export async function exportPptx(
       ERROR_CODES.EXPORTER_PPTX_FAILED,
       { cause: err },
     );
+  }
+}
+
+async function renderSlideScreenshots(
+  htmlContent: string,
+  opts: ExportPptxOptions,
+): Promise<Buffer[]> {
+  const { findSystemChrome } = await import('./chrome-discovery');
+  const puppeteer = (await import('puppeteer-core')).default;
+
+  const viewport = opts.viewport ?? { width: 1280, height: 720 };
+  const executablePath = opts.chromePath ?? (await findSystemChrome());
+  let html = buildHtmlDocument(htmlContent, { prettify: false });
+  html = await inlineLocalAssetsInHtml(html, opts);
+
+  const browser = await puppeteer.launch({
+    executablePath,
+    headless: true,
+    args: [
+      '--headless=new',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-default-browser-check',
+    ],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ ...viewport, deviceScaleFactor: 2 });
+    await page.setContent(html, {
+      waitUntil: 'networkidle0',
+      timeout: opts.renderTimeoutMs ?? 45_000,
+    });
+    await page.evaluate('document.fonts?.ready ?? Promise.resolve()');
+
+    const sectionHandles = await page.$$('section');
+    const screenshots: Buffer[] = [];
+    if (sectionHandles.length > 0) {
+      for (const section of sectionHandles) {
+        const box = await section.boundingBox();
+        if (!box || box.width <= 0 || box.height <= 0) continue;
+        const image = await page.screenshot({
+          type: 'png',
+          clip: {
+            x: Math.max(0, box.x),
+            y: Math.max(0, box.y),
+            width: Math.max(1, box.width),
+            height: Math.max(1, box.height),
+          },
+        });
+        screenshots.push(Buffer.from(image));
+      }
+    }
+    if (screenshots.length === 0) {
+      const image = await page.screenshot({ type: 'png', fullPage: true });
+      screenshots.push(Buffer.from(image));
+    }
+    return screenshots;
+  } finally {
+    await browser.close();
   }
 }
 

--- a/packages/exporters/src/zip.test.ts
+++ b/packages/exporters/src/zip.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -8,6 +16,8 @@ let tempDir = '';
 
 beforeAll(() => {
   tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'codesign-zip-test-')));
+  mkdirSync(join(tempDir, 'assets'), { recursive: true });
+  writeFileSync(join(tempDir, 'assets', 'logo.svg'), '<svg></svg>');
 });
 
 afterAll(() => {
@@ -48,6 +58,22 @@ describe('exportZip', () => {
     const dest = join(tempDir, 'minimal.zip');
     const result = await exportZip('<p>x</p>', dest);
     expect(result.bytes).toBeGreaterThan(50);
+  });
+
+  it('auto-collects local asset references and rewrites root-relative paths', async () => {
+    const dest = join(tempDir, 'auto-assets.zip');
+    await exportZip('<img src="/assets/logo.svg">', dest, {
+      assetBasePath: tempDir,
+      assetRootPath: tempDir,
+    });
+
+    const { Unzip } = await import('zip-lib');
+    const extractDir = join(tempDir, 'auto-extracted');
+    const unzip = new Unzip();
+    await unzip.extract(dest, extractDir);
+
+    expect(existsSync(join(extractDir, 'assets', 'logo.svg'))).toBe(true);
+    expect(readFileSync(join(extractDir, 'index.html'), 'utf8')).toContain('src="assets/logo.svg"');
   });
 
   it('throws EXPORTER_ZIP_FAILED when the destination cannot be written', async () => {

--- a/packages/exporters/src/zip.ts
+++ b/packages/exporters/src/zip.ts
@@ -1,4 +1,9 @@
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
+import {
+  collectLocalAssetsFromHtml,
+  type LocalAssetOptions,
+  rewriteHtmlLocalAssetReferences,
+} from './assets';
 import type { ExportResult } from './index';
 
 export interface ZipAsset {
@@ -8,9 +13,11 @@ export interface ZipAsset {
   content: Buffer | string;
 }
 
-export interface ExportZipOptions {
+export interface ExportZipOptions extends LocalAssetOptions {
   /** Extra files to bundle alongside `index.html` and the README. */
   assets?: ZipAsset[];
+  /** Automatically bundle local src/href/url() references when assetBasePath is set. */
+  collectLocalAssets?: boolean;
   /** Override the README banner. */
   readmeTitle?: string;
 }
@@ -55,8 +62,15 @@ export async function exportZip(
 
   const stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codesign-zip-'));
   try {
+    const collectedAssets =
+      (opts.collectLocalAssets ?? true) ? await collectLocalAssetsFromHtml(htmlContent, opts) : [];
+    const exportHtml =
+      (opts.collectLocalAssets ?? true)
+        ? rewriteHtmlLocalAssetReferences(htmlContent, opts)
+        : htmlContent;
+
     const indexPath = path.join(stagingDir, 'index.html');
-    await fs.writeFile(indexPath, htmlContent, 'utf8');
+    await fs.writeFile(indexPath, exportHtml, 'utf8');
 
     const readme = README_TEMPLATE(
       opts.readmeTitle ?? 'open-codesign export',
@@ -69,13 +83,16 @@ export async function exportZip(
     zip.addFile(indexPath, 'index.html');
     zip.addFile(readmePath, 'README.md');
 
-    if (opts.assets) {
+    const assets = [...collectedAssets, ...(opts.assets ?? [])];
+    if (assets.length > 0) {
       const stagingResolved = path.resolve(stagingDir);
-      for (const asset of opts.assets) {
+      const written = new Set<string>();
+      for (const asset of assets) {
         // Normalize backslashes first: on POSIX `path.resolve` treats `\` as a
         // literal char, so a Windows-style ZIP entry like `..\..\etc\passwd`
         // would slip past the containment check unless rewritten to `/`.
         const normalized = asset.path.replace(/\\/g, '/').replace(/^\/+/, '');
+        if (written.has(normalized)) continue;
         const localPath = path.resolve(stagingDir, normalized);
         const rel = path.relative(stagingResolved, localPath);
         if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
@@ -87,6 +104,7 @@ export async function exportZip(
         await fs.mkdir(path.dirname(localPath), { recursive: true });
         await fs.writeFile(localPath, asset.content);
         zip.addFile(localPath, normalized);
+        written.add(normalized);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add a shared workspace-local asset resolver for exporter HTML references (`src`, `href`, `poster`, `srcset`, and CSS `url()`).
- Inline local assets for HTML/PDF/PPTX exports and auto-bundle local assets for ZIP exports.
- Render PPTX exports as Chrome screenshots by default while keeping the legacy editable title/bullet mode available.
- Preserve Markdown tables and add PDF header/footer, wait, timeout, and settle options.
- Pass workspace/source context from the desktop export flow so exported files can resolve `assets/...` references.

Addresses #284

## Testing
- `pnpm exec biome check apps/desktop/src/main/exporter-ipc.ts apps/desktop/src/main/exporter-ipc.test.ts apps/desktop/src/preload/index.ts apps/desktop/src/renderer/src/store/slices/generation.ts packages/exporters/src/assets.ts packages/exporters/src/assets.test.ts packages/exporters/src/html.ts packages/exporters/src/html.test.ts packages/exporters/src/index.ts packages/exporters/src/markdown.ts packages/exporters/src/markdown.test.ts packages/exporters/src/pdf.ts packages/exporters/src/pdf.test.ts packages/exporters/src/pptx.ts packages/exporters/src/pptx.test.ts packages/exporters/src/zip.ts packages/exporters/src/zip.test.ts .changeset/export-fidelity-assets.md`
- `pnpm typecheck`
- `pnpm test`

## Local note
- Full `pnpm lint` is blocked in this checkout by an unrelated untracked `issues_summary.json` formatting issue. The changed files pass Biome, and CI should run on a clean checkout.