### PR TITLE
fix(desktop): guard design system linking before onboarding

### DIFF
--- a/.changeset/design-system-onboarding-guard.md
+++ b/.changeset/design-system-onboarding-guard.md
@@ -1,0 +1,6 @@
+---
+'@open-codesign/desktop': patch
+'@open-codesign/i18n': patch
+---
+
+Block design system linking before onboarding and show a friendly renderer diagnostic instead of surfacing the main-process guard error.

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -490,6 +490,43 @@ describe('useCodesignStore active provider routing', () => {
   });
 });
 
+describe('useCodesignStore design system picker', () => {
+  beforeAll(async () => {
+    await initI18n('en');
+  });
+
+  it('blocks design system linking before onboarding without invoking IPC', async () => {
+    const pickDesignSystemDirectory = vi.fn(async () => READY_CONFIG);
+    vi.stubGlobal('window', {
+      codesign: {
+        pickDesignSystemDirectory,
+      },
+      setTimeout,
+    });
+    useCodesignStore.setState({
+      config: {
+        hasKey: false,
+        provider: null,
+        modelPrimary: null,
+        baseUrl: null,
+        designSystem: null,
+      },
+    });
+
+    await useCodesignStore.getState().pickDesignSystemDirectory();
+
+    expect(pickDesignSystemDirectory).not.toHaveBeenCalled();
+    const state = useCodesignStore.getState();
+    expect(state.toasts[0]).toMatchObject({
+      variant: 'error',
+      title: 'Onboarding is not complete.',
+      description: 'Complete onboarding before linking a design system.',
+    });
+    expect(state.reportableErrors[0]?.code).toBe('DESIGN_SYSTEM_LINK_BLOCKED_ONBOARDING');
+    expect(state.reportableErrors[0]?.scope).toBe('onboarding');
+  });
+});
+
 describe('useCodesignStore previewViewport', () => {
   it('defaults to desktop', () => {
     expect(useCodesignStore.getState().previewViewport).toBe('desktop');

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -518,6 +518,15 @@ export const useCodesignStore = create<CodesignState>((set, get) => ({
 
   async pickDesignSystemDirectory() {
     if (!window.codesign) return;
+    if (get().config?.hasKey !== true) {
+      get().reportableErrorToast({
+        code: 'DESIGN_SYSTEM_LINK_BLOCKED_ONBOARDING',
+        scope: 'onboarding',
+        title: tr('errors.onboardingIncomplete'),
+        description: tr('errors.designSystemRequiresOnboarding'),
+      });
+      return;
+    }
     try {
       const next = await window.codesign.pickDesignSystemDirectory();
       set({ config: next });

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -773,6 +773,7 @@
     "exporterNotReady": "Exporter is still loading. Try again in a moment.",
     "rendererDisconnected": "Renderer is not connected to the main process.",
     "onboardingIncomplete": "Onboarding is not complete.",
+    "designSystemRequiresOnboarding": "Complete onboarding before linking a design system.",
     "providerMissingKey": "The active provider \"{{provider}}\" has no API key. Open Settings to add one.",
     "modelListFailed": "Could not load model list.",
     "unknown": "Unknown error",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -769,6 +769,7 @@
     "exporterNotReady": "El exportador aún está cargando. Intenta de nuevo en un momento.",
     "rendererDisconnected": "El renderizador no está conectado al proceso principal.",
     "onboardingIncomplete": "La bienvenida no está completa.",
+    "designSystemRequiresOnboarding": "Completa la bienvenida antes de vincular un sistema de diseño.",
     "providerMissingKey": "El proveedor activo \"{{provider}}\" no tiene clave API. Abre Configuración para agregar una.",
     "modelListFailed": "No se pudo cargar la lista de modelos.",
     "unknown": "Error desconocido",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -733,6 +733,7 @@
     "exporterNotReady": "O exportador ainda está carregando. Tente novamente em um instante.",
     "rendererDisconnected": "O renderer não está conectado ao processo principal.",
     "onboardingIncomplete": "O onboarding não foi concluído.",
+    "designSystemRequiresOnboarding": "Conclua o onboarding antes de vincular um design system.",
     "providerMissingKey": "O provedor ativo \"{{provider}}\" não tem chave de API. Abra Configurações para adicionar uma.",
     "modelListFailed": "Não foi possível carregar a lista de modelos.",
     "unknown": "Erro desconhecido",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -773,6 +773,7 @@
     "exporterNotReady": "导出器还在加载，稍等片刻再试。",
     "rendererDisconnected": "渲染进程未连接到主进程。",
     "onboardingIncomplete": "引导流程尚未完成。",
+    "designSystemRequiresOnboarding": "请先完成引导流程，再关联设计系统。",
     "providerMissingKey": "当前 provider「{{provider}}」没有 API key，请打开 Settings 填入。",
     "modelListFailed": "无法加载模型列表。",
     "unknown": "未知错误",


### PR DESCRIPTION
## Summary
- block design system linking in the renderer when onboarding is incomplete
- show a localized, reportable friendly diagnostic instead of surfacing the main-process guard error
- add a regression test that verifies the IPC picker is not invoked before onboarding

Fixes #249

## Validation
- pnpm exec biome check apps/desktop/src/renderer/src/store.ts apps/desktop/src/renderer/src/store.test.ts packages/i18n/src/locales/en.json packages/i18n/src/locales/es.json packages/i18n/src/locales/pt-BR.json packages/i18n/src/locales/zh-CN.json .changeset/design-system-onboarding-guard.md
- pnpm --dir apps/desktop exec vitest run src/renderer/src/store.test.ts
- pnpm --dir apps/desktop typecheck
- pnpm typecheck