### PR TITLE
fix(desktop): quiet missing update channel checks

### DIFF
--- a/.changeset/quiet-missing-update-channel.md
+++ b/.changeset/quiet-missing-update-channel.md
@@ -1,0 +1,5 @@
+---
+'@open-codesign/desktop': patch
+---
+
+Disable startup update checks by default and treat missing electron-updater channel metadata as a non-error condition.

--- a/apps/desktop/src/main/app-menu.ts
+++ b/apps/desktop/src/main/app-menu.ts
@@ -1,5 +1,6 @@
 import { app, dialog, Menu } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { getUpdateErrorMessage, isMissingUpdateMetadataError } from './update-errors';
 
 export function registerAppMenu(): void {
   const template: Electron.MenuItemConstructorOptions[] = [
@@ -53,10 +54,16 @@ export function registerAppMenu(): void {
               // If a newer version is available, the update-available event fires
               // and the renderer banner handles it — no dialog needed here.
             } catch (err) {
-              dialog.showErrorBox(
-                'Update Check Failed',
-                err instanceof Error ? err.message : String(err),
-              );
+              if (isMissingUpdateMetadataError(err)) {
+                dialog.showMessageBox({
+                  type: 'info',
+                  title: 'Update Check Unavailable',
+                  message:
+                    'No update channel metadata has been published for this build yet. Try again after the next public release.',
+                });
+                return;
+              }
+              dialog.showErrorBox('Update Check Failed', getUpdateErrorMessage(err));
             }
           },
         },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,6 +31,7 @@ import {
   registerWorkspaceIpc,
 } from './snapshots-ipc';
 import { initStorageSettings } from './storage-settings';
+import { getUpdateErrorMessage, isMissingUpdateMetadataError } from './update-errors';
 import { registerWorkspaceProtocolHandler, registerWorkspaceScheme } from './workspace-protocol';
 
 // Re-exports kept for index.workspace.test.ts and any external callers.
@@ -124,14 +125,20 @@ async function scheduleStartupUpdateCheck(): Promise<void> {
     const updateLog = getLogger('main:updates');
     try {
       autoUpdater.checkForUpdates().catch((err: unknown) => {
-        updateLog.error('startup.checkForUpdates.fail', {
-          message: err instanceof Error ? err.message : String(err),
-        });
+        const message = getUpdateErrorMessage(err);
+        if (isMissingUpdateMetadataError(err)) {
+          updateLog.warn('startup.checkForUpdates.missingChannel', { message });
+          return;
+        }
+        updateLog.error('startup.checkForUpdates.fail', { message });
       });
     } catch (err) {
-      updateLog.error('startup.checkForUpdates.throw', {
-        message: err instanceof Error ? err.message : String(err),
-      });
+      const message = getUpdateErrorMessage(err);
+      if (isMissingUpdateMetadataError(err)) {
+        updateLog.warn('startup.checkForUpdates.missingChannel', { message });
+        return;
+      }
+      updateLog.error('startup.checkForUpdates.throw', { message });
     }
   }, 30_000);
 }

--- a/apps/desktop/src/main/ipc/update.test.ts
+++ b/apps/desktop/src/main/ipc/update.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updaterHandlers = new Map<string, (arg: Error) => void>();
+const ipcHandleMock = vi.hoisted(() => vi.fn());
+const updaterOnMock = vi.hoisted(() =>
+  vi.fn((event: string, cb: (arg: Error) => void) => {
+    updaterHandlers.set(event, cb);
+  }),
+);
+const warnMock = vi.hoisted(() => vi.fn());
+const errorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    autoDownload: true,
+    on: updaterOnMock,
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+  },
+}));
+
+vi.mock('../electron-runtime', () => ({
+  app: { isPackaged: true },
+  ipcMain: { handle: ipcHandleMock },
+}));
+
+vi.mock('../logger', () => ({
+  getLogger: () => ({ warn: warnMock, error: errorMock }),
+}));
+
+import { setupAutoUpdater } from './update';
+
+describe('setupAutoUpdater', () => {
+  beforeEach(() => {
+    updaterHandlers.clear();
+    ipcHandleMock.mockClear();
+    updaterOnMock.mockClear();
+    warnMock.mockClear();
+    errorMock.mockClear();
+  });
+
+  it('logs missing updater metadata as a warning instead of an error', () => {
+    setupAutoUpdater(() => null);
+
+    updaterHandlers.get('error')?.(
+      new Error('Cannot find latest-linux.yml in the latest release artifacts (HttpError: 404)'),
+    );
+
+    expect(warnMock).toHaveBeenCalledWith('autoUpdater.missingChannel', {
+      message: expect.stringContaining('latest-linux.yml'),
+    });
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps unexpected updater errors at error level', () => {
+    setupAutoUpdater(() => null);
+
+    updaterHandlers.get('error')?.(new Error('update server returned 500'));
+
+    expect(errorMock).toHaveBeenCalledWith('autoUpdater.error', {
+      message: 'update server returned 500',
+      stack: expect.any(String),
+    });
+  });
+});

