### PR TITLE
fix(desktop): repair stale scaffold manifests

### DIFF
--- a/.changeset/repair-scaffold-manifest-metadata.md
+++ b/.changeset/repair-scaffold-manifest-metadata.md
@@ -1,0 +1,5 @@
+---
+'@open-codesign/desktop': patch
+---
+
+Repair stale user scaffold manifests with missing bundled metadata so built-in scaffold validation stays healthy after upgrades.

--- a/apps/desktop/src/main/ensure-user-templates.test.ts
+++ b/apps/desktop/src/main/ensure-user-templates.test.ts
@@ -76,7 +76,73 @@ describe('ensureUserTemplates', () => {
     await expect(ensureUserTemplates(userData, source)).resolves.toMatchObject({
       action: 'skipped',
       copiedFiles: 0,
+      updatedFiles: 0,
     });
+  });
+
+  it('repairs stale scaffold manifest metadata without overwriting user edits', async () => {
+    const source = path.join(root, 'bundle', 'templates');
+    mkdirSync(path.join(source, 'scaffolds'), { recursive: true });
+    writeFileSync(
+      path.join(source, 'scaffolds', 'manifest.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        scaffolds: {
+          'iphone-frame': {
+            description: 'Default iPhone frame.',
+            path: '../frames/iphone.jsx',
+            category: 'device-frame',
+            license: 'MIT-internal',
+            source: 'Open CoDesign built-in scaffold',
+          },
+          'ipad-frame': {
+            description: 'iPad frame.',
+            path: '../frames/ipad.jsx',
+            category: 'device-frame',
+            license: 'MIT-internal',
+            source: 'Open CoDesign built-in scaffold',
+          },
+        },
+      }),
+    );
+
+    const userData = path.join(root, 'user');
+    const userScaffolds = path.join(userData, 'templates', 'scaffolds');
+    mkdirSync(userScaffolds, { recursive: true });
+    writeFileSync(
+      path.join(userScaffolds, 'manifest.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        scaffolds: {
+          'iphone-frame': {
+            description: 'User edited description.',
+            path: '../frames/iphone.jsx',
+            category: 'device-frame',
+            license: 'MIT-internal',
+            source: '',
+          },
+          'custom-frame': {
+            description: 'User scaffold.',
+            path: 'custom.jsx',
+            license: 'MIT',
+            source: 'User',
+          },
+        },
+      }),
+    );
+
+    const result = await ensureUserTemplates(userData, source);
+    expect(result).toMatchObject({ action: 'merged', copiedFiles: 0, updatedFiles: 1 });
+
+    const repaired = JSON.parse(
+      readFileSync(path.join(userScaffolds, 'manifest.json'), 'utf8'),
+    ) as {
+      scaffolds: Record<string, { description: string; source: string }>;
+    };
+    expect(repaired.scaffolds['iphone-frame']?.description).toBe('User edited description.');
+    expect(repaired.scaffolds['iphone-frame']?.source).toBe('Open CoDesign built-in scaffold');
+    expect(repaired.scaffolds['ipad-frame']?.source).toBe('Open CoDesign built-in scaffold');
+    expect(repaired.scaffolds['custom-frame']?.source).toBe('User');
   });
 
   it('reports missing-source when the bundle dir does not exist', async () => {

--- a/apps/desktop/src/main/ensure-user-templates.ts
+++ b/apps/desktop/src/main/ensure-user-templates.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { cp, mkdir, readdir } from 'node:fs/promises';
+import { cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,6 +8,7 @@ export interface EnsureUserTemplatesResult {
   source: string;
   dest: string;
   copiedFiles?: number;
+  updatedFiles?: number;
 }
 
 /**
@@ -55,9 +56,10 @@ export async function ensureUserTemplates(
   }
 
   const copiedFiles = await copyMissingFiles(sourceDir, dest);
-  return copiedFiles > 0
-    ? { action: 'merged', source: sourceDir, dest, copiedFiles }
-    : { action: 'skipped', source: sourceDir, dest, copiedFiles: 0 };
+  const updatedFiles = await repairBundledManifests(sourceDir, dest);
+  return copiedFiles + updatedFiles > 0
+    ? { action: 'merged', source: sourceDir, dest, copiedFiles, updatedFiles }
+    : { action: 'skipped', source: sourceDir, dest, copiedFiles: 0, updatedFiles: 0 };
 }
 
 async function copyMissingFiles(sourceDir: string, destDir: string): Promise<number> {
@@ -76,4 +78,89 @@ async function copyMissingFiles(sourceDir: string, destDir: string): Promise<num
     copied++;
   }
   return copied;
+}
+
+async function repairBundledManifests(sourceDir: string, destDir: string): Promise<number> {
+  return repairScaffoldManifest(
+    path.join(sourceDir, 'scaffolds', 'manifest.json'),
+    path.join(destDir, 'scaffolds', 'manifest.json'),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function patchStringField(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  field: string,
+): boolean {
+  if (isNonEmptyString(target[field]) || !isNonEmptyString(source[field])) return false;
+  target[field] = source[field];
+  return true;
+}
+
+async function repairScaffoldManifest(sourcePath: string, destPath: string): Promise<number> {
+  if (!existsSync(sourcePath) || !existsSync(destPath)) return 0;
+
+  let sourceManifest: unknown;
+  let destManifest: unknown;
+  try {
+    sourceManifest = JSON.parse(await readFile(sourcePath, 'utf8')) as unknown;
+    destManifest = JSON.parse(await readFile(destPath, 'utf8')) as unknown;
+  } catch {
+    return 0;
+  }
+  if (!isRecord(sourceManifest) || !isRecord(destManifest)) return 0;
+  const sourceScaffolds = sourceManifest['scaffolds'];
+  if (!isRecord(sourceScaffolds)) return 0;
+
+  let changed = false;
+  if (destManifest['schemaVersion'] !== sourceManifest['schemaVersion']) {
+    destManifest['schemaVersion'] = sourceManifest['schemaVersion'];
+    changed = true;
+  }
+  if (!isRecord(destManifest['scaffolds'])) {
+    destManifest['scaffolds'] = {};
+    changed = true;
+  }
+  const destScaffolds = destManifest['scaffolds'];
+  if (!isRecord(destScaffolds)) return 0;
+
+  for (const [kind, rawSourceEntry] of Object.entries(sourceScaffolds)) {
+    if (!isRecord(rawSourceEntry)) continue;
+    const rawDestEntry = destScaffolds[kind];
+    if (!isRecord(rawDestEntry)) {
+      destScaffolds[kind] = cloneJsonRecord(rawSourceEntry);
+      changed = true;
+      continue;
+    }
+    for (const field of ['description', 'path', 'license', 'source', 'category']) {
+      changed = patchStringField(rawDestEntry, rawSourceEntry, field) || changed;
+    }
+    if (!Array.isArray(rawDestEntry['aliases']) && Array.isArray(rawSourceEntry['aliases'])) {
+      rawDestEntry['aliases'] = [...rawSourceEntry['aliases']];
+      changed = true;
+    }
+    if (
+      typeof rawDestEntry['sizeBytes'] !== 'number' &&
+      typeof rawSourceEntry['sizeBytes'] === 'number'
+    ) {
+      rawDestEntry['sizeBytes'] = rawSourceEntry['sizeBytes'];
+      changed = true;
+    }
+  }
+
+  if (!changed) return 0;
+  await writeFile(destPath, `${JSON.stringify(destManifest, null, 2)}\n`, 'utf8');
+  return 1;
 }


### PR DESCRIPTION
## Summary
- repair stale user scaffold manifests during template ensure/upgrade
- fill missing or empty built-in scaffold metadata such as `source` from the bundled manifest without overwriting valid user edits
- preserve user-defined scaffold entries while adding bundled entries that old manifests do not know about

Fixes #288

## Validation
- pnpm exec biome check apps/desktop/src/main/ensure-user-templates.ts apps/desktop/src/main/ensure-user-templates.test.ts .changeset/repair-scaffold-manifest-metadata.md
- pnpm --dir apps/desktop exec vitest run src/main/ensure-user-templates.test.ts
- pnpm --dir packages/core exec vitest run src/tools/scaffold.test.ts src/resource-manifest.test.ts
- pnpm --dir apps/desktop typecheck
- pnpm typecheck