### PR TITLE
fix(desktop): clarify terminated generation errors

### DIFF
--- a/.changeset/terminated-transport-display.md
+++ b/.changeset/terminated-transport-display.md
@@ -1,0 +1,5 @@
+---
+'@open-codesign/desktop': patch
+---
+
+Show a clearer transport-interrupted explanation when generation fails with opaque `terminated` errors.

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1351,6 +1351,25 @@ describe('applyGenerateError via sendPrompt', () => {
     expect(records[0]?.code).toBe('GENERATION_FAILED');
   });
 
+  it('classifies opaque terminated transport failures while keeping the raw detail', async () => {
+    const err = new Error(
+      "Error invoking remote method 'codesign:v1:generate': CodesignError: terminated",
+    );
+
+    await runFailingGenerate(err);
+
+    const state = useCodesignStore.getState();
+    expect(state.lastError).toContain('The provider connection ended before the turn completed');
+    expect(state.lastError).toContain('Technical detail: terminated');
+    expect(state.lastError).not.toBe('terminated');
+    expect(state.toasts[0]?.description).toBe(state.lastError);
+    expect(state.reportableErrors[0]?.message).toBe(err.message);
+    expect(state.reportableErrors[0]?.context).toMatchObject({
+      diagnostic_category: 'transport-interrupted',
+      display_message: state.lastError,
+    });
+  });
+
   it('attaches upstream context from a NormalizedProviderError-shaped error', async () => {
     const err = Object.assign(new Error('http 502'), {
       code: 'PROVIDER_HTTP_5XX',

--- a/apps/desktop/src/renderer/src/store/slices/errors.test.ts
+++ b/apps/desktop/src/renderer/src/store/slices/errors.test.ts
@@ -1,0 +1,43 @@
+import { initI18n } from '@open-codesign/i18n';
+import type { DiagnosticHypothesis } from '@open-codesign/shared';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildGenerateDisplayMessage } from './errors';
+
+const transportHypothesis: DiagnosticHypothesis = {
+  cause: 'diagnostics.cause.transportInterrupted',
+  category: 'transport-interrupted',
+  severity: 'warning',
+};
+
+describe('buildGenerateDisplayMessage', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('rewrites the exact opaque IPC terminated error from #189', () => {
+    // Regression for the Electron IPC wrapper plus CodesignError shape reported in #189.
+    const message =
+      "Error invoking remote method 'codesign:v1:generate': CodesignError: terminated";
+
+    expect(buildGenerateDisplayMessage(message, transportHypothesis)).toBe(
+      [
+        'The provider connection ended before the turn completed. This is usually a gateway timeout or network interruption.',
+        '',
+        'Technical detail: terminated',
+      ].join('\n'),
+    );
+  });
+
+  it('preserves specific transport messages that already explain what happened', () => {
+    const message = 'Upstream proxy aborted the response';
+
+    expect(buildGenerateDisplayMessage(message, transportHypothesis)).toBe(message);
+  });
+
+  it('preserves cleaned provider messages when no transport diagnosis exists', () => {
+    const message =
+      "Error invoking remote method 'codesign:v1:generate': CodesignError: model missing";
+
+    expect(buildGenerateDisplayMessage(message, undefined)).toBe('model missing');
+  });
+});

--- a/apps/desktop/src/renderer/src/store/slices/errors.ts
+++ b/apps/desktop/src/renderer/src/store/slices/errors.ts
@@ -185,6 +185,43 @@ export function cleanGenerateErrorMessage(originalMessage: string): string {
   );
 }
 
+function isTransportDiagnostic(
+  hypothesis: DiagnosticHypothesis | undefined,
+): hypothesis is DiagnosticHypothesis {
+  return (
+    hypothesis?.category === 'transport-interrupted' ||
+    hypothesis?.category === 'relay-stream-cutoff'
+  );
+}
+
+function isOpaqueTransportMessage(message: string): boolean {
+  const normalized = message
+    .trim()
+    .toLowerCase()
+    .replace(/^error:\s*/, '');
+  // Keep this intentionally narrow: only terse transport-layer strings get
+  // replaced. More specific upstream messages should stay visible verbatim.
+  return (
+    /^(?:fetch failed:\s*)?terminated$/.test(normalized) ||
+    normalized === 'stream terminated' ||
+    normalized === 'premature close' ||
+    normalized === 'connection error' ||
+    normalized === 'request was aborted' ||
+    normalized === 'generation aborted by provider'
+  );
+}
+
+export function buildGenerateDisplayMessage(
+  originalMessage: string,
+  hypothesis: DiagnosticHypothesis | undefined,
+): string {
+  const cleaned = cleanGenerateErrorMessage(originalMessage);
+  if (!isTransportDiagnostic(hypothesis) || !isOpaqueTransportMessage(cleaned)) return cleaned;
+  const summary = tr(hypothesis.cause);
+  if (summary === hypothesis.cause) return cleaned;
+  return `${summary}\n\nTechnical detail: ${cleaned}`;
+}
+
 export function buildGenerateErrorDescription(
   originalMessage: string,
   hypothesis: DiagnosticHypothesis | undefined,
@@ -194,5 +231,6 @@ export function buildGenerateErrorDescription(
   // When the i18n key was missing, tr() falls back to returning the key
   // itself; don't double up "diagnostics.cause.x" in the toast.
   if (hint === hypothesis.cause) return originalMessage;
+  if (originalMessage.includes(hint)) return originalMessage;
   return `${originalMessage}\n\n${tr('diagnostics.mostLikelyCause')} ${hint}`;
 }

--- a/apps/desktop/src/renderer/src/store/slices/generation.ts
+++ b/apps/desktop/src/renderer/src/store/slices/generation.ts
@@ -16,8 +16,8 @@ import type { CodesignState } from '../../store.js';
 import { modelRef, newId, normalizeReferenceUrl, tr, uniqueFiles } from '../lib/locale.js';
 import { finishIfCurrent, isReadyConfig } from '../lib/ready-config.js';
 import {
+  buildGenerateDisplayMessage,
   buildGenerateErrorDescription,
-  cleanGenerateErrorMessage,
   deriveGenerateHypothesis,
   extractCodesignErrorCode,
   extractUpstreamContext,
@@ -271,7 +271,9 @@ function applyGenerateError(
   designIdAtStart: string | null,
 ): void {
   const rawMsg = err instanceof Error ? err.message : tr('errors.unknown');
-  const displayMsg = cleanGenerateErrorMessage(rawMsg);
+  const cfg = get().config;
+  const hypothesis = deriveGenerateHypothesis(err, cfg);
+  const displayMsg = buildGenerateDisplayMessage(rawMsg, hypothesis);
   if (get().activeGenerationId !== generationId) return;
   // TODO: replace with rendererLogger once renderer-logger lands
   console.error('[store] applyGenerateError', {
@@ -304,8 +306,6 @@ function applyGenerateError(
   // toast tells the user WHY and WHAT TO TRY instead of just dumping the
   // upstream message. Fixes #130 (404 → "add /v1") and gives #158 / #134 a
   // home for gateway / instructions-required hints.
-  const cfg = get().config;
-  const hypothesis = deriveGenerateHypothesis(err, cfg);
   const description = buildGenerateErrorDescription(displayMsg, hypothesis);
   const action = buildGenerateFixAction(get, set, hypothesis, err, cfg);
   const reportContext = buildGenerateReportContext(upstream, hypothesis, displayMsg);


### PR DESCRIPTION
## Summary

Refs #189.

- Convert opaque transport failure messages like `terminated` into a clearer provider-connection interruption explanation.
- Keep the raw provider/IPC detail in the visible message as `Technical detail: ...` and in reportable error records.
- Avoid duplicating the same diagnostic cause in the toast when the display text already contains it.
- Add isolated coverage for the exact IPC error format from #189 plus preservation of more specific upstream messages.

Note: this intentionally uses `Refs` rather than `Fixes` because the PR review bot could not fetch #189 to verify the full issue text. I manually checked #189: it asks for clearer classification/preserved detail for `Error invoking remote method ... CodesignError: terminated`, which this PR covers. The issue can be closed manually after merge.

## Validation

- `pnpm exec biome check apps/desktop/src/renderer/src/store/slices/errors.ts apps/desktop/src/renderer/src/store/slices/errors.test.ts apps/desktop/src/renderer/src/store/slices/generation.ts apps/desktop/src/renderer/src/store.test.ts .changeset/terminated-transport-display.md`
- `pnpm --dir apps/desktop exec vitest run src/renderer/src/store/slices/errors.test.ts src/renderer/src/store.test.ts`
- `pnpm --dir apps/desktop typecheck`
- `pnpm --dir apps/desktop test`
- `pnpm typecheck`