### PR TITLE
fix(core): retry reasoning content failures

### DIFF
--- a/.changeset/reasoning-content-fallback.md
+++ b/.changeset/reasoning-content-fallback.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/core": patch
+---
+
+Retry agent turns with reasoning disabled when an OpenAI-compatible endpoint rejects missing `reasoning_content`.

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -21,6 +21,7 @@ const loadBuiltinSkillsMock = vi.fn(async (): Promise<LoadedSkill[]> => []);
 interface AgentCall {
   options: AgentOptions;
   prompts: Array<{ message: unknown }>;
+  continues: number;
   listeners: Array<(e: AgentEvent) => void>;
   aborted: boolean;
 }
@@ -80,6 +81,7 @@ interface AgentScript {
     times?: number;
     params?: Record<string, unknown>;
   };
+  messagesBeforeAssistant?: AgentMessage[];
   /**
    * When set, the mock switches to `overrideScript` starting from this
    * agent-call index (0-based). Lets transport-retry tests script
@@ -97,7 +99,7 @@ vi.mock('@mariozechner/pi-agent-core', () => {
     readonly state: { messages: AgentMessage[] };
     private readonly call: AgentCall;
     constructor(options: AgentOptions) {
-      this.call = { options, prompts: [], listeners: [], aborted: false };
+      this.call = { options, prompts: [], continues: 0, listeners: [], aborted: false };
       agentCalls.push(this.call);
       const seed = (options.initialState?.messages ?? []) as AgentMessage[];
       this.state = { messages: [...seed] };
@@ -200,6 +202,9 @@ vi.mock('@mariozechner/pi-agent-core', () => {
       this.state.messages.push(userMsg);
       this.emit({ type: 'message_start', message: userMsg });
       this.emit({ type: 'message_end', message: userMsg });
+      for (const extraMessage of script.messagesBeforeAssistant ?? []) {
+        this.state.messages.push(extraMessage);
+      }
 
       const assistantMsg: AgentMessage = {
         role: 'assistant',
@@ -223,6 +228,50 @@ vi.mock('@mariozechner/pi-agent-core', () => {
       };
       this.state.messages.push(assistantMsg);
 
+      for (const e of script.events ?? []) this.emit(e);
+      this.emit({
+        type: 'message_update',
+        message: assistantMsg,
+        // biome-ignore lint/suspicious/noExplicitAny: AssistantMessageEvent shape not re-exported.
+        assistantMessageEvent: { type: 'text_delta', delta: script.assistantText } as any,
+      });
+      this.emit({ type: 'message_end', message: assistantMsg });
+      this.emit({ type: 'turn_end', message: assistantMsg, toolResults: [] });
+      this.emit({ type: 'agent_end', messages: this.state.messages });
+    }
+    async continue(): Promise<void> {
+      this.call.continues += 1;
+      const callIndex = agentCalls.indexOf(this.call);
+      const script =
+        scriptedAgent.overrideScriptForCallIndex !== undefined &&
+        callIndex >= scriptedAgent.overrideScriptForCallIndex &&
+        scriptedAgent.overrideScript
+          ? { ...scriptedAgent, ...scriptedAgent.overrideScript }
+          : scriptedAgent;
+
+      this.emit({ type: 'agent_start' });
+      this.emit({ type: 'turn_start' });
+      const assistantMsg: AgentMessage = {
+        role: 'assistant',
+        // biome-ignore lint/suspicious/noExplicitAny: matches pi-ai Api/Provider literal unions in mocks.
+        api: 'anthropic-messages' as any,
+        // biome-ignore lint/suspicious/noExplicitAny: same.
+        provider: 'anthropic' as any,
+        model: 'mock-model',
+        content: [{ type: 'text', text: script.assistantText }],
+        usage: script.usage ?? {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: script.stopReason ?? 'stop',
+        ...(script.errorMessage ? { errorMessage: script.errorMessage } : {}),
+        timestamp: Date.now(),
+      };
+      this.state.messages.push(assistantMsg);
       for (const e of script.events ?? []) this.emit(e);
       this.emit({
         type: 'message_update',
@@ -448,6 +497,83 @@ describe('generateViaAgent()', () => {
     });
 
     expect(agentCalls[0]?.options.initialState?.thinkingLevel).toBe('off');
+  });
+
+  it('replays the prompt with thinking off after a first-turn reasoning_content error', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'error',
+      errorMessage:
+        '400 The `reasoning_content` in the thinking mode must be passed back to the API.',
+      overrideScriptForCallIndex: 1,
+      overrideScript: {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        stopReason: 'stop',
+      },
+    };
+    const onRetry = vi.fn();
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a dashboard',
+        history: [],
+        model: { provider: 'openrouter', modelId: 'deepseek/deepseek-r1' },
+        apiKey: 'sk-test',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        wire: 'openai-chat',
+      },
+      { onRetry, fs: makeStubFs({ 'index.html': SAMPLE_HTML }) },
+    );
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(agentCalls).toHaveLength(2);
+    expect(agentCalls[1]?.options.initialState?.thinkingLevel).toBe('off');
+    expect(agentCalls[1]?.continues).toBe(0);
+    expect(agentCalls[1]?.prompts).toHaveLength(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: expect.stringContaining('reasoning_content') }),
+    );
+  });
+
+  it('continues from the last tool result when retrying reasoning_content errors', async () => {
+    scriptedAgent = {
+      assistantText: '',
+      stopReason: 'error',
+      errorMessage:
+        '400 The `reasoning_content` in the thinking mode must be passed back to the API.',
+      messagesBeforeAssistant: [
+        {
+          role: 'toolResult',
+          toolCallId: 'done-call',
+          toolName: 'done',
+          content: [{ type: 'text', text: 'has_errors' }],
+          details: {},
+          isError: false,
+          timestamp: Date.now(),
+        } as unknown as AgentMessage,
+      ],
+      overrideScriptForCallIndex: 1,
+      overrideScript: {
+        assistantText: RESPONSE_WITH_ARTIFACT,
+        stopReason: 'stop',
+      },
+    };
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a dashboard',
+        history: [],
+        model: { provider: 'openrouter', modelId: 'deepseek/deepseek-r1' },
+        apiKey: 'sk-test',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        wire: 'openai-chat',
+      },
+      { fs: makeStubFs({ 'index.html': SAMPLE_HTML }) },
+    );
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(agentCalls).toHaveLength(2);
+    expect(agentCalls[1]?.options.initialState?.thinkingLevel).toBe('off');
+    expect(agentCalls[1]?.continues).toBe(1);
+    expect(agentCalls[1]?.prompts).toHaveLength(0);
   });
 
   it('leaves native Gemini endpoint model IDs untouched', async () => {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -417,6 +417,40 @@ function formatDoneRepairLimitText(details: DoneDetails): string {
   ].join('\n');
 }
 
+function isReasoningContentRoundTripError(errorMessage: string | undefined): boolean {
+  if (!errorMessage) return false;
+  const message = errorMessage.toLowerCase();
+  return message.includes('reasoning_content');
+}
+
+function stripTerminalAssistantFailure(messages: readonly AgentMessage[]): AgentMessage[] {
+  const out = [...messages];
+  const last = out[out.length - 1];
+  if (
+    last?.role === 'assistant' &&
+    ((last as PiAssistantMessage).stopReason === 'error' ||
+      (last as PiAssistantMessage).stopReason === 'aborted')
+  ) {
+    out.pop();
+  }
+  return out;
+}
+
+function prepareReasoningFallback(messages: readonly AgentMessage[]): {
+  messages: AgentMessage[];
+  mode: 'continue' | 'prompt';
+} {
+  const cleanMessages = stripTerminalAssistantFailure(messages);
+  const last = cleanMessages[cleanMessages.length - 1];
+  if (last?.role === 'toolResult') {
+    return { messages: cleanMessages, mode: 'continue' };
+  }
+  if (last?.role === 'user') {
+    return { messages: cleanMessages.slice(0, -1), mode: 'prompt' };
+  }
+  return { messages: cleanMessages, mode: 'prompt' };
+}
+
 function projectContextSections(context: GenerateInput['projectContext']): string[] {
   if (!context) return [];
   const sections: string[] = [];
@@ -728,14 +762,17 @@ export async function generateViaAgent(
 
   // Factory for creating agents with a given message history. Used for both
   // the initial agent and transport-level retry agents (conversation replay).
-  const createRetryAgent = (messages: AgentMessage[]): Agent => {
+  const createRetryAgent = (
+    messages: AgentMessage[],
+    retryThinkingLevel = thinkingLevel,
+  ): Agent => {
     const retryAgent = new Agent({
       initialState: {
         systemPrompt: augmentedSystemPrompt,
         model: piModel as unknown as PiAiModel<'openai-completions'>,
         messages,
         tools,
-        thinkingLevel,
+        thinkingLevel: retryThinkingLevel,
       },
       convertToLlm: (msgs) =>
         msgs.filter(
@@ -767,15 +804,18 @@ export async function generateViaAgent(
     return retryAgent;
   };
 
+  const attachAbortSignal = (target: Agent): void => {
+    if (!input.signal) return;
+    if (input.signal.aborted) {
+      target.abort();
+    } else {
+      input.signal.addEventListener('abort', () => target.abort(), { once: true });
+    }
+  };
+
   let agent = createRetryAgent(historyAsAgentMessages);
 
-  if (input.signal) {
-    if (input.signal.aborted) {
-      agent.abort();
-    } else {
-      input.signal.addEventListener('abort', () => agent.abort(), { once: true });
-    }
-  }
+  attachAbortSignal(agent);
 
   log.info('[generate] step=send_request', ctx);
   const sendStart = Date.now();
@@ -842,17 +882,60 @@ export async function generateViaAgent(
     throw remapProviderError(err, input.model.provider, input.wire);
   }
 
-  // Post-agent transport-level retry: if the agent loop exited with a
-  // transport-level error (terminated, premature close, ECONNRESET), create a
-  // fresh agent with the successful conversation history and retry the turn.
-  // This handles proxy servers that drop long-lived SSE connections after N
-  // minutes. Tool side effects (file writes) are idempotent, so replaying
-  // prior turns is safe.
+  // Post-agent recovery:
+  // - Retry transport-level failures by replaying the turn from clean history.
+  // - Retry reasoning_content round-trip failures once with thinking off,
+  //   preserving the current transcript up to the failed provider response.
   let transportRetryCount = 0;
-  while (transportRetryCount < MAX_TRANSPORT_RETRIES) {
+  let reasoningFallbackUsed = false;
+  while (true) {
     const checkMsg = findFinalAssistantMessage(agent.state.messages);
     if (!checkMsg || checkMsg.stopReason === 'stop') break;
     if (input.signal?.aborted) break;
+
+    const shouldRetryWithoutReasoning =
+      !reasoningFallbackUsed &&
+      thinkingLevel !== 'off' &&
+      checkMsg.stopReason === 'error' &&
+      isReasoningContentRoundTripError(checkMsg.errorMessage);
+    if (shouldRetryWithoutReasoning) {
+      reasoningFallbackUsed = true;
+      log.warn('[generate] step=reasoning_retry', {
+        ...ctx,
+        reason: checkMsg.errorMessage,
+      });
+      deps.onRetry?.({
+        attempt: 1,
+        totalAttempts: 1,
+        delayMs: 0,
+        reason: `reasoning retry: ${checkMsg.errorMessage}`,
+      });
+
+      const fallback = prepareReasoningFallback(agent.state.messages);
+      capturedGetApiKeyError = null;
+      agent = createRetryAgent(fallback.messages, 'off');
+      attachAbortSignal(agent);
+
+      const retryStart = Date.now();
+      try {
+        if (fallback.mode === 'continue') {
+          await agent.continue();
+        } else {
+          await agent.prompt(userContent);
+        }
+        await agent.waitForIdle();
+      } catch (err) {
+        log.error('[generate] step=reasoning_retry.fail', {
+          ...ctx,
+          ms: Date.now() - retryStart,
+          errorClass: err instanceof Error ? err.constructor.name : typeof err,
+        });
+        throw remapProviderError(err, input.model.provider, input.wire);
+      }
+      continue;
+    }
+
+    if (transportRetryCount >= MAX_TRANSPORT_RETRIES) break;
     const retryableTransportFailure =
       checkMsg.stopReason === 'error'
         ? isTransportLevelError(checkMsg.errorMessage)
@@ -879,13 +962,7 @@ export async function generateViaAgent(
     const cleanMessages = stripFailedTurn(agent.state.messages);
     capturedGetApiKeyError = null;
     agent = createRetryAgent(cleanMessages);
-    if (input.signal) {
-      if (input.signal.aborted) {
-        agent.abort();
-      } else {
-        input.signal.addEventListener('abort', () => agent.abort(), { once: true });
-      }
-    }
+    attachAbortSignal(agent);
 
     const retryStart = Date.now();
     try {


### PR DESCRIPTION
## Summary
- detect provider errors that require prior reasoning_content to be echoed back
- retry the current agent transcript once with thinkingLevel=off instead of failing the generation
- keep existing transport retry behavior and add regression coverage for both prompt replay and tool-result continuation fallback paths

Fixes #260
Fixes #252

## Testing
- pnpm exec biome check packages/core/src/agent.ts packages/core/src/agent.test.ts .changeset/reasoning-content-fallback.md
- pnpm --dir packages/core exec vitest run src/agent.test.ts
- pnpm --dir packages/core exec tsc --noEmit
- pnpm typecheck
- pnpm test (local desktop onboarding-ipc file flaked once; see note)
- pnpm --dir apps/desktop exec vitest run src/main/onboarding-ipc.test.ts

## Local note
- Full pnpm test initially hit the known local onboarding-ipc timeout/empty-registration flake; rerunning that file passed with 52 tests.