### PR TITLE
fix(core): cap done repair loop

### DIFF
--- a/.changeset/done-repair-limit.md
+++ b/.changeset/done-repair-limit.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/core": patch
+---
+
+Cap repeated `done()` error rounds so verification loops stop after three failed checks.

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -71,6 +71,16 @@ interface AgentScript {
    */
   invokeGetApiKey?: boolean;
   /**
+   * Execute one configured tool during prompt(). This lets tests exercise
+   * generateViaAgent's tool wrappers without reimplementing pi-agent-core's
+   * full model/tool loop in the mock.
+   */
+  executeTool?: {
+    name: string;
+    times?: number;
+    params?: Record<string, unknown>;
+  };
+  /**
    * When set, the mock switches to `overrideScript` starting from this
    * agent-call index (0-based). Lets transport-retry tests script
    * "first agent fails, second agent succeeds" without mutating
@@ -169,6 +179,17 @@ vi.mock('@mariozechner/pi-agent-core', () => {
         }
       }
 
+      if (script.executeTool) {
+        const tool = this.call.options.initialState?.tools?.find(
+          (candidate) => candidate.name === script.executeTool?.name,
+        );
+        if (!tool) throw new Error(`scripted tool not found: ${script.executeTool.name}`);
+        const times = script.executeTool.times ?? 1;
+        for (let index = 0; index < times; index += 1) {
+          await tool.execute(`scripted-tool-${index}`, script.executeTool.params ?? {});
+        }
+      }
+
       this.emit({ type: 'agent_start' });
       this.emit({ type: 'turn_start' });
       const userMsg: AgentMessage = {
@@ -255,6 +276,7 @@ import { applyComment } from './index.js';
 const MODEL: ModelRef = { provider: 'anthropic', modelId: 'claude-sonnet-4-6' };
 
 const SAMPLE_HTML = `<!doctype html><html lang="en"><body><h1>Hi</h1></body></html>`;
+const HTML_WITH_MISSING_ALT = `<!doctype html><html lang="en"><body><img src="hero.png"></body></html>`;
 const DESIGN_SYSTEM: StoredDesignSystem = {
   schemaVersion: STORED_DESIGN_SYSTEM_SCHEMA_VERSION,
   rootPath: '/repo',
@@ -669,6 +691,61 @@ describe('generateViaAgent()', () => {
     expect(result.warnings).toEqual([expect.stringContaining('done() reported unresolved errors')]);
   });
 
+  it('terminates done after three error rounds', async () => {
+    scriptedAgent = { assistantText: RESPONSE_WITH_ARTIFACT };
+    await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+      },
+      { fs: makeStubFs({ 'index.html': HTML_WITH_MISSING_ALT }) },
+    );
+    const doneTool = agentCalls[0]?.options.initialState?.tools?.find(
+      (tool) => tool.name === 'done',
+    );
+    if (!doneTool) throw new Error('expected done tool');
+
+    const first = await doneTool.execute('done-1', { path: 'index.html' });
+    const second = await doneTool.execute('done-2', { path: 'index.html' });
+    const third = await doneTool.execute('done-3', { path: 'index.html' });
+
+    expect(first.terminate).toBeUndefined();
+    expect(second.terminate).toBeUndefined();
+    expect(third.terminate).toBe(true);
+    const thirdDetails = third.details as { status?: string; errors?: unknown[] };
+    expect(thirdDetails.status).toBe('has_errors');
+    expect(thirdDetails.errors).toHaveLength(1);
+    expect(third.content[0]?.type).toBe('text');
+    expect(JSON.stringify(third.content)).toContain(
+      'Repair limit reached after 3 done() error rounds',
+    );
+  });
+
+  it('keeps the latest artifact when the agent stops on the done repair limit', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'toolUse',
+      executeTool: { name: 'done', times: 3, params: { path: 'index.html' } },
+    };
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+        initialResourceState: resourceState({ mutationSeq: 1 }),
+      },
+      { fs: makeStubFs({ 'index.html': HTML_WITH_MISSING_ALT }) },
+    );
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.message).toContain('Stopped after 3 done() error rounds');
+    expect(result.warnings).toEqual([expect.stringContaining('done() reported unresolved errors')]);
+    expect(result.resourceState?.lastDone?.status).toBe('has_errors');
+  });
+
   it('allows a done ok state that covers the latest mutation', async () => {
     scriptedAgent = { assistantText: RESPONSE_WITH_ARTIFACT };
     const result = await generateViaAgent(
@@ -982,6 +1059,7 @@ describe('generateViaAgent()', () => {
     expect(sys).toContain('workspace file `index.html`');
     expect(sys).toContain('Local workspace assets and scaffolded files are allowed');
     expect(sys).toContain('Call `done(path)` after the final mutation');
+    expect(sys).toContain('stop after 3 error rounds');
     expect(sys).not.toContain('text_editor.create(');
     expect(sys).not.toContain('view("index.html"');
     expect(sys).not.toContain('IOSDevice, IOSStatusBar');

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -235,6 +235,8 @@ function buildPiModel(
 // active. Keeps the base prompt (shared with the non-agent path) unchanged.
 // ---------------------------------------------------------------------------
 
+const MAX_DONE_ERROR_ROUNDS = 3;
+
 const AGENTIC_TOOL_GUIDANCE = [
   '## Workspace output contract',
   '',
@@ -249,7 +251,7 @@ const AGENTIC_TOOL_GUIDANCE = [
   '2. Load optional resources explicitly with `skill(name)` or `scaffold({kind, destPath})` before relying on them.',
   '3. Write/edit `index.html`, then call `preview(path)` when available.',
   '4. Call `tweaks()` for meaningful EDITMODE controls.',
-  '5. Call `done(path)` after the final mutation. Fix errors, then call `done` again.',
+  `5. Call \`done(path)\` after the final mutation. If it reports errors, fix and retry, but stop after ${MAX_DONE_ERROR_ROUNDS} error rounds.`,
   '',
   '## File-edit discipline',
   '',
@@ -363,9 +365,12 @@ function wrapScaffoldState(
 function wrapDoneState(
   tool: AgentTool<TSchema, unknown>,
   resourceState: ResourceStateV1,
+  onRepairLimitReached?: (() => void) | undefined,
 ): AgentTool<TSchema, unknown> {
+  let errorRounds = 0;
   return {
     ...tool,
+    executionMode: 'sequential',
     async execute(id, params, signal): Promise<AgentToolResult<unknown>> {
       const result = await tool.execute(id, params, signal);
       const details = result.details as DoneDetails | undefined;
@@ -375,10 +380,41 @@ function wrapDoneState(
           path: details.path,
           errorCount: details.errors.length,
         });
+        if (details.status === 'ok') {
+          errorRounds = 0;
+        } else {
+          errorRounds += 1;
+          if (errorRounds >= MAX_DONE_ERROR_ROUNDS) {
+            onRepairLimitReached?.();
+            return {
+              ...result,
+              content: [{ type: 'text', text: formatDoneRepairLimitText(details) }],
+              terminate: true,
+            };
+          }
+        }
       }
       return result;
     },
   };
+}
+
+function formatDoneRepairLimitText(details: DoneDetails): string {
+  const remainingErrors =
+    details.errors.length === 0
+      ? ['- done() still reported errors, but no actionable verifier details were returned.']
+      : details.errors.map(
+          (error) => `- ${error.message}${error.lineno ? ` (line ${error.lineno})` : ''}`,
+        );
+  return [
+    'has_errors',
+    `Repair limit reached after ${MAX_DONE_ERROR_ROUNDS} done() error rounds.`,
+    'STOP. Do not call done, preview, edit, or any other tool again.',
+    'The host will keep the latest artifact when possible and surface these warnings to the user.',
+    '',
+    'Remaining verifier output:',
+    ...remainingErrors,
+  ].join('\n');
 }
 
 function projectContextSections(context: GenerateInput['projectContext']): string[] {
@@ -514,6 +550,7 @@ export async function generateViaAgent(
   const buildStart = Date.now();
   const resourceState = cloneResourceState(input.initialResourceState);
   const trackedFs = deps.fs ? trackFsMutations(deps.fs, resourceState) : undefined;
+  let doneRepairLimitReached = false;
   const skillsBuiltinDir = input.templatesRoot
     ? path.join(input.templatesRoot, 'skills')
     : undefined;
@@ -595,6 +632,9 @@ export async function generateViaAgent(
       wrapDoneState(
         makeDoneTool(trackedFs, deps.runtimeVerify) as unknown as AgentTool<TSchema, unknown>,
         resourceState,
+        () => {
+          doneRepairLimitReached = true;
+        },
       ),
     );
   }
@@ -866,7 +906,9 @@ export async function generateViaAgent(
   if (!finalAssistant) {
     throw new CodesignError('Agent produced no assistant message', ERROR_CODES.PROVIDER_ERROR);
   }
-  if (finalAssistant.stopReason !== 'stop') {
+  const stoppedAfterDoneRepairLimit =
+    doneRepairLimitReached && finalAssistant.stopReason === 'toolUse';
+  if (finalAssistant.stopReason !== 'stop' && !stoppedAfterDoneRepairLimit) {
     // Prefer the original `getApiKey` throw (e.g. PROVIDER_AUTH_MISSING after
     // mid-run logout) over pi-agent-core's flattened plain-string failure,
     // so the renderer's error-code routing stays consistent with the path
@@ -902,13 +944,15 @@ export async function generateViaAgent(
 
   log.info('[generate] step=parse_response', ctx);
   const parseStart = Date.now();
-  const fullText = finalAssistant.content
-    .filter(
-      (c): c is { type: 'text'; text: string } =>
-        c.type === 'text' && typeof (c as { text?: unknown }).text === 'string',
-    )
-    .map((c) => c.text)
-    .join('');
+  const fullText = stoppedAfterDoneRepairLimit
+    ? `Stopped after ${MAX_DONE_ERROR_ROUNDS} done() error rounds. The latest artifact is available with warnings.`
+    : finalAssistant.content
+        .filter(
+          (c): c is { type: 'text'; text: string } =>
+            c.type === 'text' && typeof (c as { text?: unknown }).text === 'string',
+        )
+        .map((c) => c.text)
+        .join('');
 
   const collected: Collected = { text: fullText, artifacts: [] };
 

--- a/packages/core/src/tools/done.ts
+++ b/packages/core/src/tools/done.ts
@@ -307,7 +307,7 @@ export function makeDoneTool(
       'console errors / load failures, then replies with ' +
       '`{ status: "ok" | "has_errors", errors: [...] }`. If errors come back, ' +
       'you MUST fix them with str_replace_based_edit_tool and call `done` again. ' +
-      'Stop calling once status is "ok" or after 5 rounds. If errors still ' +
+      'Stop calling once status is "ok" or after 3 error rounds. If errors still ' +
       'remain with a valid artifact after those repair rounds, the host may ' +
       'keep the latest artifact but will surface warnings to the user.',
     parameters: DoneParams,


### PR DESCRIPTION
## Summary
- enforce a three-error-round budget around the agentic done() repair loop
- terminate the pi-agent tool loop when the budget is exhausted while preserving the latest artifact with warnings
- align done/tool prompt copy and add regression coverage for the repair-limit path

Fixes #251

## Testing
- pnpm exec biome check packages/core/src/agent.ts packages/core/src/tools/done.ts packages/core/src/agent.test.ts .changeset/done-repair-limit.md
- pnpm --dir packages/core exec vitest run src/agent.test.ts
- pnpm --dir packages/core exec tsc --noEmit
- pnpm typecheck
- pnpm test