### PR TITLE
fix(desktop): explain workspace binding conflicts

### DIFF
--- a/.changeset/workspace-conflict-guidance.md
+++ b/.changeset/workspace-conflict-guidance.md
@@ -1,0 +1,5 @@
+---
+'@open-codesign/desktop': patch
+---
+
+Show clearer guidance when a workspace folder is already bound to another design.

--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -166,12 +166,12 @@ describe('bindWorkspace', () => {
   it('throws when another active design already owns the workspace path', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db);
-    const otherDesign = createDesign(db);
+    const otherDesign = createDesign(db, 'Landing page variants');
     const conflictPath = normalizeWorkspacePath(await makeTempDir('ocd-ws-conflict-'));
     updateDesignWorkspace(db, otherDesign.id, conflictPath);
 
     await expect(bindWorkspace(db, design.id, conflictPath, false)).rejects.toThrow(
-      'Workspace path is already bound to another design',
+      'Workspace path is already bound to another design ("Landing page variants"). Choose a different folder, or open that design and change its workspace before reusing this folder.',
     );
     expect(getDesign(db, design.id)?.workspacePath).toBeNull();
   });

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -45,13 +45,30 @@ export function checkWorkspaceConflict(
   designId: string,
   normalizedPath: string,
 ): boolean {
+  return findWorkspaceConflict(db, designId, normalizedPath) !== null;
+}
+
+export function findWorkspaceConflict(
+  db: Database,
+  designId: string,
+  normalizedPath: string,
+): Design | null {
   const comparisonPath = workspacePathComparisonKey(normalizedPath);
-  return listDesigns(db).some(
-    (design) =>
-      design.id !== designId &&
-      design.workspacePath !== null &&
-      workspacePathComparisonKey(design.workspacePath) === comparisonPath,
+  return (
+    listDesigns(db).find(
+      (design) =>
+        design.id !== designId &&
+        design.workspacePath !== null &&
+        workspacePathComparisonKey(design.workspacePath) === comparisonPath,
+    ) ?? null
   );
+}
+
+function workspaceConflictMessage(conflict: Design): string {
+  return [
+    `Workspace path is already bound to another design ("${conflict.name}").`,
+    'Choose a different folder, or open that design and change its workspace before reusing this folder.',
+  ].join(' ');
 }
 
 export async function migrateWorkspaceFiles(
@@ -150,8 +167,9 @@ export async function bindWorkspace(
     logger.info('workspace.bind.noop', { designId, workspacePath: normalizedPath });
     return current;
   }
-  if (checkWorkspaceConflict(db, designId, normalizedPath)) {
-    throw new Error('Workspace path is already bound to another design');
+  const conflict = findWorkspaceConflict(db, designId, normalizedPath);
+  if (conflict !== null) {
+    throw new Error(workspaceConflictMessage(conflict));
   }
   await assertExistingWorkspaceDirectory(normalizedPath);
 


### PR DESCRIPTION
## Summary

Fixes #286.

- Keep the one-workspace-per-design guard, but return the conflicting design name in the error.
- Add actionable guidance so the UI toast tells users to choose another folder or change the other design's workspace first.
- Preserve the existing boolean conflict helper while adding a conflict lookup for richer messages.

## Validation

- `pnpm exec biome check apps/desktop/src/main/design-workspace.ts apps/desktop/src/main/design-workspace.test.ts .changeset/workspace-conflict-guidance.md`
- `pnpm --dir apps/desktop exec vitest run src/main/design-workspace.test.ts`
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop test`
- `pnpm typecheck`