### PR TITLE
fix(desktop): show delivered previews in files panel

### DIFF
--- a/.changeset/files-preview-fallback.md
+++ b/.changeset/files-preview-fallback.md
@@ -1,0 +1,5 @@
+---
+'@open-codesign/desktop': patch
+---
+
+Show a virtual `index.html` in the Files panel when a generated preview exists but no workspace file rows are available.

--- a/apps/desktop/src/renderer/src/components/FilesTabView.test.ts
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.test.ts
@@ -91,6 +91,17 @@ describe('FilesTabView preview helpers', () => {
     ).toBe('read-workspace');
   });
 
+  it('uses previewHtml for virtual fallback entries even when files.read exists', () => {
+    expect(
+      chooseWorkspacePreviewSourceMode({
+        path: 'index.html',
+        hasReadApi: true,
+        hasPreviewHtml: true,
+        preferPreviewHtml: true,
+      }),
+    ).toBe('preview-html-fallback');
+  });
+
   it('falls back to previewHtml only for legacy index.html previews without files.read', () => {
     expect(
       chooseWorkspacePreviewSourceMode({

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -216,7 +216,11 @@ export function chooseWorkspacePreviewSourceMode(input: {
   path: string;
   hasReadApi: boolean;
   hasPreviewHtml: boolean;
+  preferPreviewHtml?: boolean;
 }): WorkspacePreviewSourceMode {
+  if (input.preferPreviewHtml === true && input.path === 'index.html' && input.hasPreviewHtml) {
+    return 'preview-html-fallback';
+  }
   if (input.hasReadApi) return 'read-workspace';
   if (input.path === 'index.html' && input.hasPreviewHtml) return 'preview-html-fallback';
   return 'unavailable';
@@ -262,6 +266,7 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
   const workspaceFiles = files ?? observedFiles;
   const currentDesign = designs.find((d) => d.id === currentDesignId);
   const effectiveFile = file ?? workspaceFiles.find((f) => f.path === path) ?? null;
+  const prefersPreviewHtml = effectiveFile?.source === 'preview-html';
   const renderable = effectiveFile
     ? isRenderableDesignFileKind(effectiveFile.kind)
     : isRenderablePath(path);
@@ -303,6 +308,7 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
       path,
       hasReadApi: typeof read === 'function',
       hasPreviewHtml: Boolean(previewHtml),
+      preferPreviewHtml: prefersPreviewHtml,
     });
     if (sourceMode === 'preview-html-fallback' && previewHtml) {
       setPreviewSource({ content: previewHtml, path });
@@ -329,7 +335,7 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
     return () => {
       cancelled = true;
     };
-  }, [currentDesignId, previewDependencyKey, path, previewHtml, renderable, t]);
+  }, [currentDesignId, previewDependencyKey, path, previewHtml, renderable, t, prefersPreviewHtml]);
 
   const srcDoc = useMemo(() => {
     if (!previewSource || !renderable) return null;

--- a/apps/desktop/src/renderer/src/hooks/useDesignFiles.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesignFiles.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { DesignFileEntry } from './useDesignFiles';
+import { previewHtmlFallbackFile, withPreviewHtmlFallback } from './useDesignFiles';
+
+describe('useDesignFiles helpers', () => {
+  it('creates a virtual index.html entry from previewHtml', () => {
+    expect(previewHtmlFallbackFile('<html>ok</html>', '2026-05-03T00:00:00.000Z')).toEqual({
+      path: 'index.html',
+      kind: 'html',
+      size: 15,
+      updatedAt: '2026-05-03T00:00:00.000Z',
+      source: 'preview-html',
+    });
+  });
+
+  it('keeps real workspace files ahead of previewHtml fallback', () => {
+    const rows: DesignFileEntry[] = [
+      {
+        path: 'src/App.tsx',
+        kind: 'tsx',
+        size: 123,
+        updatedAt: '2026-05-03T00:00:00.000Z',
+        source: 'workspace',
+      },
+    ];
+
+    expect(withPreviewHtmlFallback(rows, '<html>fallback</html>')).toBe(rows);
+  });
+
+  it('uses previewHtml when the workspace list is empty', () => {
+    expect(
+      withPreviewHtmlFallback([], '<html>fallback</html>', '2026-05-03T00:00:00.000Z'),
+    ).toEqual([
+      {
+        path: 'index.html',
+        kind: 'html',
+        size: 21,
+        updatedAt: '2026-05-03T00:00:00.000Z',
+        source: 'preview-html',
+      },
+    ]);
+  });
+
+  it('returns no files when neither workspace rows nor previewHtml exist', () => {
+    expect(withPreviewHtmlFallback([], null)).toEqual([]);
+    expect(withPreviewHtmlFallback([], '')).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
@@ -4,18 +4,44 @@ import { useCodesignStore } from '../store';
 import { tr } from '../store/lib/locale';
 
 export type DesignFileKind = WorkspaceFileKind;
+export type DesignFileSource = 'workspace' | 'preview-html';
 
 export interface DesignFileEntry {
   path: string;
   kind: DesignFileKind;
   updatedAt: string;
   size?: number;
+  source?: DesignFileSource;
 }
 
 export interface UseDesignFilesResult {
   files: DesignFileEntry[];
   loading: boolean;
   backend: 'workspace' | 'snapshots';
+}
+
+export function previewHtmlFallbackFile(
+  previewHtml: string | null,
+  updatedAt = new Date().toISOString(),
+): DesignFileEntry | null {
+  if (!previewHtml) return null;
+  return {
+    path: 'index.html',
+    kind: 'html',
+    size: previewHtml.length,
+    updatedAt,
+    source: 'preview-html',
+  };
+}
+
+export function withPreviewHtmlFallback(
+  rows: DesignFileEntry[],
+  previewHtml: string | null,
+  updatedAt?: string,
+): DesignFileEntry[] {
+  if (rows.length > 0) return rows;
+  const fallback = previewHtmlFallbackFile(previewHtml, updatedAt);
+  return fallback === null ? [] : [fallback];
 }
 
 /**
@@ -36,6 +62,9 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
   const workspacePath = useCodesignStore((s) =>
     designId === null ? null : (s.designs.find((d) => d.id === designId)?.workspacePath ?? null),
   );
+  const designUpdatedAt = useCodesignStore((s) =>
+    designId === null ? undefined : s.designs.find((d) => d.id === designId)?.updatedAt,
+  );
   const pushToast = useCodesignStore((s) => s.pushToast);
   const [files, setFiles] = useState<DesignFileEntry[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -53,7 +82,7 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
     if (backend === 'workspace') {
       if (workspacePath === null) {
         lastListErrorRef.current = null;
-        setFiles([]);
+        setFiles(withPreviewHtmlFallback([], previewHtml, designUpdatedAt));
         return;
       }
       try {
@@ -69,18 +98,18 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
             };
           }
         ).files.list(designId);
-        setFiles(
-          rows.map((r) => ({
-            path: r.path,
-            kind: r.kind,
-            size: r.size,
-            updatedAt: r.updatedAt,
-          })),
-        );
+        const workspaceRows = rows.map((r) => ({
+          path: r.path,
+          kind: r.kind,
+          size: r.size,
+          updatedAt: r.updatedAt,
+          source: 'workspace' as const,
+        }));
+        setFiles(withPreviewHtmlFallback(workspaceRows, previewHtml, designUpdatedAt));
         lastListErrorRef.current = null;
       } catch (err) {
         const message = err instanceof Error ? err.message : tr('errors.unknown');
-        setFiles([]);
+        setFiles(withPreviewHtmlFallback([], previewHtml, designUpdatedAt));
         const errorKey = `${designId}:${workspacePath}:${message}`;
         if (lastListErrorRef.current !== errorKey) {
           lastListErrorRef.current = errorKey;
@@ -98,19 +127,8 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
     // Legacy fallback: no files IPC → derive a single index.html entry from
     // the last preview if we have one. Kept so downstream tests that mock a
     // codesign-without-files preload keep passing.
-    if (previewHtml) {
-      setFiles([
-        {
-          path: 'index.html',
-          kind: 'html',
-          size: previewHtml.length,
-          updatedAt: new Date().toISOString(),
-        },
-      ]);
-    } else {
-      setFiles([]);
-    }
-  }, [designId, backend, previewHtml, pushToast, workspacePath]);
+    setFiles(withPreviewHtmlFallback([], previewHtml, designUpdatedAt));
+  }, [designId, backend, designUpdatedAt, previewHtml, pushToast, workspacePath]);
 
   // Initial fetch + refetch when the design changes.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #248.

- Show a virtual `index.html` in the Files panel when `previewHtml` exists but the workspace file list is empty or unavailable.
- Mark preview-derived entries with `source: preview-html` so file preview uses the in-memory preview content instead of trying to read a nonexistent workspace file.
- Keep real workspace file rows ahead of the preview fallback.

## Validation

- `pnpm exec biome check apps/desktop/src/renderer/src/hooks/useDesignFiles.ts apps/desktop/src/renderer/src/hooks/useDesignFiles.test.ts apps/desktop/src/renderer/src/components/FilesTabView.tsx apps/desktop/src/renderer/src/components/FilesTabView.test.ts .changeset/files-preview-fallback.md`
- `pnpm --dir apps/desktop exec vitest run src/renderer/src/hooks/useDesignFiles.test.ts src/renderer/src/components/FilesTabView.test.ts`
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop test`
- `pnpm typecheck`
- `pnpm test`