### PR TITLE
fix(providers): keep Kimi and MiniMax chat models non-reasoning

### DIFF
--- a/.changeset/non-reasoning-chat-models.md
+++ b/.changeset/non-reasoning-chat-models.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/providers": patch
+---
+
+Keep Kimi and MiniMax OpenAI Chat models on the non-reasoning system-role path so compatible gateways do not reject `developer` messages.

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -435,6 +435,51 @@ describe('complete', () => {
     expect(result.content).toBe('ok');
   });
 
+  it('synthesizes Kimi and MiniMax openai-chat models with reasoning disabled', async () => {
+    getModelMock.mockReturnValue(undefined);
+    completeSimpleMock.mockImplementation(async (model) => {
+      expect(model.reasoning).toBe(false);
+      expect(model.api).toBe('openai-completions');
+      expect(model.compat?.supportsDeveloperRole).toBe(false);
+      return {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'ok' }],
+        api: 'openai-completions',
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      };
+    });
+
+    await complete(
+      { provider: 'custom-azure-kimi', modelId: 'Kimi-K2.6-2026-04-20' },
+      [{ role: 'user', content: 'hello' }],
+      {
+        apiKey: 'sk-test',
+        wire: 'openai-chat',
+        baseUrl: 'https://services.ai.azure.com/openai/v1',
+      },
+    );
+    await complete(
+      { provider: 'custom-minimax', modelId: 'minimax/minimax-m2.7' },
+      [{ role: 'user', content: 'hello' }],
+      {
+        apiKey: 'sk-test',
+        wire: 'openai-chat',
+        baseUrl: 'https://api.minimaxi.com/v1',
+      },
+    );
+  });
+
   it('omits pi-ai reasoning option when caller explicitly sets reasoning off', async () => {
     getModelMock.mockReturnValue(undefined);
     completeSimpleMock.mockImplementationOnce(async (_model, _context, opts) => {
@@ -740,6 +785,22 @@ describe('inferReasoning', () => {
   });
 
   it('returns false for third-party openai-chat with non-reasoning model ID', () => {
+    expect(
+      inferReasoning(
+        'openai-chat',
+        'Kimi-K2.6-2026-04-20',
+        'https://services.ai.azure.com/openai/v1',
+      ),
+    ).toBe(false);
+    expect(
+      inferReasoning('openai-chat', 'moonshotai/kimi-k2-instruct', 'https://my-proxy.example/v1'),
+    ).toBe(false);
+    expect(inferReasoning('openai-chat', 'MiniMax-M2.7', 'https://api.minimaxi.com/v1')).toBe(
+      false,
+    );
+    expect(
+      inferReasoning('openai-chat', 'minimax/minimax-m2.7', 'https://api.minimaxi.com/v1'),
+    ).toBe(false);
     expect(
       inferReasoning(
         'openai-chat',

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -194,6 +194,20 @@ function isReasoningModelId(modelId: string): boolean {
 }
 
 /**
+ * Some vendors use OpenAI-compatible chat endpoints but reject the
+ * reasoning/developer-role path. Check these before the broad reasoning
+ * allowlist below so namespaced catalog IDs do not accidentally opt in.
+ */
+const OPENAI_CHAT_NON_REASONING_MODEL_PATTERN = new RegExp(
+  ['(^|/)kimi[-/]', '(^|/)moonshot[-/]', '(^|/)minimax[-/]'].join('|'),
+  'i',
+);
+
+function isKnownOpenAIChatNonReasoningModelId(modelId: string): boolean {
+  return OPENAI_CHAT_NON_REASONING_MODEL_PATTERN.test(modelId);
+}
+
+/**
  * Matches reasoning-capable model IDs commonly proxied through OpenAI-compatible
  * gateways (OpenRouter, univibe, sub2api, etc). This pattern matches the same
  * set that OPENROUTER_REASONING_MODEL_RE uses for OpenRouter, but applies to
@@ -204,7 +218,6 @@ const REASONING_MODEL_ID_PATTERN = new RegExp(
     ':thinking$',
     '(^|/)claude-(?:opus|sonnet)-4',
     '^(?:openai/)?(?:o1|o3|o4|gpt-5)(?:[-.].*)?$',
-    '^minimax/minimax-m\\d',
     '^deepseek/deepseek-r\\d',
     '^qwen/qwq',
   ].join('|'),
@@ -223,6 +236,9 @@ export function inferReasoning(
     case 'openai-codex-responses':
       return true;
     case 'openai-chat':
+      if (isKnownOpenAIChatNonReasoningModelId(modelId)) {
+        return false;
+      }
       // For official OpenAI, check both base URL and model ID pattern
       if (isOpenAIOfficial(baseUrl)) {
         return isReasoningModelId(modelId);


### PR DESCRIPTION
## Summary
- Add a non-reasoning override for Kimi, Moonshot/Kimi, and MiniMax model IDs on OpenAI Chat-compatible wires.
- Remove MiniMax from the broad third-party reasoning allowlist so `minimax/minimax-m...` no longer opts into the developer-role path.
- Add regression coverage for `Kimi-K2.6-2026-04-20`, `MiniMax-M2.7`, and `minimax/minimax-m2.7`.

Fixes #257
Fixes #234

## Testing
- `pnpm exec biome check packages/providers/src/index.ts packages/providers/src/index.test.ts .changeset/non-reasoning-chat-models.md`
- `pnpm --dir packages/providers exec vitest run src/index.test.ts`
- `pnpm --dir packages/providers exec tsc --noEmit`
- `pnpm typecheck`
- `pnpm --filter @open-codesign/desktop exec vitest run src/main/onboarding-ipc.test.ts`

## Local note
- Full `pnpm test` had one unrelated timeout in `src/main/onboarding-ipc.test.ts`; rerunning that file passed (`52 passed`). Providers tests and workspace typecheck passed.
- Full `pnpm lint` is still blocked in this checkout by an unrelated untracked `issues_summary.json`; changed files pass Biome and CI should run on a clean checkout.