### PR TITLE
fix: allow ChatGPT OAuth for image generation

### DIFF
--- a/.changeset/chatgpt-image-oauth.md
+++ b/.changeset/chatgpt-image-oauth.md
@@ -1,0 +1,13 @@
+---
+"@open-codesign/providers": patch
+"@open-codesign/desktop": patch
+"@open-codesign/shared": patch
+"@open-codesign/i18n": patch
+---
+
+Allow image generation to use the signed-in ChatGPT subscription OAuth path.
+
+The image asset provider list now includes ChatGPT subscription alongside
+OpenAI API and OpenRouter. When selected, `generate_image_asset` calls the
+ChatGPT Codex Responses backend with the stored OAuth bearer token instead of
+requiring an OpenAI API key.

--- a/apps/desktop/src/main/codex-oauth-ipc.ts
+++ b/apps/desktop/src/main/codex-oauth-ipc.ts
@@ -133,6 +133,7 @@ async function persistProviderMutation(
     secrets: cfg?.secrets ?? {},
     providers: nextProviders,
     ...(cfg?.designSystem !== undefined ? { designSystem: cfg.designSystem } : {}),
+    ...(cfg?.imageGeneration !== undefined ? { imageGeneration: cfg.imageGeneration } : {}),
   });
   await writeConfig(next);
   setCachedConfig(next);
@@ -155,6 +156,7 @@ async function claimActiveProviderIfUnset(): Promise<void> {
     secrets: cfg.secrets,
     providers: cfg.providers,
     ...(cfg.designSystem !== undefined ? { designSystem: cfg.designSystem } : {}),
+    ...(cfg.imageGeneration !== undefined ? { imageGeneration: cfg.imageGeneration } : {}),
   });
   await writeConfig(next);
   setCachedConfig(next);
@@ -268,6 +270,7 @@ async function runLogout(): Promise<CodexOAuthStatus> {
       secrets: cfg.secrets,
       providers: nextProviders,
       ...(cfg.designSystem !== undefined ? { designSystem: cfg.designSystem } : {}),
+      ...(cfg.imageGeneration !== undefined ? { imageGeneration: cfg.imageGeneration } : {}),
     });
     await writeConfig(next);
     setCachedConfig(next);
@@ -325,6 +328,7 @@ export async function migrateStaleCodexEntryIfNeeded(): Promise<void> {
     secrets: cfg.secrets,
     providers: nextProviders,
     ...(cfg.designSystem !== undefined ? { designSystem: cfg.designSystem } : {}),
+    ...(cfg.imageGeneration !== undefined ? { imageGeneration: cfg.imageGeneration } : {}),
   });
   await writeConfig(next);
   setCachedConfig(next);