--- a/apps/desktop/src/main/ipc/update.ts
+++ b/apps/desktop/src/main/ipc/update.ts
@@ -2,6 +2,7 @@ import type { BrowserWindow as ElectronBrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { app, ipcMain } from '../electron-runtime';
 import { getLogger } from '../logger';
+import { getUpdateErrorMessage, isMissingUpdateMetadataError } from '../update-errors';
 
 // Cached update-available payload so a window opened after the event still
 // shows the banner. Cleared only on app quit (matching the one-shot nature
@@ -20,8 +21,14 @@ export function setupAutoUpdater(getMainWindow: () => ElectronBrowserWindow | nu
     getMainWindow()?.webContents.send('codesign:update-available', info);
   });
   autoUpdater.on('error', (err) => {
-    getLogger('main:updates').error('autoUpdater.error', {
-      message: err.message,
+    const log = getLogger('main:updates');
+    const message = getUpdateErrorMessage(err);
+    if (isMissingUpdateMetadataError(err)) {
+      log.warn('autoUpdater.missingChannel', { message });
+      return;
+    }
+    log.error('autoUpdater.error', {
+      message,
       stack: err.stack,
     });
   });

--- a/apps/desktop/src/main/preferences-ipc.test.ts
+++ b/apps/desktop/src/main/preferences-ipc.test.ts
@@ -51,7 +51,7 @@ describe('readPersisted()', () => {
     expect(result).toEqual({
       updateChannel: 'stable',
       generationTimeoutSec: 1200,
-      checkForUpdatesOnStartup: true,
+      checkForUpdatesOnStartup: false,
       dismissedUpdateVersion: '',
       diagnosticsLastReadTs: 0,
     });
@@ -253,7 +253,7 @@ describe('preferences v4 schema fields', () => {
       JSON.stringify({ schemaVersion: 3, updateChannel: 'stable', generationTimeoutSec: 1200 }),
     );
     const prefs = await readPersisted();
-    expect(prefs.checkForUpdatesOnStartup).toBe(true);
+    expect(prefs.checkForUpdatesOnStartup).toBe(false);
     expect(prefs.dismissedUpdateVersion).toBe('');
   });
 

--- a/apps/desktop/src/main/preferences-ipc.ts
+++ b/apps/desktop/src/main/preferences-ipc.ts
@@ -54,7 +54,7 @@ const DEFAULTS: Preferences = {
   // 1200s (20 min); users on fast endpoints can lower this
   // in Settings → Advanced.
   generationTimeoutSec: 1200,
-  checkForUpdatesOnStartup: true,
+  checkForUpdatesOnStartup: false,
   dismissedUpdateVersion: '',
   diagnosticsLastReadTs: 0,
 };

--- a/apps/desktop/src/main/update-errors.test.ts
+++ b/apps/desktop/src/main/update-errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isMissingUpdateMetadataError } from './update-errors';
+
+describe('isMissingUpdateMetadataError', () => {
+  it('detects missing electron-updater channel metadata', () => {
+    expect(
+      isMissingUpdateMetadataError(
+        new Error('Cannot find latest-linux.yml in the latest release artifacts (HttpError: 404)'),
+      ),
+    ).toBe(true);
+    expect(isMissingUpdateMetadataError(new Error('Cannot find latest.yml: 404'))).toBe(true);
+  });
+
+  it('does not classify other update failures as missing metadata', () => {
+    expect(isMissingUpdateMetadataError(new Error('HttpError: 500'))).toBe(false);
+    expect(isMissingUpdateMetadataError(new Error('latest.yml signature check failed'))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/desktop/src/main/update-errors.ts
+++ b/apps/desktop/src/main/update-errors.ts
@@ -1,0 +1,8 @@
+export function getUpdateErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function isMissingUpdateMetadataError(err: unknown): boolean {
+  const message = getUpdateErrorMessage(err);
+  return /\b404\b/i.test(message) && /latest(?:-[a-z0-9_-]+)?\.ya?ml/i.test(message);
+}

--- a/apps/desktop/src/renderer/src/components/settings/AdvancedTab.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/AdvancedTab.tsx
@@ -31,7 +31,7 @@ export function AdvancedTab() {
   const [prefs, setPrefs] = useState<Preferences>({
     updateChannel: 'stable',
     generationTimeoutSec: 1200,
-    checkForUpdatesOnStartup: true,
+    checkForUpdatesOnStartup: false,
     dismissedUpdateVersion: '',
     diagnosticsLastReadTs: 0,
   });


### PR DESCRIPTION
## Summary
- disable startup update checks by default for fresh or unset preferences while the release update channel is not guaranteed to publish latest*.yml metadata
- classify missing electron-updater metadata 404s (`latest.yml`, `latest-linux.yml`, etc.) as missing-channel warnings instead of startup/error logs
- show an informational manual update-check dialog for missing channel metadata while keeping unexpected updater failures at error level

Fixes #289

## Validation
- pnpm exec biome check apps/desktop/src/main/update-errors.ts apps/desktop/src/main/update-errors.test.ts apps/desktop/src/main/preferences-ipc.ts apps/desktop/src/main/preferences-ipc.test.ts apps/desktop/src/renderer/src/components/settings/AdvancedTab.tsx apps/desktop/src/main/index.ts apps/desktop/src/main/ipc/update.ts apps/desktop/src/main/ipc/update.test.ts apps/desktop/src/main/app-menu.ts .changeset/quiet-missing-update-channel.md
- pnpm --dir apps/desktop exec vitest run src/main/update-errors.test.ts src/main/preferences-ipc.test.ts src/main/ipc/update.test.ts
- pnpm --dir apps/desktop typecheck
- pnpm typecheck