--- a/apps/desktop/src/main/image-generation-settings.test.ts
+++ b/apps/desktop/src/main/image-generation-settings.test.ts
@@ -19,6 +19,8 @@ import {
 const mocks = vi.hoisted(() => ({
   cachedConfig: null as Config | null,
   getApiKeyForProvider: vi.fn<(provider: string) => string>(),
+  codexRead: vi.fn<() => Promise<unknown>>(),
+  codexGetValidAccessToken: vi.fn<() => Promise<string>>(),
   setCachedConfig: vi.fn<(config: Config) => void>(),
   writeConfig: vi.fn<(config: Config) => Promise<void>>(),
 }));
@@ -36,6 +38,13 @@ vi.mock('./onboarding-ipc', () => ({
     mocks.cachedConfig = config;
     mocks.setCachedConfig(config);
   },
+}));
+
+vi.mock('./codex-oauth-ipc', () => ({
+  getCodexTokenStore: () => ({
+    read: mocks.codexRead,
+    getValidAccessToken: mocks.codexGetValidAccessToken,
+  }),
 }));
 
 vi.mock('./keychain', () => ({
@@ -92,41 +101,53 @@ function expectThrowCode(fn: () => unknown, code: string): void {
   throw new Error(`Expected function to throw ${code}`);
 }
 
+async function expectRejectCode(promise: Promise<unknown>, code: string): Promise<void> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toMatchObject({ code });
+    return;
+  }
+  throw new Error(`Expected promise to reject ${code}`);
+}
+
 describe('image generation enablement', () => {
   afterEach(() => {
     mocks.cachedConfig = null;
     getApiKeyForProviderMock.mockReset();
+    mocks.codexRead.mockReset();
+    mocks.codexGetValidAccessToken.mockReset();
     mocks.setCachedConfig.mockReset();
     mocks.writeConfig.mockReset();
   });
 
-  it('disables generate_image_asset when image generation is turned off', () => {
+  it('disables generate_image_asset when image generation is turned off', async () => {
     const cfg = makeConfig(false);
-    expect(isGenerateImageAssetEnabled(cfg)).toBe(false);
-    expect(resolveImageGenerationConfig(cfg)).toBeNull();
+    await expect(isGenerateImageAssetEnabled(cfg)).resolves.toBe(false);
+    await expect(resolveImageGenerationConfig(cfg)).resolves.toBeNull();
   });
 
-  it('enables generate_image_asset when image generation is on and key is available', () => {
+  it('enables generate_image_asset when image generation is on and key is available', async () => {
     getApiKeyForProviderMock.mockReturnValue('sk-openai');
     const cfg = makeConfig(true);
-    expect(isGenerateImageAssetEnabled(cfg)).toBe(true);
-    expect(resolveImageGenerationConfig(cfg)).toMatchObject({
+    await expect(isGenerateImageAssetEnabled(cfg)).resolves.toBe(true);
+    await expect(resolveImageGenerationConfig(cfg)).resolves.toMatchObject({
       provider: 'openai',
       model: 'gpt-image-2',
       apiKey: 'sk-openai',
     });
   });
 
-  it('throws when image generation is on but inherited key is unavailable', () => {
+  it('throws when image generation is on but inherited key is unavailable', async () => {
     getApiKeyForProviderMock.mockImplementation(() => {
       throw new CodesignError('missing key', ERROR_CODES.PROVIDER_KEY_MISSING);
     });
     const cfg = makeConfig(true);
-    expect(() => isGenerateImageAssetEnabled(cfg)).toThrow(/missing key/);
-    expect(() => resolveImageGenerationConfig(cfg)).toThrow(/missing key/);
+    await expect(isGenerateImageAssetEnabled(cfg)).rejects.toThrow(/missing key/);
+    await expect(resolveImageGenerationConfig(cfg)).rejects.toThrow(/missing key/);
   });
 
-  it('throws PROVIDER_KEY_MISSING when custom credential mode has no custom key', () => {
+  it('throws PROVIDER_KEY_MISSING when custom credential mode has no custom key', async () => {
     const cfg = makeConfig(true);
     const parsed = hydrateConfig({
       version: 3,
@@ -146,38 +167,155 @@ describe('image generation enablement', () => {
       },
     });
 
-    expectThrowCode(() => resolveImageGenerationConfig(parsed), ERROR_CODES.PROVIDER_KEY_MISSING);
+    await expectRejectCode(resolveImageGenerationConfig(parsed), ERROR_CODES.PROVIDER_KEY_MISSING);
   });
 
-  it('reports inheritedKeyAvailable=false in the view when the provider key is missing', () => {
+  it('reports inheritedKeyAvailable=false in the view when the provider key is missing', async () => {
     getApiKeyForProviderMock.mockImplementation(() => {
       throw new CodesignError('missing key', ERROR_CODES.PROVIDER_KEY_MISSING);
     });
     const cfg = makeConfig(true);
-    const view = imageSettingsToView(cfg.imageGeneration);
+    const view = await imageSettingsToView(cfg.imageGeneration);
     expect(view.enabled).toBe(true);
     expect(view.credentialMode).toBe('inherit');
     expect(view.inheritedKeyAvailable).toBe(false);
     expect(view.hasCustomKey).toBe(false);
   });
 
-  it('reports inheritedKeyAvailable=true in the view when the provider key exists', () => {
+  it('reports inheritedKeyAvailable=true in the view when the provider key exists', async () => {
     getApiKeyForProviderMock.mockReturnValue('sk-openai');
     const cfg = makeConfig(true);
-    const view = imageSettingsToView(cfg.imageGeneration);
+    const view = await imageSettingsToView(cfg.imageGeneration);
     expect(view.inheritedKeyAvailable).toBe(true);
   });
 
-  it('throws credential corruption instead of reporting it as a missing inherited key', () => {
+  it('throws credential corruption instead of reporting it as a missing inherited key', async () => {
     getApiKeyForProviderMock.mockImplementation(() => {
       throw new CodesignError('decrypt failed', ERROR_CODES.KEYCHAIN_UNAVAILABLE);
     });
     const cfg = makeConfig(true);
-    expectThrowCode(
-      () => imageSettingsToView(cfg.imageGeneration),
+    await expectRejectCode(
+      imageSettingsToView(cfg.imageGeneration),
       ERROR_CODES.KEYCHAIN_UNAVAILABLE,
     );
-    expectThrowCode(() => imageGenerationKeyAvailable(cfg), ERROR_CODES.KEYCHAIN_UNAVAILABLE);
+    await expectRejectCode(imageGenerationKeyAvailable(cfg), ERROR_CODES.KEYCHAIN_UNAVAILABLE);
+  });
+
+  it('resolves ChatGPT subscription image generation through the OAuth token store', async () => {
+    mocks.codexGetValidAccessToken.mockResolvedValue('oauth-token');
+    const cfg = hydrateConfig({
+      version: 3,
+      activeProvider: 'chatgpt-codex',
+      activeModel: 'gpt-5.5',
+      providers: {
+        'chatgpt-codex': {
+          id: 'chatgpt-codex',
+          name: 'ChatGPT subscription',
+          builtin: false,
+          wire: 'openai-codex-responses',
+          baseUrl: 'https://chatgpt.com/backend-api',
+          defaultModel: 'gpt-5.5',
+          requiresApiKey: false,
+        },
+      },
+      secrets: {},
+      imageGeneration: {
+        schemaVersion: IMAGE_GENERATION_SCHEMA_VERSION,
+        enabled: true,
+        provider: 'chatgpt-codex',
+        credentialMode: 'inherit',
+        model: 'gpt-5.5',
+        quality: 'high',
+        size: '1536x1024',
+        outputFormat: 'png',
+      },
+    });
+
+    await expect(resolveImageGenerationConfig(cfg)).resolves.toMatchObject({
+      provider: 'chatgpt-codex',
+      model: 'gpt-5.5',
+      apiKey: 'oauth-token',
+      baseUrl: 'https://chatgpt.com/backend-api',
+    });
+    expect(getApiKeyForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('reports ChatGPT subscription inherited credential availability from OAuth status', async () => {
+    mocks.codexRead.mockResolvedValue({
+      schemaVersion: 1,
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      idToken: 'id',
+      expiresAt: Date.now() + 1000,
+      accountId: 'acct',
+      email: 'person@example.com',
+      updatedAt: Date.now(),
+    });
+    const view = await imageSettingsToView({
+      schemaVersion: IMAGE_GENERATION_SCHEMA_VERSION,
+      enabled: true,
+      provider: 'chatgpt-codex',
+      credentialMode: 'inherit',
+      model: 'gpt-5.5',
+      quality: 'high',
+      size: '1536x1024',
+      outputFormat: 'png',
+    });
+
+    expect(view.inheritedKeyAvailable).toBe(true);
+  });
+
+  it('reports ChatGPT subscription key availability from imageGenerationKeyAvailable', async () => {
+    const cfg = hydrateConfig({
+      version: 3,
+      activeProvider: 'openai',
+      activeModel: 'gpt-5.4',
+      providers: {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          builtin: true,
+          wire: 'openai-chat',
+          baseUrl: 'https://api.openai.com/v1',
+          defaultModel: 'gpt-5.4',
+        },
+        'chatgpt-codex': {
+          id: 'chatgpt-codex',
+          name: 'ChatGPT subscription',
+          builtin: false,
+          wire: 'openai-codex-responses',
+          baseUrl: 'https://chatgpt.com/backend-api',
+          defaultModel: 'gpt-5.5',
+          requiresApiKey: false,
+        },
+      },
+      secrets: {},
+      imageGeneration: {
+        schemaVersion: IMAGE_GENERATION_SCHEMA_VERSION,
+        enabled: true,
+        provider: 'chatgpt-codex',
+        credentialMode: 'inherit',
+        model: 'gpt-5.5',
+        quality: 'high',
+        size: '1536x1024',
+        outputFormat: 'png',
+      },
+    });
+
+    mocks.codexRead.mockResolvedValue({
+      schemaVersion: 1,
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      idToken: 'id',
+      expiresAt: Date.now() + 1000,
+      accountId: 'acct',
+      email: 'person@example.com',
+      updatedAt: Date.now(),
+    });
+    await expect(imageGenerationKeyAvailable(cfg)).resolves.toBe(true);
+
+    mocks.codexRead.mockResolvedValue(null);
+    await expect(imageGenerationKeyAvailable(cfg)).resolves.toBe(false);
   });
 
   it('clears provider-scoped custom keys when the image provider changes', async () => {

--- a/apps/desktop/src/main/image-generation-settings.ts
+++ b/apps/desktop/src/main/image-generation-settings.ts
@@ -4,6 +4,7 @@ import {
   type GenerateImageOptions,
 } from '@open-codesign/providers';
 import {
+  CHATGPT_CODEX_PROVIDER_ID,
   CodesignError,
   type Config,
   ERROR_CODES,
@@ -22,6 +23,7 @@ import {
   type ImageGenerationSize,
   ImageGenerationSizeSchema,
 } from '@open-codesign/shared';
+import { getCodexTokenStore } from './codex-oauth-ipc';
 import { writeConfig } from './config';
 import { ipcMain } from './electron-runtime';
 import { buildSecretRef, decryptSecret } from './keychain';
@@ -132,11 +134,21 @@ function parseOptionalHttpUrl(raw: unknown, field: string): string | undefined {
 function isCredentialAvailabilityMiss(err: unknown): boolean {
   return (
     err instanceof CodesignError &&
-    (err.code === ERROR_CODES.CONFIG_MISSING || err.code === ERROR_CODES.PROVIDER_KEY_MISSING)
+    (err.code === ERROR_CODES.CONFIG_MISSING ||
+      err.code === ERROR_CODES.PROVIDER_KEY_MISSING ||
+      err.code === ERROR_CODES.CODEX_TOKEN_NOT_LOGGED_IN)
   );
 }
 
-function hasInheritedImageCredential(provider: ImageGenerationProvider): boolean {
+async function hasInheritedImageCredential(provider: ImageGenerationProvider): Promise<boolean> {
+  if (provider === CHATGPT_CODEX_PROVIDER_ID) {
+    try {
+      return (await getCodexTokenStore().read()) !== null;
+    } catch (err) {
+      if (isCredentialAvailabilityMiss(err)) return false;
+      throw err;
+    }
+  }
   try {
     getApiKeyForProvider(provider);
     return true;
@@ -169,11 +181,11 @@ export function defaultImageGenerationSettings(): ImageGenerationSettings {
   };
 }
 
-export function imageSettingsToView(
+export async function imageSettingsToView(
   settings: ImageGenerationSettings | undefined,
-): ImageGenerationSettingsView {
+): Promise<ImageGenerationSettingsView> {
   const parsed = ImageGenerationSettingsSchema.parse(settings ?? defaultImageGenerationSettings());
-  const inheritedKeyAvailable = hasInheritedImageCredential(parsed.provider);
+  const inheritedKeyAvailable = await hasInheritedImageCredential(parsed.provider);
   return {
     enabled: parsed.enabled,
     provider: parsed.provider,
@@ -189,13 +201,23 @@ export function imageSettingsToView(
   };
 }
 
-export function resolveImageGenerationConfig(cfg: Config): ResolvedImageGenerationConfig | null {
+export async function resolveImageGenerationConfig(
+  cfg: Config,
+): Promise<ResolvedImageGenerationConfig | null> {
   const settings = cfg.imageGeneration;
   if (settings === undefined) return null;
   if (settings.enabled !== true) return null;
   const parsed = ImageGenerationSettingsSchema.parse(settings);
   let apiKey: string;
-  if (parsed.credentialMode === 'custom') {
+  if (parsed.provider === CHATGPT_CODEX_PROVIDER_ID) {
+    if (parsed.credentialMode === 'custom') {
+      throw new CodesignError(
+        'ChatGPT subscription image generation uses the signed-in ChatGPT account, not a custom API key.',
+        ERROR_CODES.IPC_BAD_INPUT,
+      );
+    }
+    apiKey = await getCodexTokenStore().getValidAccessToken();
+  } else if (parsed.credentialMode === 'custom') {
     if (parsed.apiKey === undefined) {
       throw new CodesignError(
         `Image generation is enabled but no custom API key is stored for "${parsed.provider}".`,
@@ -224,17 +246,20 @@ export function resolveImageGenerationConfig(cfg: Config): ResolvedImageGenerati
   };
 }
 
-export function isGenerateImageAssetEnabled(cfg: Config): boolean {
-  return resolveImageGenerationConfig(cfg) !== null;
+export async function isGenerateImageAssetEnabled(cfg: Config): Promise<boolean> {
+  return (await resolveImageGenerationConfig(cfg)) !== null;
 }
 
-export function imageGenerationKeyAvailable(cfg: Config | null): boolean {
+export async function imageGenerationKeyAvailable(cfg: Config | null): Promise<boolean> {
   if (cfg === null) return false;
   const settings = cfg.imageGeneration;
   if (settings === undefined) return false;
   const parsed = ImageGenerationSettingsSchema.parse(settings);
+  if (parsed.provider === CHATGPT_CODEX_PROVIDER_ID) {
+    return await hasInheritedImageCredential(parsed.provider);
+  }
   if (parsed.credentialMode === 'custom') return parsed.apiKey !== undefined;
-  return hasInheritedImageCredential(parsed.provider);
+  return await hasInheritedImageCredential(parsed.provider);
 }
 
 export function toGenerateImageOptions(
@@ -335,10 +360,15 @@ export async function updateImageGenerationSettings(
   const { apiKey: apiKeyPatch, ...safePatch } = patch;
   const provider = patch.provider ?? current.provider;
   const providerChanged = patch.provider !== undefined && patch.provider !== current.provider;
+  const credentialMode =
+    provider === CHATGPT_CODEX_PROVIDER_ID
+      ? 'inherit'
+      : (patch.credentialMode ?? current.credentialMode);
   let next: ImageGenerationSettings = {
     ...current,
     ...safePatch,
     provider,
+    credentialMode,
     model: patch.model ?? (providerChanged ? defaultImageModel(provider) : current.model),
   };
   if (patch.baseUrl === undefined && providerChanged) {
@@ -346,6 +376,10 @@ export async function updateImageGenerationSettings(
   }
   if (providerChanged && apiKeyPatch === undefined && next.apiKey !== undefined) {
     const { apiKey: _providerScopedKey, ...rest } = next;
+    next = rest;
+  }
+  if (provider === CHATGPT_CODEX_PROVIDER_ID && next.apiKey !== undefined) {
+    const { apiKey: _chatgptDoesNotUseCustomKey, ...rest } = next;
     next = rest;
   }
   if (apiKeyPatch !== undefined) {

--- a/apps/desktop/src/main/ipc/generate.ts
+++ b/apps/desktop/src/main/ipc/generate.ts
@@ -455,7 +455,7 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
       designSkills,
     });
     const cfg = getCachedConfig();
-    const imageConfig = cfg ? resolveImageGenerationConfig(cfg) : null;
+    const imageConfig = cfg ? await resolveImageGenerationConfig(cfg) : null;
     const imageLog = getLogger('image-generation');
     const generateImageAsset = imageConfig
       ? async (

--- a/apps/desktop/src/renderer/src/components/settings/ImageGenerationTab.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/ImageGenerationTab.tsx
@@ -6,11 +6,15 @@ import { useCodesignStore } from '../../store';
 import { Label, NativeSelect, Row, SectionTitle, SegmentedControl } from './primitives';
 
 function defaultImageModelFor(provider: ImageGenerationSettingsView['provider']): string {
-  return provider === 'openrouter' ? 'openai/gpt-5.4-image-2' : 'gpt-image-2';
+  if (provider === 'openrouter') return 'openai/gpt-5.4-image-2';
+  if (provider === 'chatgpt-codex') return 'gpt-5.5';
+  return 'gpt-image-2';
 }
 
 function defaultImageBaseUrlFor(provider: ImageGenerationSettingsView['provider']): string {
-  return provider === 'openrouter' ? 'https://openrouter.ai/api/v1' : 'https://api.openai.com/v1';
+  if (provider === 'openrouter') return 'https://openrouter.ai/api/v1';
+  if (provider === 'chatgpt-codex') return 'https://chatgpt.com/backend-api';
+  return 'https://api.openai.com/v1';
 }
 
 function ImageGenerationPanel() {
@@ -92,6 +96,12 @@ function ImageGenerationPanel() {
     disabled:
       'bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] border-[var(--color-border-muted)]',
   };
+  const statusLabel =
+    status === 'needsKey' && settings.provider === 'chatgpt-codex'
+      ? t('settings.imageGen.status.needsChatgptLogin', {
+          defaultValue: 'Needs ChatGPT sign-in',
+        })
+      : t(`settings.imageGen.status.${status}`);
 
   return (
     <div className="rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] p-[var(--space-4)] space-y-[var(--space-4)]">
@@ -104,7 +114,7 @@ function ImageGenerationPanel() {
               <span
                 className={`inline-flex items-center h-5 px-1.5 rounded-full border text-[var(--text-xs)] font-medium tracking-wide uppercase ${statusStyles[status]}`}
               >
-                {t(`settings.imageGen.status.${status}`)}
+                {statusLabel}
               </span>
             </div>
             <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-0.5 leading-[var(--leading-body)]">
@@ -131,12 +141,19 @@ function ImageGenerationPanel() {
             disabled={saving}
             options={[
               { value: 'openai', label: 'OpenAI' },
+              {
+                value: 'chatgpt-codex',
+                label: t('settings.imageGen.chatgptSubscription', {
+                  defaultValue: 'ChatGPT subscription',
+                }),
+              },
               { value: 'openrouter', label: 'OpenRouter' },
             ]}
             onChange={(value) => {
               const provider = value as ImageGenerationSettingsView['provider'];
               void save({
                 provider,
+                credentialMode: provider === 'chatgpt-codex' ? 'inherit' : settings.credentialMode,
                 model: defaultImageModelFor(provider),
                 baseUrl: defaultImageBaseUrlFor(provider),
               });
@@ -146,7 +163,7 @@ function ImageGenerationPanel() {
         <Row label={t('settings.imageGen.credentials')}>
           <SegmentedControl
             value={settings.credentialMode}
-            disabled={saving}
+            disabled={saving || settings.provider === 'chatgpt-codex'}
             options={[
               { value: 'inherit', label: t('settings.imageGen.inherit') },
               { value: 'custom', label: t('settings.imageGen.customKey') },

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -273,6 +273,7 @@
       "hint": "When enabled, the agent can invoke generate_image_asset during a run.",
       "enabled": "Enable image generation assist",
       "provider": "Provider",
+      "chatgptSubscription": "ChatGPT subscription",
       "credentials": "Credentials",
       "inherit": "Inherit from model provider",
       "customKey": "Use a separate key",
@@ -285,6 +286,7 @@
       "status": {
         "ready": "Ready",
         "needsKey": "Needs API key",
+        "needsChatgptLogin": "Needs ChatGPT sign-in",
         "disabled": "Disabled"
       },
       "toast": {

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -244,6 +244,7 @@
       "hint": "Cuando está habilitado, el agente puede invocar generate_image_asset durante una ejecución.",
       "enabled": "Habilitar asistente de generación de imágenes",
       "provider": "Proveedor",
+      "chatgptSubscription": "Suscripción de ChatGPT",
       "credentials": "Credenciales",
       "inherit": "Heredar del proveedor del modelo",
       "customKey": "Usar una clave separada",
@@ -256,6 +257,7 @@
       "status": {
         "ready": "Listo",
         "needsKey": "Necesita clave API",
+        "needsChatgptLogin": "Necesita iniciar sesión en ChatGPT",
         "disabled": "Deshabilitado"
       },
       "toast": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -273,6 +273,7 @@
       "hint": "开启后，Agent 在生成设计时可以调用 generate_image_asset 工具。",
       "enabled": "启用图像生成辅助",
       "provider": "服务商",
+      "chatgptSubscription": "ChatGPT 订阅",
       "credentials": "凭据方式",
       "inherit": "沿用模型服务商",
       "customKey": "单独设置 Key",
@@ -285,6 +286,7 @@
       "status": {
         "ready": "可用",
         "needsKey": "缺少 API Key",
+        "needsChatgptLogin": "需要登录 ChatGPT",
         "disabled": "未启用"
       },
       "toast": {

--- a/packages/providers/src/images.test.ts
+++ b/packages/providers/src/images.test.ts
@@ -5,6 +5,14 @@ import { defaultImageModel, generateImage } from './images';
 const PNG_HEADER_BASE64 = 'iVBORw0KGgo=';
 const WEBP_HEADER_BASE64 = 'UklGRgAAAABXRUJQ';
 
+function jwtWithClaims(claims: Record<string, unknown>): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url'),
+    Buffer.from(JSON.stringify(claims)).toString('base64url'),
+    'sig',
+  ].join('.');
+}
+
 describe('generateImage', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -105,6 +113,73 @@ describe('generateImage', () => {
       model: defaultImageModel('openrouter'),
       mimeType: 'image/webp',
       base64: WEBP_HEADER_BASE64,
+    });
+  });
+
+  it('calls ChatGPT Codex responses with OAuth headers and extracts streamed image data', async () => {
+    const token = jwtWithClaims({
+      'https://api.openai.com/auth': { chatgpt_account_id: 'acct_test' },
+      email: 'person@example.com',
+    });
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        [
+          'data: {"type":"response.output_item.done","item":{"type":"image_generation_call","result":"iVBORw0KGgo=","revised_prompt":"A tabby cat with an otter"}}',
+          'data: {"type":"response.completed","response":{"status":"completed","output":[]}}',
+          '',
+        ].join('\n\n'),
+        { status: 200, headers: { 'content-type': 'text/event-stream' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateImage({
+      provider: 'chatgpt-codex',
+      apiKey: token,
+      prompt: 'draw a cat hugging an otter',
+      size: '1024x1024',
+      quality: 'high',
+      outputFormat: 'png',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://chatgpt.com/backend-api/codex/responses',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: `Bearer ${token}`,
+          'chatgpt-account-id': 'acct_test',
+          accept: 'text/event-stream',
+          'openai-beta': 'responses=experimental',
+        }),
+        body: JSON.stringify({
+          model: 'gpt-5.5',
+          store: false,
+          stream: true,
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'draw a cat hugging an otter' }],
+            },
+          ],
+          tools: [
+            {
+              type: 'image_generation',
+              size: '1024x1024',
+              quality: 'high',
+              output_format: 'png',
+            },
+          ],
+          tool_choice: { type: 'image_generation' },
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      provider: 'chatgpt-codex',
+      model: 'gpt-5.5',
+      mimeType: 'image/png',
+      base64: PNG_HEADER_BASE64,
+      revisedPrompt: 'A tabby cat with an otter',
     });
   });
 

--- a/packages/providers/src/images.ts
+++ b/packages/providers/src/images.ts
@@ -1,6 +1,6 @@
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
 
-export type ImageGenerationProvider = 'openai' | 'openrouter';
+export type ImageGenerationProvider = 'openai' | 'openrouter' | 'chatgpt-codex';
 export type ImageOutputFormat = 'png' | 'jpeg' | 'webp';
 export type ImageQuality = 'auto' | 'low' | 'medium' | 'high';
 export type ImageSize = 'auto' | '1024x1024' | '1536x1024' | '1024x1536';
@@ -55,18 +55,38 @@ interface OpenRouterImageResponse {
   }>;
 }
 
+interface ChatGPTCodexImageEvent {
+  type?: unknown;
+  code?: unknown;
+  message?: unknown;
+  item?: unknown;
+  response?: unknown;
+}
+
+interface ImageGenerationCallItem {
+  type?: unknown;
+  result?: unknown;
+  revised_prompt?: unknown;
+}
+
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const DEFAULT_CHATGPT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api';
 const DEFAULT_OPENAI_IMAGE_MODEL = 'gpt-image-2';
 const DEFAULT_OPENROUTER_IMAGE_MODEL = 'openai/gpt-5.4-image-2';
+const DEFAULT_CHATGPT_CODEX_IMAGE_MODEL = 'gpt-5.5';
 const BASE64_IMAGE_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
 export function defaultImageModel(provider: ImageGenerationProvider): string {
-  return provider === 'openrouter' ? DEFAULT_OPENROUTER_IMAGE_MODEL : DEFAULT_OPENAI_IMAGE_MODEL;
+  if (provider === 'openrouter') return DEFAULT_OPENROUTER_IMAGE_MODEL;
+  if (provider === 'chatgpt-codex') return DEFAULT_CHATGPT_CODEX_IMAGE_MODEL;
+  return DEFAULT_OPENAI_IMAGE_MODEL;
 }
 
 export function defaultImageBaseUrl(provider: ImageGenerationProvider): string {
-  return provider === 'openrouter' ? DEFAULT_OPENROUTER_BASE_URL : DEFAULT_OPENAI_BASE_URL;
+  if (provider === 'openrouter') return DEFAULT_OPENROUTER_BASE_URL;
+  if (provider === 'chatgpt-codex') return DEFAULT_CHATGPT_CODEX_BASE_URL;
+  return DEFAULT_OPENAI_BASE_URL;
 }
 
 export async function generateImage(options: GenerateImageOptions): Promise<GenerateImageResult> {
@@ -77,9 +97,11 @@ export async function generateImage(options: GenerateImageOptions): Promise<Gene
   if (prompt.length === 0) {
     throw new CodesignError('Image prompt cannot be empty', ERROR_CODES.INPUT_EMPTY_PROMPT);
   }
-  return options.provider === 'openrouter'
-    ? generateOpenRouterImage({ ...options, prompt })
-    : generateOpenAIImage({ ...options, prompt });
+  if (options.provider === 'openrouter') return generateOpenRouterImage({ ...options, prompt });
+  if (options.provider === 'chatgpt-codex') {
+    return generateChatGPTCodexImage({ ...options, prompt });
+  }
+  return generateOpenAIImage({ ...options, prompt });
 }
 
 async function generateOpenAIImage(
@@ -178,6 +200,187 @@ async function generateOpenRouterImage(
   );
 }
 
+async function generateChatGPTCodexImage(
+  options: GenerateImageOptions & { prompt: string },
+): Promise<GenerateImageResult> {
+  const model = options.model?.trim() || DEFAULT_CHATGPT_CODEX_IMAGE_MODEL;
+  const imageTool: Record<string, unknown> = {
+    type: 'image_generation',
+  };
+  if (options.size !== undefined) imageTool['size'] = options.size;
+  if (options.quality !== undefined) imageTool['quality'] = options.quality;
+  if (options.outputFormat !== undefined) imageTool['output_format'] = options.outputFormat;
+  if (options.background !== undefined) imageTool['background'] = options.background;
+
+  const body: Record<string, unknown> = {
+    model,
+    store: false,
+    stream: true,
+    input: [
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: options.prompt }],
+      },
+    ],
+    tools: [imageTool],
+    tool_choice: { type: 'image_generation' },
+  };
+
+  const { base64, revisedPrompt } = await postChatGPTCodexImageStream(
+    resolveCodexResponsesEndpoint(options.baseUrl ?? DEFAULT_CHATGPT_CODEX_BASE_URL),
+    body,
+    options,
+  );
+  const mimeType = mimeFromFormat(options.outputFormat ?? 'png');
+  const normalized = normalizeBase64ImageData(base64, 'ChatGPT image response');
+  validateImageSignature(mimeType, normalized, 'ChatGPT image response');
+  return {
+    dataUrl: `data:${mimeType};base64,${normalized}`,
+    base64: normalized,
+    mimeType,
+    model,
+    provider: 'chatgpt-codex',
+    ...(revisedPrompt !== undefined ? { revisedPrompt } : {}),
+  };
+}
+
+async function postChatGPTCodexImageStream(
+  url: string,
+  body: Record<string, unknown>,
+  options: GenerateImageOptions,
+): Promise<{ base64: string; revisedPrompt?: string | undefined }> {
+  let res: Response;
+  const accountId = extractChatGPTAccountId(options.apiKey);
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+      headers: {
+        authorization: `Bearer ${options.apiKey}`,
+        'chatgpt-account-id': accountId,
+        originator: 'open-codesign',
+        'openai-beta': 'responses=experimental',
+        'content-type': 'application/json',
+        accept: 'text/event-stream',
+        ...(options.httpHeaders ?? {}),
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new CodesignError(
+      `Image generation request failed: ${message}`,
+      ERROR_CODES.PROVIDER_ERROR,
+      {
+        cause: err,
+      },
+    );
+  }
+  if (!res.ok) {
+    const text = await safeResponseText(res);
+    throw new CodesignError(
+      `Image generation failed with HTTP ${res.status}${text.length > 0 ? `: ${text}` : ''}`,
+      ERROR_CODES.PROVIDER_ERROR,
+    );
+  }
+  const text = await safeResponseText(res, Number.POSITIVE_INFINITY);
+  const parsed = parseChatGPTCodexImageStream(text);
+  if (parsed !== null) return parsed;
+
+  try {
+    const json = JSON.parse(text) as unknown;
+    const item = findImageGenerationCall(json);
+    if (item !== null) return item;
+  } catch {
+    // Keep the provider-facing error below focused on the missing image result.
+  }
+  throw new CodesignError(
+    'ChatGPT image response did not include generated image data',
+    ERROR_CODES.PROVIDER_ERROR,
+  );
+}
+
+function parseChatGPTCodexImageStream(
+  text: string,
+): { base64: string; revisedPrompt?: string | undefined } | null {
+  let found: { base64: string; revisedPrompt?: string | undefined } | null = null;
+  const chunks = text.split(/\r?\n\r?\n/);
+  for (const chunk of chunks) {
+    const data = chunk
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trim())
+      .join('\n')
+      .trim();
+    if (data.length === 0 || data === '[DONE]') continue;
+    let event: ChatGPTCodexImageEvent;
+    try {
+      event = JSON.parse(data) as ChatGPTCodexImageEvent;
+    } catch {
+      continue;
+    }
+    if (event.type === 'error') {
+      const message = typeof event.message === 'string' ? event.message : JSON.stringify(event);
+      throw new CodesignError(
+        `ChatGPT image generation failed: ${message}`,
+        ERROR_CODES.PROVIDER_ERROR,
+      );
+    }
+    if (event.type === 'response.failed') {
+      const message = responseErrorMessage(event.response) ?? 'ChatGPT image generation failed';
+      throw new CodesignError(message, ERROR_CODES.PROVIDER_ERROR);
+    }
+    const item =
+      event.type === 'response.output_item.done' ? readImageGenerationCall(event.item) : null;
+    if (item !== null) found = item;
+    const responseItem =
+      event.type === 'response.completed' || event.type === 'response.done'
+        ? findImageGenerationCall(event.response)
+        : null;
+    if (responseItem !== null) found = responseItem;
+  }
+  return found;
+}
+
+function findImageGenerationCall(
+  value: unknown,
+): { base64: string; revisedPrompt?: string | undefined } | null {
+  if (value === null || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const direct = readImageGenerationCall(record);
+  if (direct !== null) return direct;
+  const output = record['output'];
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      const parsed = readImageGenerationCall(item);
+      if (parsed !== null) return parsed;
+    }
+  }
+  return null;
+}
+
+function readImageGenerationCall(
+  value: unknown,
+): { base64: string; revisedPrompt?: string | undefined } | null {
+  if (value === null || typeof value !== 'object') return null;
+  const item = value as ImageGenerationCallItem;
+  if (item.type !== 'image_generation_call') return null;
+  if (typeof item.result !== 'string' || item.result.length === 0) return null;
+  const revisedPrompt =
+    typeof item.revised_prompt === 'string' && item.revised_prompt.length > 0
+      ? item.revised_prompt
+      : undefined;
+  return { base64: item.result, ...(revisedPrompt !== undefined ? { revisedPrompt } : {}) };
+}
+
+function responseErrorMessage(response: unknown): string | null {
+  if (response === null || typeof response !== 'object') return null;
+  const error = (response as Record<string, unknown>)['error'];
+  if (error === null || typeof error !== 'object') return null;
+  const message = (error as Record<string, unknown>)['message'];
+  return typeof message === 'string' && message.length > 0 ? message : null;
+}
+
 async function postJson<T>(
   url: string,
   body: Record<string, unknown>,
@@ -235,6 +438,61 @@ function joinEndpoint(baseUrl: string, path: string): string {
   let start = 0;
   while (start < path.length && path.charCodeAt(start) === 47) start++;
   return `${baseUrl.slice(0, end)}/${path.slice(start)}`;
+}
+
+function resolveCodexResponsesEndpoint(baseUrl: string): string {
+  const trimmed = baseUrl.trim();
+  let end = trimmed.length;
+  while (end > 0 && trimmed.charCodeAt(end - 1) === 47) end--;
+  const normalized = trimmed.slice(0, end);
+  if (normalized.endsWith('/codex/responses')) return normalized;
+  if (normalized.endsWith('/codex')) return `${normalized}/responses`;
+  return `${normalized}/codex/responses`;
+}
+
+function extractChatGPTAccountId(token: string): string {
+  const claims = decodeJwtClaims(token);
+  const topLevel = readNonEmptyString(claims?.['chatgpt_account_id']);
+  if (topLevel !== null) return topLevel;
+  const nested = claims?.['https://api.openai.com/auth'];
+  if (nested !== null && typeof nested === 'object') {
+    const accountId = readNonEmptyString(
+      (nested as { chatgpt_account_id?: unknown }).chatgpt_account_id,
+    );
+    if (accountId !== null) return accountId;
+  }
+  const organizations = claims?.['organizations'];
+  if (Array.isArray(organizations)) {
+    for (const org of organizations) {
+      if (org !== null && typeof org === 'object') {
+        const id = readNonEmptyString((org as { id?: unknown }).id);
+        if (id !== null) return id;
+      }
+    }
+  }
+  throw new CodesignError(
+    'ChatGPT OAuth token does not include an account id',
+    ERROR_CODES.CODEX_TOKEN_PARSE_FAILED,
+  );
+}
+
+function decodeJwtClaims(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.');
+    const payload = parts[1];
+    if (parts.length < 2 || payload === undefined || payload.length === 0) return null;
+    const parsed: unknown = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function mimeFromFormat(format: ImageOutputFormat): string {
@@ -306,9 +564,10 @@ function validateImageSignature(mimeType: string, base64: string, source: string
   }
 }
 
-async function safeResponseText(res: Response): Promise<string> {
+async function safeResponseText(res: Response, limit = 500): Promise<string> {
   try {
-    return (await res.text()).slice(0, 500);
+    const text = await res.text();
+    return Number.isFinite(limit) ? text.slice(0, limit) : text;
   } catch (err) {
     void err;
     // The non-2xx HTTP status is already the failure; the body is diagnostic.

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -118,7 +118,11 @@ export type ProviderCapabilities = z.infer<typeof ProviderCapabilitiesSchema>;
 
 export const IMAGE_GENERATION_SCHEMA_VERSION = 1 as const;
 
-export const ImageGenerationProviderSchema = z.enum(['openai', 'openrouter']);
+export const ImageGenerationProviderSchema = z.enum([
+  'openai',
+  'openrouter',
+  CHATGPT_CODEX_PROVIDER_ID,
+]);
 export type ImageGenerationProvider = z.infer<typeof ImageGenerationProviderSchema>;
 
 export const ImageGenerationCredentialModeSchema = z.enum(['inherit', 'custom']);


### PR DESCRIPTION
## Summary
- add ChatGPT subscription as an image generation credential source backed by the existing ChatGPT OAuth token store
- route ChatGPT subscription image requests through the Codex responses backend with streamed image-generation parsing
- keep OpenAI/OpenRouter API-key flows unchanged and preserve image generation settings during ChatGPT OAuth config updates

## Notes
- ChatGPT subscription billing remains separate from OpenAI Platform API billing; this PR uses the signed-in ChatGPT/Codex OAuth path, not Platform API credits.

## Verification
- pnpm --filter @open-codesign/providers test -- images.test.ts
- pnpm --filter @open-codesign/shared test -- config.test.ts
- pnpm --filter @open-codesign/desktop test -- image-generation-settings.test.ts codex-oauth-ipc.test.ts
- pnpm --filter @open-codesign/providers typecheck
- pnpm --filter @open-codesign/shared typecheck
- pnpm --filter @open-codesign/desktop typecheck
- pnpm exec biome check .changeset/chatgpt-image-oauth.md apps/desktop/src/main/codex-oauth-ipc.ts apps/desktop/src/main/image-generation-settings.test.ts apps/desktop/src/main/image-generation-settings.ts apps/desktop/src/main/ipc/generate.ts apps/desktop/src/renderer/src/components/settings/ImageGenerationTab.tsx packages/i18n/src/locales/en.json packages/i18n/src/locales/es.json packages/i18n/src/locales/zh-CN.json packages/providers/src/images.test.ts packages/providers/src/images.ts packages/shared/src/config.ts