### PR TITLE
feat: add local workspace workflow

### DIFF
--- a/.changeset/local-workspace-preview.md
+++ b/.changeset/local-workspace-preview.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/desktop": minor
+---
+
+Add workspace-backed design creation, file browsing, project rebinding, and local preview modes, including a packaged preview runtime dependency fix so desktop builds include `ms` for `puppeteer-core`/`debug`.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "jszip": "^3.10.1",
+    "ms": "2.1.3",
     "puppeteer-core": "^24.42.0"
   },
   "devDependencies": {

--- a/apps/desktop/src/main/ask-ipc.test.ts
+++ b/apps/desktop/src/main/ask-ipc.test.ts
@@ -59,6 +59,27 @@ describe('ask-ipc', () => {
     await expect(second).resolves.toEqual({ status: 'cancelled', answers: [] });
   });
 
+  it('lists pending ask requests so the renderer can recover a missed event', async () => {
+    handlers.clear();
+    registerAskIpc();
+    const send = vi.fn();
+    const fakeWindow = {
+      isDestroyed: () => false,
+      webContents: { send },
+    } as unknown as Electron.BrowserWindow;
+    const inFlight = requestAsk('session-recover', sampleInput, () => fakeWindow);
+    const listPending = handlers.get('ask:list-pending');
+    if (!listPending) throw new Error('ask:list-pending handler not registered');
+
+    const result = listPending(null, undefined);
+
+    expect(result).toEqual([
+      expect.objectContaining({ sessionId: 'session-recover', input: sampleInput }),
+    ]);
+    cancelPendingAskRequests('session-recover');
+    await expect(inFlight).resolves.toEqual({ status: 'cancelled', answers: [] });
+  });
+
   it('rejects malformed answers for a known request instead of leaving it pending', async () => {
     handlers.clear();
     registerAskIpc();

--- a/apps/desktop/src/main/ask-ipc.ts
+++ b/apps/desktop/src/main/ask-ipc.ts
@@ -20,6 +20,7 @@ interface PendingAsk {
   resolve: (result: AskResult) => void;
   reject: (reason?: unknown) => void;
   sessionId: string;
+  input: AskInput;
 }
 
 const pending = new Map<string, PendingAsk>();
@@ -31,6 +32,8 @@ export interface AskRequestPayload {
 }
 
 export function registerAskIpc(): void {
+  ipcMain.handle('ask:list-pending', () => listPendingAskRequests());
+
   ipcMain.handle('ask:resolve', (_event, raw: unknown) => {
     const requestId = readRequestId(raw, 'ask:resolve');
     const entry = pending.get(requestId);
@@ -70,7 +73,7 @@ export function requestAsk(
 ): Promise<AskResult> {
   const requestId = `ask-${randomUUID()}`;
   return new Promise<AskResult>((resolve, reject) => {
-    pending.set(requestId, { resolve, reject, sessionId });
+    pending.set(requestId, { resolve, reject, sessionId, input });
     const win = getMainWindow();
     if (!win || win.isDestroyed()) {
       pending.delete(requestId);
@@ -86,6 +89,14 @@ export function requestAsk(
     });
     win.webContents.send('ask:request', payload);
   });
+}
+
+export function listPendingAskRequests(): AskRequestPayload[] {
+  return Array.from(pending, ([requestId, entry]) => ({
+    requestId,
+    sessionId: entry.sessionId,
+    input: entry.input,
+  }));
 }
 
 export function cancelPendingAskRequests(sessionId: string): void {

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { copyFile, mkdir, stat } from 'node:fs/promises';
 import path from 'node:path';
-import type { Design } from '@open-codesign/shared';
+import type { Design, WorkspaceMode } from '@open-codesign/shared';
 import { type BrowserWindow, dialog, shell } from 'electron';
 import { getLogger } from './logger';
 import {
@@ -145,6 +145,7 @@ export async function bindWorkspace(
   designId: string,
   workspacePath: string | null,
   migrateFiles: boolean,
+  workspaceMode?: WorkspaceMode,
 ): Promise<Design> {
   const current = requireDesign(db, designId);
 
@@ -183,7 +184,7 @@ export async function bindWorkspace(
     await migrateWorkspaceFiles(db, designId, normalizedPath);
   }
 
-  const updated = updateDesignWorkspace(db, designId, normalizedPath);
+  const updated = updateDesignWorkspace(db, designId, normalizedPath, workspaceMode);
   if (updated === null) {
     throw new Error(`Design not found: ${designId}`);
   }

--- a/apps/desktop/src/main/done-verify.test.ts
+++ b/apps/desktop/src/main/done-verify.test.ts
@@ -1,3 +1,6 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   formatRuntimeLoadError,
@@ -34,23 +37,18 @@ describe('done runtime verifier error formatting', () => {
   });
 
   it('allows only the verifier file for file:// requests', () => {
+    const verifyFilePath = join(tmpdir(), 'codesign-done', 'verify.html');
+    expect(isDoneVerifierRequestAllowed(pathToFileURL(verifyFilePath).href, verifyFilePath)).toBe(
+      true,
+    );
     expect(
       isDoneVerifierRequestAllowed(
-        'file:///tmp/codesign-done/verify.html',
-        '/tmp/codesign-done/verify.html',
-      ),
-    ).toBe(true);
-    expect(
-      isDoneVerifierRequestAllowed(
-        'file:///Users/me/private.txt',
-        '/tmp/codesign-done/verify.html',
+        pathToFileURL(join(tmpdir(), 'private.txt')).href,
+        verifyFilePath,
       ),
     ).toBe(false);
-    expect(
-      isDoneVerifierRequestAllowed(
-        'https://fonts.googleapis.com/css2',
-        '/tmp/codesign-done/verify.html',
-      ),
-    ).toBe(true);
+    expect(isDoneVerifierRequestAllowed('https://fonts.googleapis.com/css2', verifyFilePath)).toBe(
+      true,
+    );
   });
 });

--- a/apps/desktop/src/main/exporter-ipc.test.ts
+++ b/apps/desktop/src/main/exporter-ipc.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { CodesignError } from '@open-codesign/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
@@ -64,7 +64,7 @@ describe('parseRequest', () => {
     expect(result.sourcePath).toBe('screens/home/index.html');
     expect(exportAssetOptions(result)).toMatchObject({
       assetRootPath: '/workspace',
-      assetBasePath: '/workspace/screens/home',
+      assetBasePath: resolve('/workspace', 'screens/home'),
       sourcePath: 'screens/home/index.html',
     });
   });
@@ -103,7 +103,7 @@ describe('parseRequest', () => {
 
     expect(result.sourcePath).toBe('screens/home/App.jsx');
     expect(exportAssetOptions(result)).toMatchObject({
-      assetBasePath: '/workspace/screens/home',
+      assetBasePath: resolve('/workspace', 'screens/home'),
       sourcePath: 'screens/home/App.jsx',
     });
   });
@@ -131,7 +131,7 @@ describe('export path helpers', () => {
       now: new Date('2026-05-05T10:20:30.000Z'),
     });
 
-    expect(out).toBe('/Users/roy/Downloads/Launch-Deck-Q2-Home-2026-05-05-102030.pptx');
+    expect(out).toBe(join('/Users/roy/Downloads', 'Launch-Deck-Q2-Home-2026-05-05-102030.pptx'));
   });
 
   it('falls back to an open-codesign name inside Downloads when no design name is available', () => {
@@ -143,7 +143,7 @@ describe('export path helpers', () => {
       now: new Date('2026-05-05T10:20:30.000Z'),
     });
 
-    expect(out).toBe('/Users/roy/Downloads/open-codesign-App-2026-05-05-102030.md');
+    expect(out).toBe(join('/Users/roy/Downloads', 'open-codesign-App-2026-05-05-102030.md'));
   });
 
   it('treats legacy defaultFilename as a Downloads filename, not a cwd-relative path', () => {
@@ -154,7 +154,7 @@ describe('export path helpers', () => {
       now: new Date('2026-05-05T10:20:30.000Z'),
     });
 
-    expect(out).toBe('/Users/roy/Downloads/codesign-2026-05-05T06-04-43.html');
+    expect(out).toBe(join('/Users/roy/Downloads', 'codesign-2026-05-05T06-04-43.html'));
   });
 
   it('keeps legacy defaultFilename on the requested format extension', () => {
@@ -165,7 +165,7 @@ describe('export path helpers', () => {
       now: new Date('2026-05-05T10:20:30.000Z'),
     });
 
-    expect(out).toBe('/Users/roy/Downloads/preview.html.pdf');
+    expect(out).toBe(join('/Users/roy/Downloads', 'preview.html.pdf'));
   });
 
   it('keeps export files on the selected format extension', () => {

--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -1,6 +1,7 @@
 import { CancelGenerationPayloadV1, CodesignError } from '@open-codesign/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  acquireInFlightWorkspaceGeneration,
   armGenerationTimeout,
   cancelGenerationRequest,
   extractGenerationTimeoutError,
@@ -197,12 +198,50 @@ describe('withInFlightGenerationForDesign', () => {
     const controller = makeController();
     const inFlight = new Map([['gen-1', controller]]);
     const inFlightByDesign = new Map([['design-1', { generationId: 'gen-1', startedAt: 1234 }]]);
+    const inFlightByWorkspace = new Map([
+      ['/workspace', { generationId: 'gen-1', startedAt: 1234 }],
+    ]);
     const logIpc = { info: vi.fn() };
 
-    cancelGenerationRequest('gen-1', inFlight, logIpc, inFlightByDesign);
+    cancelGenerationRequest('gen-1', inFlight, logIpc, inFlightByDesign, inFlightByWorkspace);
 
     expect(inFlight.has('gen-1')).toBe(false);
     expect(inFlightByDesign.has('design-1')).toBe(false);
+    expect(inFlightByWorkspace.has('/workspace')).toBe(false);
+  });
+});
+
+describe('acquireInFlightWorkspaceGeneration', () => {
+  it('rejects a second generation for the same workspace while the first is running', () => {
+    const inFlightByWorkspace = new Map<string, { generationId: string; startedAt: number }>();
+    const release = acquireInFlightWorkspaceGeneration('gen-1', '/workspace', inFlightByWorkspace);
+
+    expect(() =>
+      acquireInFlightWorkspaceGeneration('gen-2', '/workspace', inFlightByWorkspace),
+    ).toThrow(CodesignError);
+
+    release();
+    expect(inFlightByWorkspace.has('/workspace')).toBe(false);
+  });
+
+  it('allows different workspaces to run concurrently', () => {
+    const inFlightByWorkspace = new Map<string, { generationId: string; startedAt: number }>();
+    const releaseOne = acquireInFlightWorkspaceGeneration(
+      'gen-1',
+      '/workspace-a',
+      inFlightByWorkspace,
+    );
+    const releaseTwo = acquireInFlightWorkspaceGeneration(
+      'gen-2',
+      '/workspace-b',
+      inFlightByWorkspace,
+    );
+
+    expect([...inFlightByWorkspace.keys()].sort()).toEqual(['/workspace-a', '/workspace-b']);
+
+    releaseOne();
+    releaseTwo();
+    expect(inFlightByWorkspace.size).toBe(0);
   });
 });
 

--- a/apps/desktop/src/main/generation-ipc.ts
+++ b/apps/desktop/src/main/generation-ipc.ts
@@ -14,6 +14,7 @@ export function cancelGenerationRequest(
   inFlight: Map<string, AbortController>,
   logIpc: CancellationLogger,
   inFlightByDesign?: Map<string, InFlightGeneration>,
+  inFlightByWorkspace?: Map<string, InFlightGeneration>,
 ): void {
   if (typeof raw !== 'string') {
     throw new CodesignError(
@@ -30,6 +31,11 @@ export function cancelGenerationRequest(
   if (inFlightByDesign !== undefined) {
     for (const [designId, generation] of inFlightByDesign) {
       if (generation.generationId === raw) inFlightByDesign.delete(designId);
+    }
+  }
+  if (inFlightByWorkspace !== undefined) {
+    for (const [workspaceKey, generation] of inFlightByWorkspace) {
+      if (generation.generationId === raw) inFlightByWorkspace.delete(workspaceKey);
     }
   }
   logIpc.info('generate.cancelled', { id: raw });
@@ -75,6 +81,27 @@ export async function withInFlightGenerationForDesign<T>(
       inFlightByDesign.delete(designId);
     }
   }
+}
+
+export function acquireInFlightWorkspaceGeneration(
+  id: string,
+  workspaceKey: string,
+  inFlightByWorkspace: Map<string, InFlightGeneration>,
+): () => void {
+  const existing = inFlightByWorkspace.get(workspaceKey);
+  if (existing !== undefined && existing.generationId !== id) {
+    throw new CodesignError(
+      'A generation is already running for this workspace. Wait for it to finish or stop it before continuing.',
+      'GENERATION_ALREADY_RUNNING',
+    );
+  }
+  const startedAt = existing?.startedAt ?? Date.now();
+  inFlightByWorkspace.set(workspaceKey, { generationId: id, startedAt });
+  return () => {
+    if (inFlightByWorkspace.get(workspaceKey)?.generationId === id) {
+      inFlightByWorkspace.delete(workspaceKey);
+    }
+  };
 }
 
 export function listInFlightGenerations(

--- a/apps/desktop/src/main/ipc/generate.ts
+++ b/apps/desktop/src/main/ipc/generate.ts
@@ -36,6 +36,7 @@ import { CHATGPT_CODEX_PROVIDER_ID, getCodexTokenStore } from '../codex-oauth-ip
 import { makeRuntimeVerifier } from '../done-verify';
 import { app, ipcMain } from '../electron-runtime';
 import {
+  acquireInFlightWorkspaceGeneration,
   armGenerationTimeout,
   cancelGenerationRequest,
   extractGenerationTimeoutError,
@@ -673,6 +674,7 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
   /** In-flight requests: generationId → AbortController */
   const inFlight = new Map<string, AbortController>();
   const inFlightByDesign = new Map<string, { generationId: string; startedAt: number }>();
+  const inFlightByWorkspace = new Map<string, { generationId: string; startedAt: number }>();
 
   const armTimeout = (id: string, controller: AbortController) =>
     armGenerationTimeout(
@@ -820,7 +822,13 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
 
           const t0 = Date.now();
           let clearTimeoutGuard: () => void = () => {};
+          let releaseWorkspaceGeneration: () => void = () => {};
           try {
+            releaseWorkspaceGeneration = acquireInFlightWorkspaceGeneration(
+              id,
+              workspaceRoot,
+              inFlightByWorkspace,
+            );
             clearTimeoutGuard = await armTimeout(id, controller);
             const isCodex = active.model.provider === CHATGPT_CODEX_PROVIDER_ID;
             let capturedMessages: DesignBriefConversationMessages | null = null;
@@ -1251,6 +1259,7 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
             throw rethrow;
           } finally {
             clearTimeoutGuard();
+            releaseWorkspaceGeneration();
           }
         },
       );
@@ -1259,7 +1268,7 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
 
   ipcMain.handle('codesign:v1:cancel-generation', (_e, raw: unknown) => {
     const { generationId } = CancelGenerationPayloadV1.parse(raw);
-    cancelGenerationRequest(generationId, inFlight, logIpc, inFlightByDesign);
+    cancelGenerationRequest(generationId, inFlight, logIpc, inFlightByDesign, inFlightByWorkspace);
   });
 
   ipcMain.handle('codesign:v1:generation-status', () => ({
@@ -1334,7 +1343,13 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
 
           const t0 = Date.now();
           let clearTimeoutGuard: () => void = () => {};
+          let releaseWorkspaceGeneration: () => void = () => {};
           try {
+            releaseWorkspaceGeneration = acquireInFlightWorkspaceGeneration(
+              id,
+              workspaceRoot,
+              inFlightByWorkspace,
+            );
             clearTimeoutGuard = await armTimeout(id, controller);
             const isCodex = active.model.provider === CHATGPT_CODEX_PROVIDER_ID;
             const result = await runGenerate(
@@ -1402,6 +1417,7 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
             throw rethrow;
           } finally {
             clearTimeoutGuard();
+            releaseWorkspaceGeneration();
           }
         },
       );
@@ -1468,5 +1484,6 @@ export function registerGenerateIpc({ db, getMainWindow }: RegisterGenerateIpcDe
     }
     inFlight.clear();
     inFlightByDesign.clear();
+    inFlightByWorkspace.clear();
   };
 }

--- a/apps/desktop/src/main/ipc/generate.workspace-rename.test.ts
+++ b/apps/desktop/src/main/ipc/generate.workspace-rename.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import type { Design } from '@open-codesign/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -66,7 +67,7 @@ generateControl.reset();
 
 vi.mock('../electron-runtime', () => ({
   app: {
-    getPath: vi.fn(() => '/tmp/open-codesign-generate-rename-tests'),
+    getPath: vi.fn(() => path.join(os.tmpdir(), 'open-codesign-generate-rename-tests')),
   },
   ipcMain: {
     handle: vi.fn((channel: string, handler: Handler) => {
@@ -199,6 +200,7 @@ import { requestAsk } from '../ask-ipc';
 import { appendSessionChatMessage } from '../session-chat';
 import { createDesign, initInMemoryDb, updateDesignWorkspace } from '../snapshots-db';
 import { registerSnapshotsIpc } from '../snapshots-ipc';
+import { normalizeWorkspacePath } from '../workspace-path';
 import { registerGenerateIpc } from './generate';
 
 function getHandler(channel: string): Handler {
@@ -208,8 +210,16 @@ function getHandler(channel: string): Handler {
 }
 
 describe('generate IPC workspace rename coordination', () => {
-  const documentsRoot = '/tmp/open-codesign-generate-rename-tests';
+  const documentsRoot = path.join(os.tmpdir(), 'open-codesign-generate-rename-tests');
   const defaultWorkspaceRoot = path.join(documentsRoot, 'CoDesign');
+
+  function initTestDb() {
+    return {
+      ...initInMemoryDb(),
+      dataDir: path.join(documentsRoot, 'data'),
+      sessionDir: path.join(documentsRoot, 'sessions'),
+    };
+  }
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -223,12 +233,11 @@ describe('generate IPC workspace rename coordination', () => {
 
   afterEach(async () => {
     generateControl.release();
-    await rm(':memory:', { recursive: true, force: true });
     await rm(documentsRoot, { recursive: true, force: true });
   });
 
   it('allows set_title rename to settle while the agent generation is still running', async () => {
-    const db = initInMemoryDb();
+    const db = initTestDb();
     const design = createDesign(db, 'Untitled design 1');
     const oldWorkspace = path.join(defaultWorkspaceRoot, 'Untitled-design-1');
     await mkdir(oldWorkspace);
@@ -275,7 +284,7 @@ describe('generate IPC workspace rename coordination', () => {
 
     const renamed = await renamePromise;
     expect(renamed.workspacePath).toBe(
-      path.join(defaultWorkspaceRoot, 'Hybrid-Workshop-Day-Agenda'),
+      normalizeWorkspacePath(path.join(defaultWorkspaceRoot, 'Hybrid-Workshop-Day-Agenda')),
     );
   });
 
@@ -298,7 +307,7 @@ describe('generate IPC workspace rename coordination', () => {
         },
       ],
     });
-    const db = initInMemoryDb();
+    const db = initTestDb();
     const design = createDesign(db, 'Untitled design 1');
     const workspace = path.join(defaultWorkspaceRoot, 'Untitled-design-1');
     await mkdir(workspace);
@@ -360,7 +369,7 @@ describe('generate IPC workspace rename coordination', () => {
         },
       ],
     });
-    const db = initInMemoryDb();
+    const db = initTestDb();
     const design = createDesign(db, 'Untitled design 1');
     const workspace = path.join(defaultWorkspaceRoot, 'Untitled-design-1');
     await mkdir(path.join(workspace, 'references'), { recursive: true });
@@ -418,7 +427,7 @@ describe('generate IPC workspace rename coordination', () => {
       ],
     });
     vi.mocked(requestAsk).mockResolvedValueOnce({ status: 'cancelled', answers: [] });
-    const db = initInMemoryDb();
+    const db = initTestDb();
     const design = createDesign(db, 'Untitled design 1');
     const workspace = path.join(defaultWorkspaceRoot, 'Untitled-design-1');
     await mkdir(workspace);
@@ -464,7 +473,7 @@ describe('generate IPC workspace rename coordination', () => {
         },
       ],
     });
-    const db = initInMemoryDb();
+    const db = initTestDb();
     const design = createDesign(db, 'Untitled design 1');
     const workspace = path.join(defaultWorkspaceRoot, 'Untitled-design-1');
     await mkdir(workspace);

--- a/apps/desktop/src/main/ipc/runtime-fs.ts
+++ b/apps/desktop/src/main/ipc/runtime-fs.ts
@@ -12,7 +12,11 @@ import {
 import { prepareWorkspaceWriteContent } from '../workspace-file-content';
 import { normalizeWorkspacePath } from '../workspace-path';
 import { withStableWorkspacePath } from '../workspace-path-lock';
-import { resolveSafeWorkspaceChildPath } from '../workspace-reader';
+import {
+  assertWorkspacePathVisible,
+  isIgnoredWorkspacePath,
+  resolveSafeWorkspaceChildPath,
+} from '../workspace-reader';
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -171,6 +175,7 @@ export function createRuntimeTextEditorFs({
 
   async function persistMutation(filePath: string, content: string): Promise<string> {
     const normalizedPath = normalizeDesignFilePath(filePath);
+    assertWorkspacePathVisible(normalizedPath);
     const writeContent = prepareWorkspaceWriteContent(normalizedPath, content);
     if (designId === null || db === null) return writeContent.storedContent;
     try {
@@ -219,6 +224,7 @@ export function createRuntimeTextEditorFs({
     absolutePath?: string,
   ): Promise<{ path: string; content: string }> {
     const normalizedPath = normalizeDesignFilePath(filePath);
+    assertWorkspacePathVisible(normalizedPath);
     const sourcePath = absolutePath;
     let content: string;
     if (!sourcePath) {
@@ -282,6 +288,7 @@ export function createRuntimeTextEditorFs({
       const prefix = dir.length === 0 || dir === '.' ? '' : `${dir.replace(/\/+$/, '')}/`;
       const entries: string[] = [];
       for (const p of fsMap.keys()) {
+        if (isIgnoredWorkspacePath(p)) continue;
         if (!p.startsWith(prefix)) continue;
         const rest = p.slice(prefix.length);
         if (rest.length > 0) entries.push(rest);

--- a/apps/desktop/src/main/open-external.test.ts
+++ b/apps/desktop/src/main/open-external.test.ts
@@ -16,6 +16,12 @@ describe('isAllowedExternalUrl', () => {
     ).toBe(true);
   });
 
+  it('accepts loopback preview URLs', () => {
+    expect(isAllowedExternalUrl('http://localhost:5173/preview')).toBe(true);
+    expect(isAllowedExternalUrl('http://127.0.0.1:4173/')).toBe(true);
+    expect(isAllowedExternalUrl('http://[::1]:5173/')).toBe(true);
+  });
+
   it('rejects unrelated host', () => {
     expect(
       isAllowedExternalUrl('https://evil.example.com/OpenCoworkAI/open-codesign/issues/new'),

--- a/apps/desktop/src/main/open-external.ts
+++ b/apps/desktop/src/main/open-external.ts
@@ -17,6 +17,13 @@ const ALLOWED_PATHS = [
   `/${GITHUB_OWNER}/${GITHUB_REPO}/releases`,
   `/${GITHUB_OWNER}/${GITHUB_REPO}/issues`,
 ];
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+function isAllowedLoopbackUrl(parsed: URL): boolean {
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+  const hostname = parsed.hostname.toLowerCase();
+  return LOOPBACK_HOSTS.has(hostname) || hostname.endsWith('.localhost');
+}
 
 export function isAllowedExternalUrl(raw: string): boolean {
   let parsed: URL;
@@ -25,6 +32,7 @@ export function isAllowedExternalUrl(raw: string): boolean {
   } catch {
     return false;
   }
+  if (isAllowedLoopbackUrl(parsed)) return true;
   if (parsed.protocol !== 'https:') return false;
   if (parsed.hostname !== ALLOWED_HOST) return false;
   return ALLOWED_PATHS.some((p) => parsed.pathname === p || parsed.pathname.startsWith(`${p}/`));

--- a/apps/desktop/src/main/open-external.ts
+++ b/apps/desktop/src/main/open-external.ts
@@ -5,6 +5,10 @@
  *   - `/releases/...`  — update banner → release notes
  *   - `/issues/...`    — Report flow → prefilled bug issue
  *
+ * Local preview controls may also open explicit loopback HTTP(S) URLs. Those
+ * URLs are configured or detected by the user and only opened from direct UI
+ * actions, so remote hosts and non-HTTP schemes still stay out of scope.
+ *
  * Anything else (different host, different repo, different path) is rejected
  * so a compromised renderer can't coerce the main process into opening an
  * attacker-controlled URL via `shell.openExternal`.

--- a/apps/desktop/src/main/preferences-ipc.test.ts
+++ b/apps/desktop/src/main/preferences-ipc.test.ts
@@ -108,13 +108,16 @@ describe('readPersisted()', () => {
     });
   });
 
-  it('throws when persisted preferences contain unknown fields', async () => {
-    readFileMock.mockResolvedValueOnce(JSON.stringify({ schemaVersion: 5, accidental: true }));
+  it('ignores unknown fields in persisted preferences from stale local builds', async () => {
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        schemaVersion: 8,
+        generationTimeoutSec: 900,
+        localWorkspaceDefaultMode: 'work-on-project',
+      }),
+    );
 
-    await expect(readPersisted()).rejects.toMatchObject({
-      code: ERROR_CODES.PREFERENCES_READ_FAIL,
-      message: expect.stringContaining('unsupported field'),
-    });
+    await expect(readPersisted()).resolves.toMatchObject({ generationTimeoutSec: 900 });
   });
 
   it('migrates schemaVersion 1 with legacy 120s timeout to the 1200s default', async () => {
@@ -229,7 +232,7 @@ describe('readPersisted()', () => {
       schemaVersion: number;
       diagnosticsLastReadTs: number;
     };
-    expect(written.schemaVersion).toBe(7);
+    expect(written.schemaVersion).toBe(8);
     expect(written.diagnosticsLastReadTs).toBe(result.diagnosticsLastReadTs);
     expect(written.diagnosticsLastReadTs).toBeGreaterThanOrEqual(before);
     expect(written.diagnosticsLastReadTs).toBeLessThanOrEqual(after);
@@ -349,7 +352,7 @@ describe('preferences memory schema fields', () => {
       workspaceMemoryAutoUpdate: boolean;
       userMemoryAutoUpdate: boolean;
     };
-    expect(written.schemaVersion).toBe(7);
+    expect(written.schemaVersion).toBe(8);
     expect(written.memoryEnabled).toBe(false);
     expect(written.workspaceMemoryAutoUpdate).toBe(false);
     expect(written.userMemoryAutoUpdate).toBe(true);

--- a/apps/desktop/src/main/preferences-ipc.ts
+++ b/apps/desktop/src/main/preferences-ipc.ts
@@ -17,7 +17,7 @@ import { getLogger } from './logger';
 
 const logger = getLogger('preferences-ipc');
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 // v1 → v2: raise the abandoned 120s timeout default (which aborted real
 // agentic runs mid-loop) to 600s. Values that happen to equal the old
 // default are treated as unmigrated defaults, not user intent.
@@ -75,7 +75,6 @@ const PREFERENCE_UPDATE_FIELDS = [
   'workspaceMemoryAutoUpdate',
   'userMemoryAutoUpdate',
 ] as const;
-const PERSISTED_PREFERENCE_FIELDS = ['schemaVersion', ...PREFERENCE_UPDATE_FIELDS] as const;
 
 function assertKnownPreferenceFields(r: Record<string, unknown>): void {
   for (const key of Object.keys(r)) {
@@ -93,14 +92,6 @@ function failInvalidPersistedPreference(message: string): never {
     `preferences.json is invalid: ${message}`,
     ERROR_CODES.PREFERENCES_READ_FAIL,
   );
-}
-
-function assertKnownPersistedFields(r: Record<string, unknown>): void {
-  for (const key of Object.keys(r)) {
-    if (!(PERSISTED_PREFERENCE_FIELDS as readonly string[]).includes(key)) {
-      failInvalidPersistedPreference(`unsupported field "${key}"`);
-    }
-  }
 }
 
 function readPersistedSchema(r: Record<string, unknown>): number {
@@ -186,8 +177,11 @@ function parsePersistedFile(rawJson: unknown): Preferences {
     failInvalidPersistedPreference('preferences.json must contain an object');
   }
   const parsed = rawJson as Record<string, unknown>;
-  assertKnownPersistedFields(parsed);
   const persistedSchema = readPersistedSchema(parsed);
+  // Persisted preferences live on the user's machine and may contain keys
+  // from short-lived experimental builds. Once the schema version is known to
+  // be supported, ignore unknown keys so a stale local setting cannot brick
+  // startup after a clean rebuild. IPC update payloads remain strict.
   const rawTimeout = readPersistedTimeout(parsed);
   const migratedTimeout =
     persistedSchema < 2 && rawTimeout === V1_DEFAULT_TIMEOUT_SEC

--- a/apps/desktop/src/main/session-chat.test.ts
+++ b/apps/desktop/src/main/session-chat.test.ts
@@ -89,6 +89,29 @@ describe('session design brief storage', () => {
     }
   });
 
+  it('keeps shared-workspace conversations isolated by design id', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'codesign-session-shared-'));
+    try {
+      const db = initSnapshotsDb(path.join(root, 'design-store.json'));
+      const source = createDesign(db, 'Existing conversation');
+      const fresh = createDesign(db, 'Fresh conversation');
+      updateDesignWorkspace(db, source.id, root);
+      updateDesignWorkspace(db, fresh.id, root);
+      const opts = { db, sessionDir: db.sessionDir };
+
+      appendSessionChatMessage(opts, {
+        designId: source.id,
+        kind: 'user',
+        payload: { text: 'keep this in the original session' },
+      });
+
+      expect(listSessionChatMessages(opts, source.id)).toHaveLength(1);
+      expect(listSessionChatMessages(opts, fresh.id)).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not make seeded legacy snapshot history look like fresh activity', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'codesign-session-seed-'));
     vi.useFakeTimers();

--- a/apps/desktop/src/main/snapshots-db.test.ts
+++ b/apps/desktop/src/main/snapshots-db.test.ts
@@ -13,6 +13,7 @@ import {
   listSnapshots,
   recordDiagnosticEvent,
   touchDesignActivity,
+  updateDesignPreview,
   updateDesignWorkspace,
   upsertDesignFile,
 } from './snapshots-db';
@@ -108,5 +109,17 @@ describe('json design store', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('keeps the saved preview URL when switching back to managed preview', () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Preview settings');
+
+    updateDesignPreview(db, design.id, 'connected-url', 'http://localhost:5173/');
+    const managed = updateDesignPreview(db, design.id, 'managed-file', null);
+
+    expect(managed?.previewMode).toBe('managed-file');
+    expect(managed?.previewUrl).toBe('http://localhost:5173/');
+    expect(getDesign(db, design.id)?.previewUrl).toBe('http://localhost:5173/');
   });
 });

--- a/apps/desktop/src/main/snapshots-db.ts
+++ b/apps/desktop/src/main/snapshots-db.ts
@@ -15,7 +15,9 @@ import type {
   DiagnosticEventInput,
   DiagnosticEventRow,
   DiagnosticLevel,
+  PreviewMode,
   SnapshotCreateInput,
+  WorkspaceMode,
 } from '@open-codesign/shared';
 import { assertWorkspacePath } from './workspace-path';
 
@@ -259,6 +261,7 @@ export function updateDesignWorkspace(
   db: Database,
   id: string,
   workspacePath: string,
+  workspaceMode?: WorkspaceMode,
 ): Design | null {
   const checkedWorkspacePath = assertWorkspacePath(workspacePath);
   return mutateStore(db, (data) => {
@@ -269,6 +272,32 @@ export function updateDesignWorkspace(
     const updated: Design = {
       ...current,
       workspacePath: checkedWorkspacePath,
+      ...(workspaceMode !== undefined ? { workspaceMode } : {}),
+      updatedAt: nowIso(),
+    };
+    data.designs[idx] = updated;
+    return updated;
+  });
+}
+
+export function updateDesignPreview(
+  db: Database,
+  id: string,
+  previewMode: PreviewMode,
+  previewUrl: string | null,
+): Design | null {
+  return mutateStore(db, (data) => {
+    const idx = data.designs.findIndex((design) => design.id === id);
+    if (idx < 0) return null;
+    const current = data.designs[idx];
+    if (current === undefined) return null;
+    const updated: Design = {
+      ...current,
+      previewMode,
+      previewUrl:
+        previewMode === 'connected-url' || previewMode === 'external-app'
+          ? previewUrl
+          : (current.previewUrl ?? null),
       updatedAt: nowIso(),
     };
     data.designs[idx] = updated;

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -9,7 +9,7 @@
  * initSnapshotsDb().
  */
 
-import { copyFile, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type {
   ChatAppendInput,
@@ -19,6 +19,7 @@ import type {
   CommentUpdateInput,
   Design,
   DesignSnapshot,
+  PreviewMode,
   SnapshotCreateInput,
 } from '@open-codesign/shared';
 import { ChatMessageKind, CodesignError, CommentKind, CommentRect } from '@open-codesign/shared';
@@ -67,6 +68,7 @@ import {
   setDesignThumbnail,
   softDeleteDesign,
   touchDesignActivity,
+  updateDesignPreview,
   updateDesignWorkspace,
   upsertDesignFile,
 } from './snapshots-db';
@@ -78,10 +80,13 @@ import {
   withStableWorkspacePath,
 } from './workspace-path-lock';
 import {
+  assertWorkspacePathVisible,
   classifyWorkspaceFileKind,
+  listWorkspaceDirectoryAt,
   listWorkspaceFilesAt,
   readWorkspaceFileAt,
   resolveSafeWorkspaceChildPath,
+  type WorkspaceDirectoryEntry,
   type WorkspaceFileEntry,
   type WorkspaceFileReadResult,
 } from './workspace-reader';
@@ -234,6 +239,359 @@ function requireBoundWorkspacePath(design: Design, message: string): string {
   } catch (cause) {
     throw new CodesignError('Stored workspace path is invalid', 'IPC_BAD_INPUT', { cause });
   }
+}
+
+function parsePreviewMode(value: unknown): PreviewMode {
+  if (
+    value === 'managed-file' ||
+    value === 'connected-url' ||
+    value === 'external-app' ||
+    value === 'none'
+  ) {
+    return value;
+  }
+  throw new CodesignError(
+    'previewMode must be managed-file, connected-url, external-app, or none',
+    'IPC_BAD_INPUT',
+  );
+}
+
+function normalizeConnectedPreviewUrl(value: unknown): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new CodesignError('previewUrl must be a string or null', 'IPC_BAD_INPUT');
+  }
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch (cause) {
+    throw new CodesignError('previewUrl must be a valid URL', 'IPC_BAD_INPUT', { cause });
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new CodesignError('previewUrl must start with http:// or https://', 'IPC_BAD_INPUT');
+  }
+  return url.toString();
+}
+
+const APP_PROJECT_ROOT_FILES = [
+  'angular.json',
+  'astro.config.cjs',
+  'astro.config.js',
+  'astro.config.mjs',
+  'astro.config.ts',
+  'next.config.cjs',
+  'next.config.js',
+  'next.config.mjs',
+  'next.config.ts',
+  'nuxt.config.js',
+  'nuxt.config.mjs',
+  'nuxt.config.ts',
+  'parcel.config.js',
+  'remix.config.js',
+  'remix.config.ts',
+  'svelte.config.js',
+  'svelte.config.ts',
+  'src-tauri/Cargo.toml',
+  'src-tauri/Tauri.toml',
+  'src-tauri/tauri.conf.json',
+  'src-tauri/tauri.conf.json5',
+  'src-tauri/tauri.conf.toml',
+  'tauri.conf.json',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.ts',
+  'webpack.config.js',
+  'webpack.config.ts',
+] as const;
+
+const NATIVE_APP_PROJECT_FILES = [
+  'src-tauri/Cargo.toml',
+  'src-tauri/Tauri.toml',
+  'src-tauri/tauri.conf.json',
+  'src-tauri/tauri.conf.json5',
+  'src-tauri/tauri.conf.toml',
+  'tauri.conf.json',
+  'electron-builder.yml',
+  'electron-builder.yaml',
+  'electron.vite.config.js',
+  'electron.vite.config.mjs',
+  'electron.vite.config.ts',
+  'capacitor.config.json',
+  'capacitor.config.ts',
+] as const;
+
+const COMMON_DEV_SERVER_PORTS = [
+  5173, 3000, 3001, 5174, 4173, 4200, 4321, 8080, 8000, 5000, 6006, 1234, 1420,
+] as const;
+
+interface PreviewDetectCandidate {
+  url: string;
+  source: string;
+  status: 'matched' | 'native-runtime-required' | 'not-preview' | 'unreachable';
+  httpStatus?: number;
+  contentType?: string;
+  title?: string;
+  error?: string;
+}
+
+interface PreviewDetectResult {
+  schemaVersion: 1;
+  found: boolean;
+  url: string | null;
+  candidates: PreviewDetectCandidate[];
+  message: string;
+}
+
+interface PreviewCandidateSpec {
+  url: string;
+  source: string;
+}
+
+async function readWorkspacePackageJson(
+  workspacePath: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await readFile(path.join(workspacePath, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function packageScripts(pkg: Record<string, unknown> | null): string[] {
+  if (pkg === null || !isRecord(pkg['scripts'])) return [];
+  return Object.values(pkg['scripts']).filter(
+    (value): value is string => typeof value === 'string',
+  );
+}
+
+function packageNamesFromManifest(pkg: Record<string, unknown> | null): Set<string> {
+  const names = new Set<string>();
+  if (pkg === null) return names;
+  for (const key of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const entry = pkg[key];
+    if (!isRecord(entry)) continue;
+    for (const name of Object.keys(entry)) names.add(name);
+  }
+  return names;
+}
+
+function scriptsSuggestNativeRuntime(scripts: string[]): boolean {
+  return scripts.some((script) => /\b(?:tauri|electron|capacitor)\b/i.test(script));
+}
+
+function packageManifestLooksLikeApplicationProject(pkg: Record<string, unknown> | null): boolean {
+  const names = packageNamesFromManifest(pkg);
+  if (
+    [
+      '@angular/core',
+      '@astrojs/react',
+      '@capacitor/core',
+      '@remix-run/react',
+      '@sveltejs/kit',
+      '@tauri-apps/api',
+      '@vitejs/plugin-react',
+      'astro',
+      'electron',
+      'next',
+      'nuxt',
+      'parcel',
+      'react-scripts',
+      'svelte',
+      'vite',
+      'webpack',
+    ].some((name) => names.has(name))
+  ) {
+    return true;
+  }
+  return packageScripts(pkg).some((script) =>
+    /\b(?:astro|capacitor|electron|next|nuxt|parcel|react-scripts|remix|svelte-kit|tauri|vite|webpack)\b/i.test(
+      script,
+    ),
+  );
+}
+
+async function workspaceRequiresNativeRuntime(input: {
+  workspacePath: string;
+  packageNames: Set<string>;
+  scripts: string[];
+}): Promise<boolean> {
+  if (
+    input.packageNames.has('@tauri-apps/api') ||
+    input.packageNames.has('electron') ||
+    input.packageNames.has('@capacitor/core') ||
+    Array.from(input.packageNames).some(
+      (name) => name.startsWith('@tauri-apps/plugin-') || name.startsWith('tauri-plugin-'),
+    ) ||
+    scriptsSuggestNativeRuntime(input.scripts)
+  ) {
+    return true;
+  }
+  return workspaceHasAnyFile(input.workspacePath, NATIVE_APP_PROJECT_FILES);
+}
+
+function extractPortsFromScripts(scripts: string[]): number[] {
+  const ports = new Set<number>();
+  const pattern =
+    /(?:--port|--https-port|-p)\s+([0-9]{2,5})|(?:PORT|VITE_PORT|NUXT_PORT|ASTRO_PORT|STORYBOOK_PORT)\s*=\s*([0-9]{2,5})|(?:localhost|127\.0\.0\.1|\[::1\]):([0-9]{2,5})/gi;
+  for (const script of scripts) {
+    for (const match of script.matchAll(pattern)) {
+      const raw = match[1] ?? match[2] ?? match[3];
+      const port = raw ? Number.parseInt(raw, 10) : Number.NaN;
+      if (Number.isInteger(port) && port > 0 && port <= 65535) ports.add(port);
+    }
+  }
+  return Array.from(ports);
+}
+
+async function workspaceHasAnyFile(
+  workspacePath: string,
+  files: readonly string[],
+): Promise<boolean> {
+  for (const file of files) {
+    if (await pathExists(path.join(workspacePath, file))) return true;
+  }
+  return false;
+}
+
+export async function workspaceLooksLikeApplicationProject(
+  workspacePath: string,
+): Promise<boolean> {
+  if (await workspaceHasAnyFile(workspacePath, APP_PROJECT_ROOT_FILES)) return true;
+  return packageManifestLooksLikeApplicationProject(await readWorkspacePackageJson(workspacePath));
+}
+
+function addPreviewCandidate(
+  candidates: Map<string, PreviewCandidateSpec>,
+  url: string,
+  source: string,
+): void {
+  let normalized: string | null;
+  try {
+    normalized = normalizeConnectedPreviewUrl(url);
+  } catch {
+    normalized = null;
+  }
+  if (normalized === null || candidates.has(normalized)) return;
+  candidates.set(normalized, { url: normalized, source });
+}
+
+async function localPreviewCandidatesForWorkspace(input: {
+  workspacePath: string;
+  currentUrl?: string | null;
+}): Promise<PreviewCandidateSpec[]> {
+  const candidates = new Map<string, PreviewCandidateSpec>();
+  if (input.currentUrl) addPreviewCandidate(candidates, input.currentUrl, 'saved preview URL');
+
+  const pkg = await readWorkspacePackageJson(input.workspacePath);
+  for (const port of extractPortsFromScripts(packageScripts(pkg))) {
+    addPreviewCandidate(candidates, `http://localhost:${port}/`, 'package.json script');
+  }
+  for (const port of COMMON_DEV_SERVER_PORTS) {
+    addPreviewCandidate(candidates, `http://localhost:${port}/`, 'common local preview port');
+  }
+  return Array.from(candidates.values());
+}
+
+function titleFromHtml(html: string): string | undefined {
+  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+  const title = match?.[1]?.trim();
+  return title && title.length > 0 ? title : undefined;
+}
+
+function looksLikeHtmlPreview(contentType: string, body: string): boolean {
+  const lowerContentType = contentType.toLowerCase();
+  return (
+    lowerContentType.includes('text/html') ||
+    /^\s*<!doctype html/i.test(body) ||
+    /<html[\s>]/i.test(body)
+  );
+}
+
+function responseDisallowsEmbeddedPreview(headers: Headers): boolean {
+  const xFrameOptions = headers.get('x-frame-options')?.toLowerCase() ?? '';
+  if (xFrameOptions.includes('deny') || xFrameOptions.includes('sameorigin')) return true;
+
+  const csp = headers.get('content-security-policy')?.toLowerCase() ?? '';
+  const frameAncestors = csp.match(/(?:^|;)\s*frame-ancestors\s+([^;]+)/u)?.[1] ?? '';
+  return frameAncestors.includes("'none'") || frameAncestors.includes("'self'");
+}
+
+async function probePreviewCandidate(
+  candidate: PreviewCandidateSpec,
+  options: { nativeRuntimeRequired: boolean },
+): Promise<PreviewDetectCandidate> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 700);
+  try {
+    const response = await fetch(candidate.url, { signal: controller.signal, redirect: 'follow' });
+    const contentType = response.headers.get('content-type') ?? '';
+    const body = await response.text().catch(() => '');
+    const matched = response.status < 500 && looksLikeHtmlPreview(contentType, body);
+    const needsExternalPreview =
+      matched &&
+      (options.nativeRuntimeRequired || responseDisallowsEmbeddedPreview(response.headers));
+    const title = titleFromHtml(body);
+    return {
+      url: candidate.url,
+      source: candidate.source,
+      status: matched
+        ? needsExternalPreview
+          ? 'native-runtime-required'
+          : 'matched'
+        : 'not-preview',
+      httpStatus: response.status,
+      ...(contentType.length > 0 ? { contentType } : {}),
+      ...(title ? { title } : {}),
+    };
+  } catch (err) {
+    return {
+      url: candidate.url,
+      source: candidate.source,
+      status: 'unreachable',
+      error:
+        err instanceof Error && err.name === 'AbortError'
+          ? 'timeout'
+          : err instanceof Error
+            ? err.message
+            : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function detectLocalPreviewServer(input: {
+  workspacePath: string;
+  currentUrl?: string | null;
+}): Promise<PreviewDetectResult> {
+  const pkg = await readWorkspacePackageJson(input.workspacePath);
+  const scripts = packageScripts(pkg);
+  const nativeRuntimeRequired = await workspaceRequiresNativeRuntime({
+    workspacePath: input.workspacePath,
+    packageNames: packageNamesFromManifest(pkg),
+    scripts,
+  });
+  const candidates = await localPreviewCandidatesForWorkspace(input);
+  const probed = await Promise.all(
+    candidates.map((candidate) => probePreviewCandidate(candidate, { nativeRuntimeRequired })),
+  );
+  const match = probed.find((candidate) => candidate.status === 'matched') ?? null;
+  const nativeMatch =
+    probed.find((candidate) => candidate.status === 'native-runtime-required') ?? null;
+  return {
+    schemaVersion: 1,
+    found: match !== null,
+    url: match?.url ?? null,
+    candidates: probed,
+    message:
+      match !== null
+        ? `Found a local preview at ${match.url}`
+        : nativeMatch !== null
+          ? `Found a local native app at ${nativeMatch.url}. Use External app preview.`
+          : 'No running local preview server was found.',
+  };
 }
 
 /**
@@ -521,7 +879,7 @@ export async function renameAutoManagedWorkspaceForDesign(input: {
 
   await rename(currentPath, nextPath);
   return runDb('rename-design.workspace', () =>
-    updateDesignWorkspace(input.db, input.designBeforeRename.id, nextPath),
+    updateDesignWorkspace(input.db, input.designBeforeRename.id, nextPath, 'blank-canvas'),
   );
 }
 
@@ -534,6 +892,15 @@ function requireSchemaV1(r: Record<string, unknown>, channel: string): void {
   if (r['schemaVersion'] !== 1) {
     throw new CodesignError(`${channel} requires schemaVersion: 1`, 'IPC_BAD_INPUT');
   }
+}
+
+function parseRenameWorkspaceOption(r: Record<string, unknown>): boolean {
+  const value = r['renameWorkspace'];
+  if (value === undefined) return true;
+  if (typeof value !== 'boolean') {
+    throw new CodesignError('renameWorkspace must be a boolean when provided', 'IPC_BAD_INPUT');
+  }
+  return value;
 }
 
 function parseSnapshotCreateInput(raw: unknown): SnapshotCreateInput {
@@ -909,7 +1276,13 @@ export function registerSnapshotsIpc(db: Database): void {
         if (requestedWorkspacePath === undefined) {
           autoWorkspacePath = workspacePath;
         }
-        return await bindWorkspace(db, design.id, workspacePath, false);
+        return await bindWorkspace(
+          db,
+          design.id,
+          workspacePath,
+          false,
+          requestedWorkspacePath === undefined ? 'blank-canvas' : 'work-on-project',
+        );
       } catch (err) {
         if (autoWorkspacePath !== null) {
           await cleanupAutoAllocatedWorkspace(autoWorkspacePath, 'create-design');
@@ -953,6 +1326,7 @@ export function registerSnapshotsIpc(db: Database): void {
       }
       const designId = r['id'] as string;
       const name = r['name'] as string;
+      const renameWorkspace = parseRenameWorkspaceOption(r);
       return await runWithWorkspaceRenameQueue(designId, async () => {
         const before = runDb('rename-design.lookup', () => getDesign(db, designId));
         if (before === null) {
@@ -963,20 +1337,22 @@ export function registerSnapshotsIpc(db: Database): void {
           throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
         }
         let finalDesign = updated;
-        try {
-          finalDesign =
-            (await renameAutoManagedWorkspaceForDesign({
-              db,
-              designBeforeRename: before,
-              newName: updated.name,
-            })) ?? updated;
-        } catch (err) {
-          logger.warn('design.workspace_rename.skipped', {
-            id: updated.id,
-            workspacePath: before.workspacePath,
-            targetName: updated.name,
-            error: err instanceof Error ? err.message : String(err),
-          });
+        if (renameWorkspace) {
+          try {
+            finalDesign =
+              (await renameAutoManagedWorkspaceForDesign({
+                db,
+                designBeforeRename: before,
+                newName: updated.name,
+              })) ?? updated;
+          } catch (err) {
+            logger.warn('design.workspace_rename.skipped', {
+              id: updated.id,
+              workspacePath: before.workspacePath,
+              targetName: updated.name,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
         logger.info('design.renamed', {
           id: finalDesign.id,
@@ -1059,7 +1435,7 @@ export function registerSnapshotsIpc(db: Database): void {
         const workspacePath = await allocateDefaultWorkspacePath(name);
         autoWorkspacePath = workspacePath;
         await copyTrackedWorkspaceFiles(db, sourceId, sourceWorkspacePath, workspacePath);
-        const bound = await bindWorkspace(db, cloned.id, workspacePath, false);
+        const bound = await bindWorkspace(db, cloned.id, workspacePath, false, 'blank-canvas');
         logger.info('design.duplicated', { sourceId, newId: bound.id });
         return bound;
       } catch (err) {
@@ -1081,6 +1457,96 @@ export function registerSnapshotsIpc(db: Database): void {
         });
         throw translateWorkspaceBindError(err, 'Workspace creation failed');
       }
+    },
+  );
+
+  ipcMain.handle(
+    'snapshots:v1:preview:update',
+    async (_e: unknown, raw: unknown): Promise<Design> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:preview:update expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'snapshots:v1:preview:update');
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+
+      const designId = r['designId'] as string;
+      const previewMode = parsePreviewMode(r['previewMode']);
+      const previewUrl = normalizeConnectedPreviewUrl(r['previewUrl']);
+      if (previewMode === 'connected-url' && previewUrl === null) {
+        throw new CodesignError(
+          'previewUrl is required when previewMode is connected-url',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const current = await getDesignAfterPendingWorkspaceRename(db, 'preview:update', designId);
+      if (current === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+      if (
+        previewMode === 'managed-file' &&
+        current.workspacePath !== null &&
+        (await workspaceLooksLikeApplicationProject(
+          requireBoundWorkspacePath(current, 'No workspace bound to this design'),
+        ))
+      ) {
+        throw new CodesignError(
+          'Integrated preview is not available for app workspaces. Use Local URL or Off.',
+          'IPC_BAD_INPUT',
+        );
+      }
+
+      const updated = runDb('preview:update', () =>
+        updateDesignPreview(db, designId, previewMode, previewUrl),
+      );
+      if (updated === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+      logger.info('design.preview_updated', {
+        id: updated.id,
+        previewMode: updated.previewMode,
+        previewUrl: updated.previewUrl,
+      });
+      return updated;
+    },
+  );
+
+  ipcMain.handle(
+    'snapshots:v1:preview:detect',
+    async (_e: unknown, raw: unknown): Promise<PreviewDetectResult> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'snapshots:v1:preview:detect expects an object payload',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'snapshots:v1:preview:detect');
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+      const designId = r['designId'] as string;
+      const design = await getDesignAfterPendingWorkspaceRename(db, 'preview:detect', designId);
+      if (design === null) {
+        throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+      }
+      const workspacePath = requireBoundWorkspacePath(design, 'No workspace bound to this design');
+      const result = await detectLocalPreviewServer({
+        workspacePath,
+        currentUrl: design.previewUrl ?? null,
+      });
+      logger.info('design.preview_detected', {
+        id: design.id,
+        found: result.found,
+        url: result.url,
+        candidateCount: result.candidates.length,
+      });
+      return result;
     },
   );
 
@@ -1226,6 +1692,7 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
           r['designId'] as string,
           workspacePath,
           r['migrateFiles'] as boolean,
+          'work-on-project',
         );
         if (design === null) {
           throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
@@ -1354,6 +1821,54 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
   );
 
   ipcMain.handle(
+    'codesign:files:v1:list-dir',
+    async (_e: unknown, raw: unknown): Promise<WorkspaceDirectoryEntry[]> => {
+      if (typeof raw !== 'object' || raw === null) {
+        throw new CodesignError(
+          'codesign:files:v1:list-dir expects { designId, path }',
+          'IPC_BAD_INPUT',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+      requireSchemaV1(r, 'codesign:files:v1:list-dir');
+      if (typeof r['designId'] !== 'string' || r['designId'].trim().length === 0) {
+        throw new CodesignError('designId must be a non-empty string', 'IPC_BAD_INPUT');
+      }
+      const dirPath = r['path'] === undefined ? '.' : r['path'];
+      if (typeof dirPath !== 'string') {
+        throw new CodesignError('path must be a string', 'IPC_BAD_INPUT');
+      }
+      const designId = r['designId'] as string;
+      return withStableWorkspacePath(designId, async () => {
+        const design = await getDesignAfterPendingWorkspaceRename(db, 'files:list-dir', designId);
+        if (design === null) {
+          throw new CodesignError('Design not found', 'IPC_NOT_FOUND');
+        }
+        if (design.workspacePath === null) {
+          logger.warn('files.listDir.workspace_missing', { designId: design.id });
+          return [];
+        }
+        const workspacePath = requireBoundWorkspacePath(
+          design,
+          'Design is not bound to a workspace',
+        );
+        if (!(await checkWorkspaceFolderExists(workspacePath))) {
+          logger.warn('files.listDir.workspace_unavailable', {
+            designId: design.id,
+            workspacePath,
+          });
+          return [];
+        }
+        try {
+          return await listWorkspaceDirectoryAt(workspacePath, dirPath);
+        } catch (cause) {
+          throw new CodesignError('Failed to list workspace directory', 'IPC_DB_ERROR', { cause });
+        }
+      });
+    },
+  );
+
+  ipcMain.handle(
     'codesign:files:v1:read',
     async (_e: unknown, raw: unknown): Promise<WorkspaceFileReadResult> => {
       if (typeof raw !== 'object' || raw === null) {
@@ -1428,6 +1943,7 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
         let normalizedPath: string;
         try {
           normalizedPath = normalizeDesignFilePath(r['path'] as string);
+          assertWorkspacePathVisible(normalizedPath);
         } catch (cause) {
           throw new CodesignError('Invalid workspace file path', 'IPC_BAD_INPUT', { cause });
         }
@@ -1479,6 +1995,7 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
         let normalizedPath: string;
         try {
           normalizedPath = normalizeDesignFilePath(r['path'] as string);
+          assertWorkspacePathVisible(normalizedPath);
         } catch (cause) {
           throw new CodesignError('Invalid workspace file path', 'IPC_BAD_INPUT', { cause });
         }
@@ -1521,6 +2038,7 @@ export function registerWorkspaceIpc(db: Database, getWin: () => BrowserWindow |
       let normalizedPath: string;
       try {
         normalizedPath = normalizeDesignFilePath(r['path'] as string);
+        assertWorkspacePathVisible(normalizedPath);
       } catch (cause) {
         throw new CodesignError('Invalid workspace file path', 'IPC_BAD_INPUT', { cause });
       }
@@ -1721,7 +2239,10 @@ export const SNAPSHOTS_CHANNELS_V1 = [
   'snapshots:v1:workspace:update',
   'snapshots:v1:workspace:open',
   'snapshots:v1:workspace:check',
+  'snapshots:v1:preview:update',
+  'snapshots:v1:preview:detect',
   'codesign:files:v1:list',
+  'codesign:files:v1:list-dir',
   'codesign:files:v1:read',
   'codesign:files:v1:preview',
   'codesign:files:v1:thumbnail',

--- a/apps/desktop/src/main/snapshots-ipc.workspace-files.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.workspace-files.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -52,7 +52,9 @@ describe('workspace files IPC legacy workspace fallback', () => {
   it('returns an empty file list when the bound workspace folder is missing', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db, 'Missing workspace folder');
-    updateDesignWorkspace(db, design.id, '/tmp/open-codesign-missing-workspace-for-list');
+    const missingWorkspace = path.join(tmpdir(), 'open-codesign-missing-workspace-for-list');
+    await rm(missingWorkspace, { recursive: true, force: true });
+    updateDesignWorkspace(db, design.id, missingWorkspace);
     registerWorkspaceIpc(db, () => null);
 
     const list = getHandler('codesign:files:v1:list');

--- a/apps/desktop/src/main/snapshots-ipc.workspace-naming.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.workspace-naming.test.ts
@@ -8,6 +8,7 @@ import {
   isAutoManagedWorkspacePath,
   renameAutoManagedWorkspaceForDesign,
 } from './snapshots-ipc';
+import { normalizeWorkspacePath } from './workspace-path';
 
 vi.mock('./electron-runtime', () => ({
   app: {
@@ -79,7 +80,7 @@ describe('auto-managed workspace naming', () => {
       defaultRoot: root,
     });
 
-    const expected = path.join(root, 'Studio-Loop-Welcome-Email');
+    const expected = normalizeWorkspacePath(path.join(root, 'Studio-Loop-Welcome-Email'));
     expect(updated?.workspacePath).toBe(expected);
     expect(getDesign(db, design.id)?.workspacePath).toBe(expected);
     await expect(exists(oldWorkspace)).resolves.toBe(false);
@@ -101,7 +102,9 @@ describe('auto-managed workspace naming', () => {
       defaultRoot: root,
     });
 
-    expect(updated?.workspacePath).toBe(path.join(root, 'Studio-Loop-Welcome-Email-1'));
+    expect(updated?.workspacePath).toBe(
+      normalizeWorkspacePath(path.join(root, 'Studio-Loop-Welcome-Email-1')),
+    );
   });
 
   it('leaves user-chosen workspaces alone', async () => {
@@ -119,7 +122,7 @@ describe('auto-managed workspace naming', () => {
       });
 
       expect(updated).toBeNull();
-      expect(getDesign(db, design.id)?.workspacePath).toBe(userWorkspace);
+      expect(getDesign(db, design.id)?.workspacePath).toBe(normalizeWorkspacePath(userWorkspace));
       await expect(exists(userWorkspace)).resolves.toBe(true);
     } finally {
       await rm(userWorkspace, { recursive: true, force: true });

--- a/apps/desktop/src/main/snapshots-ipc.workspace-rename-race.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.workspace-rename-race.test.ts
@@ -2,14 +2,29 @@ import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { Design } from '@open-codesign/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createDesign, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
-import { registerSnapshotsIpc, registerWorkspaceIpc } from './snapshots-ipc';
+import { createDesign, getDesign, initInMemoryDb, updateDesignWorkspace } from './snapshots-db';
+import {
+  detectLocalPreviewServer,
+  registerSnapshotsIpc,
+  registerWorkspaceIpc,
+} from './snapshots-ipc';
+import { normalizeWorkspacePath } from './workspace-path';
 import { withStableWorkspacePath } from './workspace-path-lock';
 import type { WorkspaceFileEntry } from './workspace-reader';
 
 type Handler = (event: unknown, raw: unknown) => unknown;
 
 const handlers = vi.hoisted(() => new Map<string, Handler>());
+const testRoots = vi.hoisted(() => {
+  const base = (
+    process.env['RUNNER_TEMP'] ??
+    process.env['TMPDIR'] ??
+    process.env['TEMP'] ??
+    process.env['TMP'] ??
+    (process.platform === 'win32' ? 'C:/Temp' : '/tmp')
+  ).replaceAll('\\', '/');
+  return { documentsRoot: `${base}/open-codesign-rename-tests` };
+});
 const renameControl = vi.hoisted(() => {
   let markStarted: (() => void) | null = null;
   let release: (() => void) | null = null;
@@ -58,7 +73,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 vi.mock('./electron-runtime', () => ({
   app: {
-    getPath: vi.fn(() => '/tmp/open-codesign-tests'),
+    getPath: vi.fn(() => testRoots.documentsRoot),
   },
   dialog: {
     showOpenDialog: vi.fn(),
@@ -91,7 +106,7 @@ async function exists(p: string): Promise<boolean> {
 }
 
 describe('workspace files IPC during auto-managed workspace renames', () => {
-  const documentsRoot = '/tmp/open-codesign-tests';
+  const documentsRoot = testRoots.documentsRoot;
   const defaultWorkspaceRoot = path.join(documentsRoot, 'CoDesign');
   let root: string;
 
@@ -142,8 +157,134 @@ describe('workspace files IPC during auto-managed workspace renames', () => {
     renameControl.release();
     const [updated, files] = await Promise.all([renamePromise, listPromise]);
 
-    expect(updated.workspacePath).toBe(path.join(root, 'General-Agent-Benchmark-Deck'));
+    expect(updated.workspacePath).toBe(
+      normalizeWorkspacePath(path.join(root, 'General-Agent-Benchmark-Deck')),
+    );
     expect(files.map((file) => file.path)).toContain('App.jsx');
+  });
+
+  it('marks reachable Tauri dev servers as external app previews', async () => {
+    const workspace = path.join(root, 'MadWhisp');
+    await mkdir(path.join(workspace, 'src-tauri'), { recursive: true });
+    await writeFile(path.join(workspace, 'src-tauri', 'tauri.conf.json'), '{}', 'utf8');
+
+    const fetchMock = vi.fn(async () => {
+      return new Response('<!doctype html><title>MadWhisp</title>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const result = await detectLocalPreviewServer({
+        workspacePath: workspace,
+        currentUrl: 'http://localhost:1420/',
+      });
+
+      expect(result.found).toBe(false);
+      expect(result.url).toBeNull();
+      expect(
+        result.candidates.find((candidate) => candidate.url === 'http://localhost:1420/'),
+      ).toMatchObject({
+        status: 'native-runtime-required',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('can rename design metadata without moving an auto-managed workspace folder', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Untitled design 1');
+    const oldWorkspace = path.join(root, 'Untitled-design-1');
+    const newWorkspace = path.join(root, 'Studio-Loop-Welcome-Email');
+    await mkdir(oldWorkspace);
+    await writeFile(path.join(oldWorkspace, 'App.jsx'), 'function App() { return null; }', 'utf8');
+    updateDesignWorkspace(db, design.id, oldWorkspace);
+    registerSnapshotsIpc(db);
+
+    const renameDesign = getHandler('snapshots:v1:rename-design');
+    const updated = (await renameDesign(null, {
+      schemaVersion: 1,
+      id: design.id,
+      name: 'Studio Loop Welcome Email',
+      renameWorkspace: false,
+    })) as Design;
+
+    expect(updated.name).toBe('Studio Loop Welcome Email');
+    expect(updated.workspacePath).toBe(normalizeWorkspacePath(oldWorkspace));
+    await expect(exists(path.join(oldWorkspace, 'App.jsx'))).resolves.toBe(true);
+    await expect(exists(newWorkspace)).resolves.toBe(false);
+  });
+
+  it('stores a connected preview URL without moving the workspace folder', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Local app');
+    const workspace = path.join(root, 'local-app');
+    await mkdir(workspace);
+    updateDesignWorkspace(db, design.id, workspace, 'work-on-project');
+    registerSnapshotsIpc(db);
+
+    const updatePreview = getHandler('snapshots:v1:preview:update');
+    const updated = (await updatePreview(null, {
+      schemaVersion: 1,
+      designId: design.id,
+      previewMode: 'connected-url',
+      previewUrl: 'http://localhost:5173',
+    })) as Design;
+
+    expect(updated.previewMode).toBe('connected-url');
+    expect(updated.previewUrl).toBe('http://localhost:5173/');
+    expect(updated.workspacePath).toBe(normalizeWorkspacePath(workspace));
+    expect(getDesign(db, design.id)?.previewUrl).toBe('http://localhost:5173/');
+    await expect(exists(workspace)).resolves.toBe(true);
+  });
+
+  it('rejects integrated file preview for an app-shaped workspace', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'App workspace');
+    const workspace = path.join(root, 'app-workspace');
+    await mkdir(workspace);
+    await writeFile(path.join(workspace, 'package.json'), '{"scripts":{"dev":"vite"}}', 'utf8');
+    updateDesignWorkspace(db, design.id, workspace, 'work-on-project');
+    registerSnapshotsIpc(db);
+
+    const updatePreview = getHandler('snapshots:v1:preview:update');
+
+    await expect(
+      updatePreview(null, {
+        schemaVersion: 1,
+        designId: design.id,
+        previewMode: 'managed-file',
+        previewUrl: null,
+      }),
+    ).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'IPC_BAD_INPUT',
+    });
+  });
+
+  it('allows integrated file preview for a simple HTML workspace with package metadata', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db, 'Simple HTML workspace');
+    const workspace = path.join(root, 'simple-html-workspace');
+    await mkdir(workspace);
+    await writeFile(path.join(workspace, 'index.html'), '<main>Hello</main>', 'utf8');
+    await writeFile(path.join(workspace, 'package.json'), '{"name":"static-page"}', 'utf8');
+    updateDesignWorkspace(db, design.id, workspace, 'work-on-project');
+    registerSnapshotsIpc(db);
+
+    const updatePreview = getHandler('snapshots:v1:preview:update');
+
+    const updated = (await updatePreview(null, {
+      schemaVersion: 1,
+      designId: design.id,
+      previewMode: 'managed-file',
+      previewUrl: null,
+    })) as Design;
+
+    expect(updated.previewMode).toBe('managed-file');
   });
 
   it('defers auto-managed workspace folder renames while generation owns a stable workspace path', async () => {
@@ -188,7 +329,7 @@ describe('workspace files IPC during auto-managed workspace renames', () => {
     const updated = await renamePromise;
     await generationLease;
 
-    expect(updated.workspacePath).toBe(newWorkspace);
+    expect(updated.workspacePath).toBe(normalizeWorkspacePath(newWorkspace));
     await expect(exists(oldWorkspace)).resolves.toBe(false);
     await expect(exists(path.join(newWorkspace, 'App.jsx'))).resolves.toBe(true);
   });

--- a/apps/desktop/src/main/workspace-reader.test.ts
+++ b/apps/desktop/src/main/workspace-reader.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   classifyWorkspaceFileKind,
+  listWorkspaceDirectoryAt,
   listWorkspaceFilesAt,
   readWorkspaceFileAt,
   readWorkspaceFilesAt,
@@ -102,12 +103,14 @@ describe('readWorkspaceFilesAt', () => {
     expect(result.map((f) => f.file)).toEqual(['index.html']);
   });
 
-  it('throws when a matched source file cannot be read as UTF-8 text', async () => {
+  it('skips matched source files that are not UTF-8 text during bulk scans', async () => {
     await writeFile(join(root, 'ok.html'), '<p>ok</p>');
-    // A stray NUL byte is our binary sniff. Writing .html keeps it on the
-    // default pattern so we prove the binary filter (not the glob) fails it.
+    await writeFile(join(root, 'invalid.txt'), Buffer.from([0xff, 0xfe, 0xfd]));
     await writeFile(join(root, 'binary.html'), Buffer.from([0x00, 0x01, 0x02, 0x03]));
-    await expect(readWorkspaceFilesAt(root)).rejects.toThrow(/Failed to read workspace file/);
+
+    const result = await readWorkspaceFilesAt(root);
+
+    expect(result.map((file) => file.file)).toEqual(['ok.html']);
   });
 
   it('throws when the workspace root cannot be scanned', async () => {
@@ -166,6 +169,37 @@ describe('workspace file metadata/read helpers', () => {
     ]);
   });
 
+  it('lists only immediate visible children for lazy file tree loading', async () => {
+    await mkdir(join(root, 'src', 'components'), { recursive: true });
+    await writeFile(join(root, 'src', 'App.tsx'), 'export function App() { return null; }');
+    await writeFile(join(root, 'src', 'components', 'Button.tsx'), 'export function Button() {}');
+    await writeFile(join(root, 'DESIGN.md'), '# Design');
+
+    const rootEntries = await listWorkspaceDirectoryAt(root, '.');
+    expect(rootEntries.map((entry) => entry.path)).toEqual(['src', 'DESIGN.md']);
+
+    const srcEntries = await listWorkspaceDirectoryAt(root, 'src');
+    expect(srcEntries.map((entry) => entry.path)).toEqual(['src/components', 'src/App.tsx']);
+  });
+
+  it('hides agent worktrees, hidden files, and build outputs from workspace listings', async () => {
+    await mkdir(join(root, '.claude', 'worktrees', 'demo', 'src'), { recursive: true });
+    await mkdir(join(root, 'target', 'debug'), { recursive: true });
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, '.claude', 'worktrees', 'demo', 'src', 'App.tsx'), 'wrong app');
+    await writeFile(join(root, 'target', 'debug', 'app.exe'), 'binary');
+    await writeFile(join(root, 'build-out.txt'), Buffer.from([0xff, 0xfe, 0xfd]));
+    await writeFile(join(root, '.gitignore'), 'node_modules');
+    await writeFile(join(root, 'CLAUDE.md'), '# stale model instructions');
+    await writeFile(join(root, 'src', 'App.tsx'), 'right app');
+
+    const rootEntries = await listWorkspaceDirectoryAt(root, '.');
+    expect(rootEntries.map((entry) => entry.path)).toEqual(['src']);
+
+    const recursiveEntries = await listWorkspaceFilesAt(root);
+    expect(recursiveEntries.map((entry) => entry.path)).toEqual(['src/App.tsx']);
+  });
+
   it('skips operating system metadata files from workspace listings', async () => {
     await writeFile(join(root, '.DS_Store'), 'finder metadata');
     await mkdir(join(root, 'assets'), { recursive: true });
@@ -185,6 +219,21 @@ describe('workspace file metadata/read helpers', () => {
 
   it('rejects path escapes in single-file reads', async () => {
     await expect(readWorkspaceFileAt(root, '../outside.jsx')).rejects.toThrow(/escapes/);
+  });
+
+  it('rejects hidden and ignored single-file reads', async () => {
+    await mkdir(join(root, '.claude'), { recursive: true });
+    await writeFile(join(root, '.claude', 'secret.jsx'), 'export const secret = true;');
+    await writeFile(join(root, 'CLAUDE.md'), '# stale model instructions');
+
+    await expect(readWorkspaceFileAt(root, '.claude/secret.jsx')).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'IPC_BAD_INPUT',
+    });
+    await expect(readWorkspaceFileAt(root, 'CLAUDE.md')).rejects.toMatchObject({
+      name: 'CodesignError',
+      code: 'IPC_BAD_INPUT',
+    });
   });
 
   it('rejects single-file reads through symlinked workspace path segments', async () => {

--- a/apps/desktop/src/main/workspace-reader.ts
+++ b/apps/desktop/src/main/workspace-reader.ts
@@ -2,6 +2,7 @@ import type { Dirent } from 'node:fs';
 import { lstat, readdir, readFile, stat } from 'node:fs/promises';
 import { basename, extname, join, relative, resolve, sep } from 'node:path';
 import { TextDecoder } from 'node:util';
+import { CodesignError } from '@open-codesign/shared';
 
 export const DEFAULT_WORKSPACE_PATTERNS = [
   '**/*.html',
@@ -28,17 +29,22 @@ export const DEFAULT_WORKSPACE_PATTERNS = [
 export const WORKSPACE_IGNORED_DIRS = new Set<string>([
   'node_modules',
   '.git',
+  '.claude',
   '.codesign',
   'dist',
   'build',
   'out',
+  'target',
   '.next',
   '.turbo',
   '.vite',
   '.cache',
+  '.ruff_cache',
   '.pnpm-store',
   '__pycache__',
   'coverage',
+  'playwright-report',
+  'test-results',
 ]);
 
 /** Hard caps: stop after 200 files or 2 MB total bytes, whichever first. Main-
@@ -55,16 +61,19 @@ export interface WorkspaceFile {
 
 /**
  * Scan `root` for files whose workspace-relative path matches any of
- * `patterns` (default: HTML/JSX/CSS/JS). Returns UTF-8 contents. Matching
- * files must be readable text; otherwise the caller gets a visible source-scan
- * error instead of a silently partial tweak scan. Results are truncated to
- * `MAX_FILES` / `MAX_BYTES`.
+ * `patterns` (default: HTML/JSX/CSS/JS). Returns UTF-8 contents. The bulk
+ * context scan is best-effort: matched files that are too large, binary, or
+ * not valid UTF-8 are skipped so one generated build log cannot block a turn.
+ * Results are truncated to `MAX_FILES` / `MAX_BYTES`.
  */
 export async function readWorkspaceFilesAt(
   root: string,
   patterns?: string[],
 ): Promise<WorkspaceFile[]> {
   const active = patterns && patterns.length > 0 ? patterns : [...DEFAULT_WORKSPACE_PATTERNS];
+  const exactMatches = new Set(
+    active.filter((pattern) => !pattern.includes('*') && !pattern.includes('?')),
+  );
   const matchers = active.map(globToRegExp);
 
   const out: WorkspaceFile[] = [];
@@ -86,14 +95,14 @@ export async function readWorkspaceFilesAt(
       if (out.length >= MAX_FILES || totalBytes >= MAX_BYTES) return;
       const abs = join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (WORKSPACE_IGNORED_DIRS.has(entry.name)) continue;
+        if (isIgnoredWorkspaceDirectoryName(entry.name)) continue;
         await walk(abs);
         continue;
       }
       if (!entry.isFile()) continue;
       if (isIgnoredWorkspaceFileName(entry.name)) continue;
       const rel = normalizeSlashes(relative(root, abs));
-      if (!matchers.some((re) => re.test(rel))) continue;
+      if (!exactMatches.has(rel) && !matchers.some((re) => re.test(rel))) continue;
       let size = 0;
       try {
         size = (await stat(abs)).size;
@@ -106,10 +115,8 @@ export async function readWorkspaceFilesAt(
       let contents: string;
       try {
         contents = await readUtf8TextFile(abs);
-      } catch (err) {
-        throw new Error(
-          `Failed to read workspace file ${rel}: ${err instanceof Error ? err.message : String(err)}`,
-        );
+      } catch {
+        continue;
       }
       out.push({ file: rel, contents });
       totalBytes += Buffer.byteLength(contents, 'utf8');
@@ -156,8 +163,31 @@ export interface WorkspaceFileReadResult extends WorkspaceFileEntry {
   content: string;
 }
 
+export interface WorkspaceDirectoryEntry {
+  /** Workspace-relative POSIX path. Directories never end with `/`. */
+  path: string;
+  /** Basename for display. */
+  name: string;
+  type: 'file' | 'directory';
+  kind?: WorkspaceFileKind;
+  size?: number;
+  updatedAt?: string;
+}
+
+export interface ListWorkspaceFilesOptions {
+  maxFiles?: number;
+}
+
 const LIST_IGNORED_DIRS = WORKSPACE_IGNORED_DIRS;
-const WORKSPACE_IGNORED_FILE_NAMES = new Set<string>(['.DS_Store', 'Thumbs.db', 'desktop.ini']);
+const WORKSPACE_IGNORED_FILE_NAMES = new Set<string>([
+  '.ds_store',
+  'thumbs.db',
+  'desktop.ini',
+  'build-out.txt',
+  'build-output.txt',
+  'claude.md',
+  'memory.md',
+]);
 
 const LIST_MAX_FILES = 2_000;
 const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
@@ -216,7 +246,27 @@ export function isWorkspaceTextReadablePath(path: string): boolean {
 }
 
 function isIgnoredWorkspaceFileName(name: string): boolean {
-  return WORKSPACE_IGNORED_FILE_NAMES.has(name);
+  return name.startsWith('.') || WORKSPACE_IGNORED_FILE_NAMES.has(name.toLowerCase());
+}
+
+function isIgnoredWorkspaceDirectoryName(name: string): boolean {
+  return name.startsWith('.') || LIST_IGNORED_DIRS.has(name.toLowerCase());
+}
+
+export function isIgnoredWorkspacePath(path: string): boolean {
+  return normalizeSlashes(path)
+    .split('/')
+    .filter((part) => part.length > 0 && part !== '.')
+    .some((part, index, parts) => {
+      const isLast = index === parts.length - 1;
+      return isIgnoredWorkspaceDirectoryName(part) || (isLast && isIgnoredWorkspaceFileName(part));
+    });
+}
+
+export function assertWorkspacePathVisible(path: string): void {
+  if (isIgnoredWorkspacePath(path)) {
+    throw new CodesignError(`hidden workspace path is not accessible: ${path}`, 'IPC_BAD_INPUT');
+  }
 }
 
 export function classifyWorkspaceFileKind(path: string): WorkspaceFileKind {
@@ -305,11 +355,15 @@ async function readUtf8TextFile(abs: string): Promise<string> {
  * Returns entries sorted by path (POSIX-style separators). A bound workspace
  * that cannot be scanned is an invalid runtime state, so scan failures throw.
  */
-export async function listWorkspaceFilesAt(root: string): Promise<WorkspaceFileEntry[]> {
+export async function listWorkspaceFilesAt(
+  root: string,
+  opts: ListWorkspaceFilesOptions = {},
+): Promise<WorkspaceFileEntry[]> {
   const out: WorkspaceFileEntry[] = [];
+  const maxFiles = opts.maxFiles ?? LIST_MAX_FILES;
 
   async function walk(dir: string): Promise<void> {
-    if (out.length >= LIST_MAX_FILES) return;
+    if (out.length >= maxFiles) return;
     let entries: Dirent[] = [];
     try {
       entries = await readdir(dir, { withFileTypes: true });
@@ -321,10 +375,10 @@ export async function listWorkspaceFilesAt(root: string): Promise<WorkspaceFileE
       );
     }
     for (const entry of entries) {
-      if (out.length >= LIST_MAX_FILES) return;
+      if (out.length >= maxFiles) return;
       const abs = join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (LIST_IGNORED_DIRS.has(entry.name)) continue;
+        if (isIgnoredWorkspaceDirectoryName(entry.name)) continue;
         await walk(abs);
         continue;
       }
@@ -355,6 +409,60 @@ export async function listWorkspaceFilesAt(root: string): Promise<WorkspaceFileE
   await walk(root);
   out.sort((a, b) => a.path.localeCompare(b.path));
   return out;
+}
+
+export async function listWorkspaceDirectoryAt(
+  root: string,
+  dirPath = '.',
+): Promise<WorkspaceDirectoryEntry[]> {
+  const absRoot = resolve(root);
+  const absDir = await resolveSafeWorkspaceChildPath(absRoot, dirPath);
+  const relDir = normalizeSlashes(relative(absRoot, absDir));
+  assertWorkspacePathVisible(relDir);
+  const dirStat = await stat(absDir);
+  if (!dirStat.isDirectory()) {
+    throw new Error(`not a directory: ${dirPath}`);
+  }
+
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(absDir, { withFileTypes: true });
+  } catch (err) {
+    throw new Error(
+      `Failed to scan workspace directory ${relDir || '.'}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const out: WorkspaceDirectoryEntry[] = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      if (isIgnoredWorkspaceDirectoryName(entry.name)) continue;
+      const relPath = normalizeSlashes(relative(absRoot, join(absDir, entry.name)));
+      out.push({ path: relPath, name: entry.name, type: 'directory' });
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (isIgnoredWorkspaceFileName(entry.name)) continue;
+    const abs = join(absDir, entry.name);
+    const fileStat = await stat(abs);
+    const relPath = normalizeSlashes(relative(absRoot, abs));
+    out.push({
+      path: relPath,
+      name: entry.name,
+      type: 'file',
+      kind: classifyWorkspaceFileKind(relPath),
+      size: fileStat.size,
+      updatedAt: fileStat.mtime.toISOString(),
+    });
+  }
+
+  return out.sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+    return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+  });
 }
 
 /** Tiny glob → regex. Supports `**` (any including slashes), `*` (no slash),
@@ -420,6 +528,7 @@ export async function readWorkspaceFileAt(
 ): Promise<WorkspaceFileReadResult> {
   const abs = await resolveSafeWorkspaceChildPath(root, relPath);
   const rel = normalizeSlashes(relative(resolve(root), abs));
+  assertWorkspacePathVisible(rel);
   let size = 0;
   let mtime = new Date();
   try {

--- a/apps/desktop/src/main/workspace-watcher.ts
+++ b/apps/desktop/src/main/workspace-watcher.ts
@@ -7,7 +7,7 @@ import { ipcMain } from './electron-runtime';
 import { getLogger } from './logger';
 import { type Database, getDesign } from './snapshots-db';
 import { normalizeWorkspacePath } from './workspace-path';
-import { WORKSPACE_IGNORED_DIRS } from './workspace-reader';
+import { isIgnoredWorkspacePath } from './workspace-reader';
 
 /**
  * Files watcher (T2.3 follow-up). Without this, edits made in Finder / a
@@ -54,11 +54,7 @@ const watchers = new Map<string, ActiveWatcher>();
 
 function isIgnored(rel: string): boolean {
   if (!rel) return true;
-  if (rel.endsWith('.DS_Store')) return true;
-  for (const seg of rel.split(/[\\/]/)) {
-    if (WORKSPACE_IGNORED_DIRS.has(seg)) return true;
-  }
-  return false;
+  return isIgnoredWorkspacePath(rel);
 }
 
 function toForwardSlashes(path: string): string {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -16,6 +16,7 @@ import type {
   LocalInputFile,
   ModelRef,
   OnboardingState,
+  PreviewMode,
   ReasoningLevel,
   ReportEventInput,
   ReportEventResult,
@@ -43,6 +44,7 @@ export type {
   ExternalConfigsDetection,
   ImageGenerationSettingsView,
   ModelsListResponse,
+  PreviewMode,
   TestEndpointResponse,
 };
 
@@ -77,6 +79,14 @@ export interface WorkspaceFileEntry {
   kind: WorkspaceFileKind;
   size: number;
   updatedAt: string;
+}
+export interface WorkspaceDirectoryEntry {
+  path: string;
+  name: string;
+  type: 'file' | 'directory';
+  kind?: WorkspaceFileKind;
+  size?: number;
+  updatedAt?: string;
 }
 export interface WorkspaceFileReadResult extends WorkspaceFileEntry {
   content: string;
@@ -115,6 +125,25 @@ export interface WorkspaceDocumentThumbnailResult {
   path: string;
   thumbnailDataUrl: string | null;
 }
+
+export interface PreviewDetectCandidate {
+  url: string;
+  source: string;
+  status: 'matched' | 'native-runtime-required' | 'not-preview' | 'unreachable';
+  httpStatus?: number;
+  contentType?: string;
+  title?: string;
+  error?: string;
+}
+
+export interface PreviewDetectResult {
+  schemaVersion: 1;
+  found: boolean;
+  url: string | null;
+  candidates: PreviewDetectCandidate[];
+  message: string;
+}
+
 export type WorkspaceImportSource = 'composer' | 'workspace' | 'canvas' | 'clipboard';
 export type WorkspaceImportKind = 'reference' | 'asset';
 export interface WorkspaceImportFileInput {
@@ -135,6 +164,10 @@ export interface WorkspaceImportResult {
   mediaType: string;
   kind: WorkspaceImportKind;
   source: WorkspaceImportSource;
+}
+
+export interface RenameDesignOptions {
+  renameWorkspace?: boolean;
 }
 
 export interface ExportInvokeResponse {
@@ -594,6 +627,12 @@ const api = {
         schemaVersion: 1,
         designId,
       }) as Promise<WorkspaceFileEntry[]>,
+    listDir: (designId: string, path = '.') =>
+      ipcRenderer.invoke('codesign:files:v1:list-dir', {
+        schemaVersion: 1,
+        designId,
+        path,
+      }) as Promise<WorkspaceDirectoryEntry[]>,
     read: (designId: string, path: string) =>
       ipcRenderer.invoke('codesign:files:v1:read', {
         schemaVersion: 1,
@@ -660,11 +699,14 @@ const api = {
         schemaVersion: 1,
         id,
       }) as Promise<Design | null>,
-    renameDesign: (id: string, name: string) =>
+    renameDesign: (id: string, name: string, options?: RenameDesignOptions) =>
       ipcRenderer.invoke('snapshots:v1:rename-design', {
         schemaVersion: 1,
         id,
         name,
+        ...(options?.renameWorkspace !== undefined
+          ? { renameWorkspace: options.renameWorkspace }
+          : {}),
       }) as Promise<Design>,
     setThumbnail: (id: string, thumbnailText: string | null) =>
       ipcRenderer.invoke('snapshots:v1:set-thumbnail', {
@@ -720,6 +762,18 @@ const api = {
         schemaVersion: 1,
         designId,
       }) as Promise<{ exists: boolean }>,
+    updatePreview: (designId: string, previewMode: PreviewMode, previewUrl?: string | null) =>
+      ipcRenderer.invoke('snapshots:v1:preview:update', {
+        schemaVersion: 1,
+        designId,
+        previewMode,
+        previewUrl: previewUrl ?? null,
+      }) as Promise<Design>,
+    detectPreview: (designId: string) =>
+      ipcRenderer.invoke('snapshots:v1:preview:detect', {
+        schemaVersion: 1,
+        designId,
+      }) as Promise<PreviewDetectResult>,
   },
   chat: {
     list: (designId: string) =>
@@ -838,6 +892,7 @@ const api = {
   openExternal: (url: string) =>
     ipcRenderer.invoke('codesign:v1:open-external', url) as Promise<void>,
   ask: {
+    pending: () => ipcRenderer.invoke('ask:list-pending') as Promise<AskRequest[]>,
     onRequest: (cb: (req: AskRequest) => void) => {
       const listener = (_e: unknown, req: AskRequest) => cb(req);
       ipcRenderer.on('ask:request', listener);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -36,10 +36,6 @@ export function App() {
   const loadDesigns = useCodesignStore((s) => s.loadDesigns);
   const syncGenerationStatus = useCodesignStore((s) => s.syncGenerationStatus);
   const switchDesign = useCodesignStore((s) => s.switchDesign);
-  const sendPrompt = useCodesignStore((s) => s.sendPrompt);
-  const isGenerating = useCodesignStore(
-    (s) => s.isGenerating && s.generatingDesignId === s.currentDesignId,
-  );
   const setView = useCodesignStore((s) => s.setView);
   const view = useCodesignStore((s) => s.view);
   const previousView = useCodesignStore((s) => s.previousView);
@@ -56,7 +52,7 @@ export function App() {
   const activeReportLocalId = useCodesignStore((s) => s.activeReportLocalId);
   const closeReportDialog = useCodesignStore((s) => s.closeReportDialog);
 
-  const [prompt, setPrompt] = useState('');
+  const [prefillPrompt, setPrefillPrompt] = useState<{ id: number; text: string } | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(() =>
     Math.max(320, Math.round(window.innerWidth * 0.25)),
   );
@@ -133,27 +129,13 @@ export function App() {
     void bootstrap();
   }, [loadConfig, loadDesigns, switchDesign, syncGenerationStatus]);
 
-  function submit(): void {
-    const trimmed = prompt.trim();
-    if (!trimmed || isGenerating) return;
-    void sendPrompt({ prompt: trimmed });
-    setPrompt('');
-  }
-
   const ready = configLoaded && config?.hasKey;
+  const prefillComposer = useCallback((text: string) => {
+    setPrefillPrompt((prev) => ({ id: (prev?.id ?? 0) + 1, text }));
+  }, []);
 
   const bindings = useMemo(
     () => [
-      {
-        combo: 'mod+enter',
-        handler: () => {
-          if (!ready) return;
-          const trimmed = prompt.trim();
-          if (!trimmed || isGenerating) return;
-          void sendPrompt({ prompt: trimmed });
-          setPrompt('');
-        },
-      },
       {
         combo: 'mod+,',
         handler: () => {
@@ -195,10 +177,7 @@ export function App() {
       },
     ],
     [
-      prompt,
-      isGenerating,
       ready,
-      sendPrompt,
       view,
       previousView,
       designsViewOpen,
@@ -245,7 +224,7 @@ export function App() {
                 // doesn't quietly land in the current design's input box.
                 const created = await createNewDesign();
                 if (!created) return;
-                setPrompt(p);
+                prefillComposer(p);
                 setView('workspace');
               }}
             />
@@ -259,7 +238,7 @@ export function App() {
             <div className="flex-1 min-h-0 min-w-0 overflow-hidden flex relative">
               {isResizing && <div className="absolute inset-0 z-20 cursor-col-resize" />}
               <div className="relative shrink-0" style={{ width: sidebarWidth }}>
-                <Sidebar prompt={prompt} setPrompt={setPrompt} onSubmit={submit} />
+                <Sidebar prefillPrompt={prefillPrompt} />
                 <div
                   role="separator"
                   aria-orientation="vertical"
@@ -270,7 +249,7 @@ export function App() {
               </div>
               <main className="flex flex-col min-h-0 flex-1 min-w-0">
                 <Suspense fallback={null}>
-                  <PreviewPane onPickStarter={(p) => setPrompt(p)} />
+                  <PreviewPane onPickStarter={prefillComposer} />
                 </Suspense>
               </main>
             </div>

--- a/apps/desktop/src/renderer/src/components/AskModal.test.ts
+++ b/apps/desktop/src/renderer/src/components/AskModal.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, expect, it } from 'vitest';
 import type { AskRequest } from '../../../preload/index';
-import { advanceAskQueue, enqueueAskRequest, sanitizeInlineSvg } from './AskModal';
+import {
+  advanceAskQueue,
+  answerValueForImportedFiles,
+  enqueueAskRequest,
+  enqueueAskRequests,
+  sanitizeInlineSvg,
+} from './AskModal';
 
 const request = (requestId: string): AskRequest => ({
   requestId,
@@ -52,6 +58,16 @@ describe('AskModal queue helpers', () => {
     expect(state.queue.map((item) => item.requestId)).toEqual(['ask-2']);
   });
 
+  it('dedupes replayed pending requests', () => {
+    const first = request('ask-1');
+    const second = request('ask-2');
+
+    const state = enqueueAskRequests({ active: first, queue: [second] }, [first, second]);
+
+    expect(state.active?.requestId).toBe('ask-1');
+    expect(state.queue.map((item) => item.requestId)).toEqual(['ask-2']);
+  });
+
   it('advances to the next request after the active request resolves', () => {
     const state = {
       active: request('ask-1'),
@@ -62,5 +78,35 @@ describe('AskModal queue helpers', () => {
 
     expect(next.active?.requestId).toBe('ask-2');
     expect(next.queue.map((item) => item.requestId)).toEqual(['ask-3']);
+  });
+});
+
+describe('file answer helpers', () => {
+  it('prefers imported workspace paths over browser file names', () => {
+    expect(
+      answerValueForImportedFiles({
+        importedPaths: ['references/logo.png'],
+        selectedNames: ['logo.png'],
+      }),
+    ).toBe('references/logo.png');
+  });
+
+  it('keeps multiple imported paths for multi-file answers', () => {
+    expect(
+      answerValueForImportedFiles({
+        importedPaths: ['references/logo.png', 'references/screenshot.png'],
+        selectedNames: ['logo.png', 'screenshot.png'],
+        multiple: true,
+      }),
+    ).toEqual(['references/logo.png', 'references/screenshot.png']);
+  });
+
+  it('falls back to selected names when import is unavailable', () => {
+    expect(
+      answerValueForImportedFiles({
+        importedPaths: [],
+        selectedNames: ['logo.png'],
+      }),
+    ).toBe('logo.png');
   });
 });

--- a/apps/desktop/src/renderer/src/components/AskModal.tsx
+++ b/apps/desktop/src/renderer/src/components/AskModal.tsx
@@ -12,6 +12,8 @@ import type {
   AskSvgOptionsQuestion,
   AskTextOptionsQuestion,
 } from '../../../preload/index';
+import { fileListToWorkspaceImport } from '../lib/file-ingest';
+import { useCodesignStore } from '../store';
 
 /**
  * Inline questionnaire rendered whenever main pushes `ask:request` over IPC.
@@ -21,7 +23,8 @@ import type {
  * interruption.
  */
 
-type AnswerValue = string | number | string[] | null;
+export type AnswerValue = string | number | string[] | null;
+type FileImportHandler = (files: readonly File[]) => Promise<string[]>;
 
 const SVG_ALLOWED_TAGS = new Set([
   'svg',
@@ -143,8 +146,14 @@ export interface AskQueueState {
 }
 
 export function enqueueAskRequest(state: AskQueueState, request: AskRequest): AskQueueState {
+  if (state.active?.requestId === request.requestId) return state;
+  if (state.queue.some((item) => item.requestId === request.requestId)) return state;
   if (state.active === null) return { active: request, queue: state.queue };
   return { active: state.active, queue: [...state.queue, request] };
+}
+
+export function enqueueAskRequests(state: AskQueueState, requests: AskRequest[]): AskQueueState {
+  return requests.reduce((next, request) => enqueueAskRequest(next, request), state);
 }
 
 export function advanceAskQueue(state: AskQueueState): AskQueueState {
@@ -152,18 +161,40 @@ export function advanceAskQueue(state: AskQueueState): AskQueueState {
   return { active: next ?? null, queue: rest };
 }
 
+export function answerValueForImportedFiles(input: {
+  importedPaths: readonly string[];
+  selectedNames: readonly string[];
+  multiple?: boolean | undefined;
+}): AnswerValue {
+  const values = input.importedPaths.length > 0 ? input.importedPaths : input.selectedNames;
+  if (values.length === 0) return null;
+  return input.multiple ? [...values] : (values[0] ?? null);
+}
+
 export function AskModal() {
   const t = useT();
+  const importFilesToWorkspace = useCodesignStore((s) => s.importFilesToWorkspace);
   const [askQueue, setAskQueue] = useState<AskQueueState>({ active: null, queue: [] });
   const [answers, setAnswers] = useState<Record<string, AnswerValue>>({});
   const panelRef = useRef<HTMLElement>(null);
   const pending = askQueue.active;
 
   useEffect(() => {
+    let disposed = false;
     const off = window.codesign?.ask?.onRequest?.((req) => {
       setAskQueue((prev) => enqueueAskRequest(prev, req));
     });
+    void window.codesign?.ask
+      ?.pending?.()
+      .then((requests) => {
+        if (disposed) return;
+        setAskQueue((prev) => enqueueAskRequests(prev, requests));
+      })
+      .catch(() => {
+        // The live IPC event remains the primary path; pending replay is recovery-only.
+      });
     return () => {
+      disposed = true;
       off?.();
     };
   }, []);
@@ -195,6 +226,15 @@ export function AskModal() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [pending, cancel]);
+
+  const importQuestionFiles = useCallback<FileImportHandler>(
+    async (files) => {
+      const input = await fileListToWorkspaceImport(files);
+      const imported = await importFilesToWorkspace({ source: 'composer', ...input });
+      return imported.map((file) => file.path);
+    },
+    [importFilesToWorkspace],
+  );
 
   if (!pending) return null;
 
@@ -243,6 +283,7 @@ export function AskModal() {
                 question={q}
                 value={answers[q.id] ?? null}
                 onChange={(v) => setValue(q.id, v)}
+                onImportFiles={importQuestionFiles}
               />
             ))}
           </div>
@@ -284,9 +325,10 @@ interface FieldProps {
   question: AskQuestion;
   value: AnswerValue;
   onChange: (v: AnswerValue) => void;
+  onImportFiles: FileImportHandler;
 }
 
-function QuestionField({ question, value, onChange }: FieldProps) {
+function QuestionField({ question, value, onChange, onImportFiles }: FieldProps) {
   return (
     <div className="flex flex-col gap-[var(--space-1_5)]">
       <label
@@ -295,7 +337,7 @@ function QuestionField({ question, value, onChange }: FieldProps) {
       >
         {question.prompt}
       </label>
-      {renderControl(question, value, onChange)}
+      {renderControl(question, value, onChange, onImportFiles)}
     </div>
   );
 }
@@ -304,6 +346,7 @@ function renderControl(
   q: AskQuestion,
   value: AnswerValue,
   onChange: (v: AnswerValue) => void,
+  onImportFiles: FileImportHandler,
 ): ReactElement {
   switch (q.type) {
     case 'text-options':
@@ -313,7 +356,7 @@ function renderControl(
     case 'slider':
       return <SliderField q={q} value={value} onChange={onChange} />;
     case 'file':
-      return <FileField q={q} onChange={onChange} />;
+      return <FileField q={q} onChange={onChange} onImportFiles={onImportFiles} />;
     case 'freeform':
       return <FreeformField q={q} value={value} onChange={onChange} />;
   }
@@ -451,24 +494,68 @@ function SliderField({
   );
 }
 
-function FileField({ q, onChange }: { q: AskFileQuestion; onChange: (v: AnswerValue) => void }) {
+function FileField({
+  q,
+  onChange,
+  onImportFiles,
+}: {
+  q: AskFileQuestion;
+  onChange: (v: AnswerValue) => void;
+  onImportFiles: FileImportHandler;
+}) {
+  const t = useT();
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFiles(fileList: FileList | null) {
+    const files = Array.from(fileList ?? []);
+    if (files.length === 0) {
+      onChange(null);
+      return;
+    }
+    const selectedNames = files.map((file) => file.name);
+    setImporting(true);
+    setError(null);
+    try {
+      const importedPaths = await onImportFiles(files);
+      onChange(answerValueForImportedFiles({ importedPaths, selectedNames, multiple: q.multiple }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'File import failed');
+      onChange(
+        answerValueForImportedFiles({ importedPaths: [], selectedNames, multiple: q.multiple }),
+      );
+    } finally {
+      setImporting(false);
+    }
+  }
+
   return (
-    <input
-      id={`ask-q-${q.id}`}
-      type="file"
-      accept={q.accept?.join(',')}
-      multiple={q.multiple}
-      onChange={(e) => {
-        const files = Array.from(e.target.files ?? []);
-        if (files.length === 0) {
-          onChange(null);
-          return;
-        }
-        if (q.multiple) onChange(files.map((f) => f.name));
-        else onChange(files[0]?.name ?? null);
-      }}
-      className="max-w-full text-[12.5px] text-[var(--color-text-primary)]"
-    />
+    <div className="flex flex-col gap-[var(--space-1)]">
+      <input
+        id={`ask-q-${q.id}`}
+        type="file"
+        accept={q.accept?.join(',')}
+        multiple={q.multiple}
+        disabled={importing}
+        aria-busy={importing}
+        onChange={(e) => {
+          void handleFiles(e.currentTarget.files);
+        }}
+        className="max-w-full text-[12.5px] text-[var(--color-text-primary)]"
+      />
+      {importing ? (
+        <p className="text-[11px] text-[var(--color-text-secondary)]">
+          {t('common.loading', { defaultValue: 'Loading...' })}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="text-[11px] text-[var(--color-danger)]">
+          {t('ask.fileImportFallback', {
+            defaultValue: 'Could not import the file automatically; sending the file name instead.',
+          })}
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/components/CanvasTabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/CanvasTabBar.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
 import { Eye, FolderOpen, X } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { useCodesignStore } from '../store';
 
 function fileTabLabel(path: string): string {
@@ -59,6 +59,7 @@ export function CanvasTabBar() {
   const active = useCodesignStore((s) => s.activeCanvasTab);
   const setActive = useCodesignStore((s) => s.setActiveCanvasTab);
   const close = useCodesignStore((s) => s.closeCanvasTab);
+  const hasFileTabs = tabs.some((tab) => tab.kind === 'file');
 
   if (tabs.length === 0) return null;
 
@@ -70,50 +71,65 @@ export function CanvasTabBar() {
     >
       {tabs.map((tab, index) => {
         const isActive = index === active;
+        const isFilesTab = tab.kind === 'files';
+        const isFileTab = tab.kind === 'file';
         const item = tabMeta(tab, t);
 
         return (
-          <div
-            key={item.key}
-            role="tab"
-            aria-selected={isActive}
-            className={`group relative flex shrink-0 items-center gap-[var(--space-2)] px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
-              isActive
-                ? 'text-[var(--color-text-primary)]'
-                : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
-            }`}
-          >
-            <button
-              type="button"
-              onClick={() => setActive(index)}
-              title={item.title}
-              className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
+          <Fragment key={item.key}>
+            <div
+              role="tab"
+              aria-selected={isActive}
+              className={`group relative flex shrink-0 items-center gap-[var(--space-2)] px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
+                isFilesTab
+                  ? 'mr-[var(--space-1)] rounded-t-[var(--radius-sm)] bg-[var(--color-background)]'
+                  : ''
+              } ${isFileTab ? 'rounded-t-[var(--radius-sm)] border-x border-transparent' : ''} ${
+                isActive
+                  ? isFileTab
+                    ? 'border-[var(--color-border-muted)] bg-[var(--color-background)] text-[var(--color-text-primary)]'
+                    : 'text-[var(--color-text-primary)]'
+                  : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+              }`}
             >
-              {item.icon}
-              <span
-                className="max-w-[220px] truncate"
-                style={item.mono ? { fontFamily: 'var(--font-mono)' } : undefined}
-              >
-                {item.label}
-              </span>
-            </button>
-            {item.closable ? (
               <button
                 type="button"
-                onClick={() => close(index)}
-                aria-label={t('canvas.closeTab', { name: item.label })}
-                className="p-[2px] text-[var(--color-text-muted)] opacity-50 transition-opacity hover:text-[var(--color-text-primary)] hover:opacity-100"
+                onClick={() => setActive(index)}
+                title={item.title}
+                className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
               >
-                <X className="h-3 w-3" aria-hidden />
+                {item.icon}
+                <span
+                  className="max-w-[220px] truncate"
+                  style={item.mono ? { fontFamily: 'var(--font-mono)' } : undefined}
+                >
+                  {item.label}
+                </span>
               </button>
-            ) : null}
-            {isActive ? (
-              <span
+              {item.closable ? (
+                <button
+                  type="button"
+                  onClick={() => close(index)}
+                  aria-label={t('canvas.closeTab', { name: item.label })}
+                  className="p-[2px] text-[var(--color-text-muted)] opacity-50 transition-opacity hover:text-[var(--color-text-primary)] hover:opacity-100"
+                >
+                  <X className="h-3 w-3" aria-hidden />
+                </button>
+              ) : null}
+              {isActive ? (
+                <span
+                  aria-hidden
+                  className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
+                />
+              ) : null}
+            </div>
+            {isFilesTab && hasFileTabs ? (
+              <div
                 aria-hidden
-                className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
+                className="my-[7px] h-[18px] w-px shrink-0 bg-[var(--color-border-muted)]"
               />
             ) : null}
-          </div>
+          </Fragment>
         );
       })}
     </div>

--- a/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.test.tsx
@@ -26,7 +26,7 @@ vi.mock('react', async (importOriginal) => {
 });
 
 import type { CodesignApi } from '../../../preload';
-import { useDesignFiles } from '../hooks/useDesignFiles';
+import { useLazyDesignFileTree } from '../hooks/useDesignFiles';
 import { useCodesignStore } from '../store';
 import { FilesPanel } from './FilesPanel';
 
@@ -41,9 +41,13 @@ vi.mock('../store', async (importOriginal) => {
     useCodesignStore: mockStoreHook,
   };
 });
-vi.mock('../hooks/useDesignFiles', () => ({
-  useDesignFiles: vi.fn(),
-}));
+vi.mock('../hooks/useDesignFiles', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../hooks/useDesignFiles')>();
+  return {
+    ...actual,
+    useLazyDesignFileTree: vi.fn(),
+  };
+});
 
 declare global {
   interface Window {
@@ -350,10 +354,12 @@ describe('FilesPanel workspace integration', () => {
 
     describe('FilesPanel rendering UI', () => {
       beforeEach(() => {
-        vi.mocked(useDesignFiles).mockReturnValue({
+        vi.mocked(useLazyDesignFileTree).mockReturnValue({
           files: [],
+          tree: [],
           loading: false,
           backend: 'snapshots',
+          loadDirectory: vi.fn(),
         });
         useCodesignStore.setState({
           currentDesignId: 'design-1',

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -1,13 +1,20 @@
 import { useT } from '@open-codesign/i18n';
-import { FileCode2, Folder, FolderOpen, Plus } from 'lucide-react';
-import { type DragEvent, useEffect, useState } from 'react';
-import { formatAbsoluteTime, formatRelativeTime, useDesignFiles } from '../hooks/useDesignFiles';
+import { ChevronRight, FileCode2, Folder, FolderOpen, Plus } from 'lucide-react';
+import { type DragEvent, type ReactNode, useEffect, useRef, useState } from 'react';
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+  useLazyDesignFileTree,
+} from '../hooks/useDesignFiles';
 import {
   clipboardFilesToWorkspaceBlobs,
   dataTransferFilesToWorkspaceFiles,
 } from '../lib/file-ingest';
+import type { FileTreeNode } from '../lib/file-tree';
 import { workspacePathComparisonKey } from '../lib/workspace-path';
 import { useCodesignStore } from '../store';
+
+export { buildFileTree } from '../lib/file-tree';
 
 function formatBytes(n: number | undefined): string {
   if (n === undefined) return '';
@@ -20,7 +27,7 @@ function truncatePath(path: string, maxLength = 50): string {
   if (path.length <= maxLength) return path;
   const start = path.substring(0, maxLength / 2 - 2);
   const end = path.substring(path.length - maxLength / 2 + 2);
-  return `${start}…${end}`;
+  return `${start}...${end}`;
 }
 
 export function FilesPanel() {
@@ -33,13 +40,21 @@ export function FilesPanel() {
   const importFilesToWorkspace = useCodesignStore((s) => s.importFilesToWorkspace);
   const addImportedFileToPrompt = useCodesignStore((s) => s.useImportedFileInPrompt);
   const requestWorkspaceRebind = useCodesignStore((s) => s.requestWorkspaceRebind);
-  const { files, loading } = useDesignFiles(currentDesignId);
+  const { files, tree: fileTree, loading, loadDirectory } = useLazyDesignFileTree(currentDesignId);
   const [workspaceLoading, setWorkspaceLoading] = useState(false);
   const [folderExists, setFolderExists] = useState<boolean | null>(null);
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
+  const expandedDesignRef = useRef<string | null>(currentDesignId);
 
   const currentDesign = designs.find((d) => d.id === currentDesignId);
   const workspacePath = currentDesign?.workspacePath ?? null;
   const isCurrentDesignGenerating = isGenerating && generatingDesignId === currentDesignId;
+
+  useEffect(() => {
+    if (expandedDesignRef.current === currentDesignId) return;
+    expandedDesignRef.current = currentDesignId;
+    setExpandedDirs(new Set());
+  }, [currentDesignId]);
 
   useEffect(() => {
     if (!workspacePath || !currentDesignId) {
@@ -126,6 +141,107 @@ export function FilesPanel() {
       ...(blobs?.blobs.length ? { blobs: blobs.blobs } : {}),
     } as const;
     await importFilesToWorkspace(input);
+  }
+
+  function toggleDirectory(node: FileTreeNode) {
+    if (node.type !== 'directory') return;
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(node.path)) {
+        next.delete(node.path);
+      } else {
+        next.add(node.path);
+        if (!node.loaded && !node.loading) void loadDirectory(node.path);
+      }
+      return next;
+    });
+  }
+
+  function renderTreeNode(node: FileTreeNode, depth: number): ReactNode {
+    if (node.type === 'directory') {
+      const isExpanded = expandedDirs.has(node.path);
+      return (
+        <li key={node.path}>
+          <button
+            type="button"
+            onClick={() => toggleDirectory(node)}
+            aria-expanded={isExpanded}
+            className="group flex h-9 w-full min-w-0 items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] px-[var(--space-2)] text-left text-[var(--text-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]"
+            style={{ paddingLeft: `calc(var(--space-2) + ${depth * 16}px)` }}
+          >
+            <ChevronRight
+              className={`size-3.5 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              aria-hidden
+            />
+            {isExpanded ? (
+              <FolderOpen className="size-4 shrink-0" aria-hidden />
+            ) : (
+              <Folder className="size-4 shrink-0" aria-hidden />
+            )}
+            <span className="min-w-0 flex-1 truncate font-medium" title={node.path}>
+              {node.name}
+            </span>
+            <span
+              className="shrink-0 text-[10px] text-[var(--color-text-muted)]"
+              style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+            >
+              {node.fileCount ?? ''}
+            </span>
+          </button>
+          {isExpanded && node.loading && (
+            <div
+              className="h-8 px-[var(--space-2)] text-[var(--text-xs)] text-[var(--color-text-muted)] flex items-center"
+              style={{ paddingLeft: `calc(var(--space-2) + ${(depth + 1) * 16 + 20}px)` }}
+            >
+              {t('common.loading')}
+            </div>
+          )}
+          {isExpanded && node.children.length > 0 && (
+            <ul className="list-none p-0 m-0">
+              {node.children.map((child) => renderTreeNode(child, depth + 1))}
+            </ul>
+          )}
+        </li>
+      );
+    }
+
+    const f = node.file;
+    return (
+      <li key={node.path}>
+        <div className="group flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] hover:bg-[var(--color-surface-hover)] transition-[background-color] duration-[var(--duration-faster)]">
+          <button
+            type="button"
+            onClick={() => openFileTab(f.path)}
+            className="flex min-w-0 flex-1 items-center gap-[var(--space-2)] h-9 pr-[var(--space-2)] text-left"
+            style={{ paddingLeft: `calc(var(--space-2) + ${depth * 16 + 20}px)` }}
+          >
+            <FileCode2 className="size-4 shrink-0 text-[var(--color-text-secondary)]" aria-hidden />
+            <span
+              className="min-w-0 flex-1 truncate text-[var(--text-sm)] text-[var(--color-text-primary)] leading-[var(--leading-ui)]"
+              title={f.path}
+            >
+              {node.name}
+            </span>
+            <span
+              className="hidden shrink-0 text-[10px] text-[var(--color-text-muted)] sm:inline"
+              title={formatAbsoluteTime(f.updatedAt)}
+              style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+            >
+              {formatBytes(f.size)} - {formatRelativeTime(f.updatedAt)}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => addImportedFileToPrompt(f.path)}
+            title="Use in next prompt"
+            className="mr-[var(--space-1)] inline-flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-active)] hover:text-[var(--color-text-primary)]"
+          >
+            <Plus className="size-4" aria-hidden />
+            <span className="sr-only">Use in next prompt</span>
+          </button>
+        </div>
+      </li>
+    );
   }
 
   if (!currentDesignId) {
@@ -225,7 +341,7 @@ export function FilesPanel() {
             </span>
           </header>
 
-          {files.length === 0 ? (
+          {files.length === 0 && fileTree.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-[var(--space-3)] px-[var(--space-6)] text-center py-[var(--space-8)]">
               <div className="w-12 h-12 rounded-full border border-dashed border-[var(--color-border)] flex items-center justify-center">
                 <FileCode2
@@ -237,6 +353,10 @@ export function FilesPanel() {
                 {t('canvas.files.empty')}
               </p>
             </div>
+          ) : fileTree.length > 0 ? (
+            <ul className="list-none p-0 m-0 rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface)] py-[var(--space-1)]">
+              {fileTree.map((node) => renderTreeNode(node, 0))}
+            </ul>
           ) : (
             <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-2)]">
               {files.map((f) => (
@@ -260,7 +380,7 @@ export function FilesPanel() {
                           title={formatAbsoluteTime(f.updatedAt)}
                           style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
                         >
-                          {formatBytes(f.size)} · {formatRelativeTime(f.updatedAt)}
+                          {formatBytes(f.size)} - {formatRelativeTime(f.updatedAt)}
                         </span>
                       </div>
                     </button>

--- a/apps/desktop/src/renderer/src/components/FilesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesPanel.tsx
@@ -27,7 +27,7 @@ function truncatePath(path: string, maxLength = 50): string {
   if (path.length <= maxLength) return path;
   const start = path.substring(0, maxLength / 2 - 2);
   const end = path.substring(path.length - maxLength / 2 + 2);
-  return `${start}...${end}`;
+  return `${start}…${end}`;
 }
 
 export function FilesPanel() {

--- a/apps/desktop/src/renderer/src/components/FilesTabView.test.ts
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { openFileTab } from '../store/slices/tabs';
 import {
   chooseWorkspacePreviewSourceMode,
+  clampFileBrowserWidth,
   createWorkspaceFilePreviewMessageHandlers,
   defaultWorkspacePreviewPath,
+  detectedPreviewTarget,
+  effectivePreviewModeForDesign,
+  externalAppManagedFallbackPath,
+  htmlRequiresWorkspaceDevServer,
   isMarkdownPreviewFile,
   isPreviewSourceUsableForSelectedPath,
   isRenderableDesignFileKind,
@@ -18,6 +23,90 @@ import {
 } from './FilesTabView';
 
 describe('FilesTabView preview helpers', () => {
+  it('clamps the file browser splitter width to usable bounds', () => {
+    expect(clampFileBrowserWidth(120, 1280)).toBe(260);
+    expect(clampFileBrowserWidth(480.4, 1280)).toBe(480);
+    expect(clampFileBrowserWidth(900, 1280)).toBe(704);
+    expect(clampFileBrowserWidth(900, 900)).toBe(495);
+  });
+
+  it('keeps native app detections on external app preview', () => {
+    expect(
+      detectedPreviewTarget({
+        schemaVersion: 1,
+        found: false,
+        url: null,
+        message: 'Use External app preview.',
+        candidates: [
+          {
+            url: 'http://localhost:1420/',
+            source: 'common local preview port',
+            status: 'native-runtime-required',
+            httpStatus: 200,
+          },
+        ],
+      }),
+    ).toEqual({ mode: 'external-app', url: 'http://localhost:1420/' });
+  });
+
+  it('connects ordinary web previews after detection', () => {
+    expect(
+      detectedPreviewTarget({
+        schemaVersion: 1,
+        found: true,
+        url: 'http://localhost:5173/',
+        message: 'Found a local preview.',
+        candidates: [
+          {
+            url: 'http://localhost:5173/',
+            source: 'package.json script',
+            status: 'matched',
+            httpStatus: 200,
+          },
+        ],
+      }),
+    ).toEqual({ mode: 'connected-url', url: 'http://localhost:5173/' });
+  });
+
+  it('keeps simple HTML workspaces on integrated preview even with package.json present', () => {
+    expect(
+      effectivePreviewModeForDesign({
+        files: [
+          {
+            path: 'index.html',
+            kind: 'html',
+            updatedAt: '2026-05-10T00:00:00.000Z',
+            size: 120,
+          },
+          {
+            path: 'package.json',
+            kind: 'text',
+            updatedAt: '2026-05-10T00:00:00.000Z',
+            size: 80,
+          },
+        ],
+      }),
+    ).toBe('managed-file');
+  });
+
+  it('detects Vite-style app entry HTML that needs a dev server', () => {
+    expect(
+      htmlRequiresWorkspaceDevServer(
+        '<div id="root"></div><script type="module" src="/src/index.tsx"></script>',
+      ),
+    ).toBe(true);
+    expect(
+      htmlRequiresWorkspaceDevServer(
+        '<div id="root"></div><script type="module" src="./src/main.jsx"></script>',
+      ),
+    ).toBe(true);
+    expect(
+      htmlRequiresWorkspaceDevServer(
+        '<main>Hello</main><script type="module">console.log("ok")</script>',
+      ),
+    ).toBe(false);
+  });
+
   it('forwards element selection messages from file preview iframes into comment state', () => {
     const selectCanvasElement = vi.fn();
     const openCommentBubble = vi.fn();
@@ -130,15 +219,23 @@ describe('FilesTabView preview helpers', () => {
     ).toBe(false);
   });
 
-  it('uses the design-level resolver for main design runtime files only', () => {
+  it('uses the design-level resolver only for generated preview fallbacks', () => {
+    expect(
+      shouldUseDesignPreviewResolverForFile({
+        path: 'App.jsx',
+        previewKind: 'runtime',
+        source: 'preview-html',
+      }),
+    ).toBe(true);
     expect(shouldUseDesignPreviewResolverForFile({ path: 'App.jsx', previewKind: 'runtime' })).toBe(
-      true,
+      false,
     );
     expect(
-      shouldUseDesignPreviewResolverForFile({ path: 'index.html', previewKind: 'runtime' }),
-    ).toBe(true);
-    expect(
-      shouldUseDesignPreviewResolverForFile({ path: 'screens/App.jsx', previewKind: 'runtime' }),
+      shouldUseDesignPreviewResolverForFile({
+        path: 'index.html',
+        previewKind: 'runtime',
+        source: 'workspace',
+      }),
     ).toBe(false);
     expect(
       shouldUseDesignPreviewResolverForFile({ path: 'DESIGN.md', previewKind: 'markdown' }),
@@ -288,6 +385,37 @@ describe('FilesTabView preview helpers', () => {
         { path: 'brief.pdf', kind: 'pdf', updatedAt: '2026-04-26T00:00:00Z', size: 100 },
       ]),
     ).toBe('brief.pdf');
+  });
+
+  it('keeps a managed preview fallback available for external-app workspaces', () => {
+    expect(
+      externalAppManagedFallbackPath({
+        selectedPath: 'App.jsx',
+        defaultPath: 'index.html',
+        hasPersistedPreview: true,
+      }),
+    ).toBe('App.jsx');
+    expect(
+      externalAppManagedFallbackPath({
+        selectedPath: null,
+        defaultPath: 'index.html',
+        hasPersistedPreview: true,
+      }),
+    ).toBe('index.html');
+    expect(
+      externalAppManagedFallbackPath({
+        selectedPath: null,
+        defaultPath: null,
+        hasPersistedPreview: true,
+      }),
+    ).toBe('App.jsx');
+    expect(
+      externalAppManagedFallbackPath({
+        selectedPath: null,
+        defaultPath: null,
+        hasPersistedPreview: false,
+      }),
+    ).toBeNull();
   });
 
   it('prefers actual workspace reads over previewSource when the files API is available', () => {

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -1,12 +1,40 @@
 import { useT } from '@open-codesign/i18n';
 import { buildPreviewDocument, isRenderablePath } from '@open-codesign/runtime';
-import { DEFAULT_SOURCE_ENTRY, LEGACY_SOURCE_ENTRY } from '@open-codesign/shared';
-import { FileCode2, FileText, Folder, FolderOpen } from 'lucide-react';
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { DEFAULT_SOURCE_ENTRY, LEGACY_SOURCE_ENTRY, type PreviewMode } from '@open-codesign/shared';
+import {
+  ChevronRight,
+  ExternalLink,
+  FileCode2,
+  FileText,
+  Folder,
+  FolderOpen,
+  Globe2,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  lazy,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import type { WorkspaceDocumentPreviewResult } from '../../../preload';
-import { type DesignFileEntry, type DesignFileKind, useDesignFiles } from '../hooks/useDesignFiles';
+import type { PreviewDetectResult, WorkspaceDocumentPreviewResult } from '../../../preload';
+import {
+  type DesignFileEntry,
+  type DesignFileKind,
+  type DesignFileSource,
+  useDesignFiles,
+  useLazyDesignFileTree,
+} from '../hooks/useDesignFiles';
+import type { FileTreeNode } from '../lib/file-tree';
 import { workspacePathComparisonKey } from '../lib/workspace-path';
 import {
   formatIframeError,
@@ -27,11 +55,156 @@ export { resolveReferencedWorkspacePreviewPath } from '../preview/workspace-sour
 
 const TweakPanel = lazy(() => import('./TweakPanel').then((m) => ({ default: m.TweakPanel })));
 
+const FILE_BROWSER_WIDTH_STORAGE_KEY = 'open-codesign:file-browser-width';
+const FILE_BROWSER_DEFAULT_WIDTH = 360;
+const FILE_BROWSER_MIN_WIDTH = 260;
+const FILE_BROWSER_MAX_WIDTH = 720;
+
+export function clampFileBrowserWidth(width: number, viewportWidth = 1280): number {
+  const maxWidth = Math.max(
+    FILE_BROWSER_MIN_WIDTH,
+    Math.min(FILE_BROWSER_MAX_WIDTH, Math.round(viewportWidth * 0.55)),
+  );
+  return Math.min(Math.max(Math.round(width), FILE_BROWSER_MIN_WIDTH), maxWidth);
+}
+
+function initialFileBrowserWidth(): number {
+  if (typeof window === 'undefined') return FILE_BROWSER_DEFAULT_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(FILE_BROWSER_WIDTH_STORAGE_KEY);
+    const parsed = raw === null ? Number.NaN : Number.parseInt(raw, 10);
+    return clampFileBrowserWidth(
+      Number.isFinite(parsed) ? parsed : FILE_BROWSER_DEFAULT_WIDTH,
+      window.innerWidth,
+    );
+  } catch {
+    return clampFileBrowserWidth(FILE_BROWSER_DEFAULT_WIDTH, window.innerWidth);
+  }
+}
+
 function truncatePath(path: string, maxLength = 40): string {
   if (path.length <= maxLength) return path;
   const start = path.substring(0, maxLength / 2 - 2);
   const end = path.substring(path.length - maxLength / 2 + 2);
   return `${start}…${end}`;
+}
+
+const APP_WORKSPACE_ROOT_FILES = new Set([
+  'angular.json',
+  'astro.config.cjs',
+  'astro.config.js',
+  'astro.config.mjs',
+  'astro.config.ts',
+  'next.config.cjs',
+  'next.config.js',
+  'next.config.mjs',
+  'next.config.ts',
+  'nuxt.config.js',
+  'nuxt.config.mjs',
+  'nuxt.config.ts',
+  'parcel.config.js',
+  'remix.config.js',
+  'remix.config.ts',
+  'svelte.config.js',
+  'svelte.config.ts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.ts',
+  'webpack.config.js',
+  'webpack.config.ts',
+]);
+
+export function normalizeConnectedPreviewUrlInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  const withScheme = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(trimmed) ? trimmed : `http://${trimmed}`;
+  try {
+    const url = new URL(withScheme);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function looksLikeApplicationWorkspace(files: DesignFileEntry[]): boolean {
+  return files.some((file) => {
+    const normalized = file.path.replaceAll('\\', '/').toLowerCase();
+    if (normalized.includes('/')) return false;
+    return APP_WORKSPACE_ROOT_FILES.has(normalized);
+  });
+}
+
+export function effectivePreviewModeForDesign(input: {
+  previewMode?: PreviewMode | null | undefined;
+  previewUrl?: string | null | undefined;
+  files: DesignFileEntry[];
+}): PreviewMode {
+  const integratedBlocked = looksLikeApplicationWorkspace(input.files);
+  if (integratedBlocked && input.previewMode === 'managed-file') return 'none';
+  if (input.previewMode) return input.previewMode;
+  if (input.previewUrl && input.previewUrl.trim().length > 0) return 'connected-url';
+  if (integratedBlocked) return 'none';
+  return 'managed-file';
+}
+
+const WORKSPACE_MODULE_SCRIPT_RE = /<script\b([^>]*)>/gi;
+const MODULE_SCRIPT_TYPE_RE = /\btype\s*=\s*["']module["']/i;
+const SCRIPT_SRC_RE = /\bsrc\s*=\s*["']([^"']+)["']/i;
+
+export function htmlRequiresWorkspaceDevServer(source: string): boolean {
+  for (const match of source.matchAll(WORKSPACE_MODULE_SCRIPT_RE)) {
+    const attributes = match[1] ?? '';
+    if (!MODULE_SCRIPT_TYPE_RE.test(attributes)) continue;
+    const src = SCRIPT_SRC_RE.exec(attributes)?.[1]?.trim();
+    if (!src) continue;
+    const normalized = src.replaceAll('\\', '/').replace(/^\.\//, '').toLowerCase();
+    if (normalized.startsWith('/src/') || normalized.startsWith('src/')) return true;
+  }
+  return false;
+}
+
+function previewModeLabelKey(mode: PreviewMode): string {
+  if (mode === 'connected-url') return 'canvas.workspace.preview.mode.connectedUrlShort';
+  if (mode === 'external-app') return 'canvas.workspace.preview.mode.externalAppShort';
+  if (mode === 'none') return 'canvas.workspace.preview.mode.offShort';
+  return 'canvas.workspace.preview.mode.integratedShort';
+}
+
+export function previewModeSummary(input: {
+  mode: PreviewMode;
+  previewUrl?: string | null | undefined;
+  integratedPreviewBlocked?: boolean;
+}): { key: string; options?: Record<string, string> } {
+  if (input.mode === 'connected-url') {
+    const url = input.previewUrl?.trim();
+    return url
+      ? { key: 'canvas.workspace.preview.summary.connected', options: { url } }
+      : { key: 'canvas.workspace.preview.summary.waitingUrl' };
+  }
+  if (input.mode === 'external-app') {
+    const url = input.previewUrl?.trim();
+    return url
+      ? { key: 'canvas.workspace.preview.summary.externalWithUrl', options: { url } }
+      : { key: 'canvas.workspace.preview.summary.external' };
+  }
+  if (input.mode === 'none') {
+    return input.integratedPreviewBlocked
+      ? { key: 'canvas.workspace.preview.summary.integratedBlocked' }
+      : { key: 'canvas.workspace.preview.summary.off' };
+  }
+  return { key: 'canvas.workspace.preview.summary.integrated' };
+}
+
+export function detectedPreviewTarget(
+  result: PreviewDetectResult,
+): { mode: 'connected-url' | 'external-app'; url: string } | null {
+  const nativeCandidate = result.candidates.find(
+    (candidate) => candidate.status === 'native-runtime-required',
+  );
+  if (nativeCandidate) return { mode: 'external-app', url: nativeCandidate.url };
+  if (result.found && result.url) return { mode: 'connected-url', url: result.url };
+  return null;
 }
 
 function escapeHtmlText(value: string): string {
@@ -43,7 +216,7 @@ function escapeHtmlText(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function WorkspaceSection() {
+function WorkspaceSection({ files }: { files: DesignFileEntry[] }) {
   const t = useT();
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
   const designs = useCodesignStore((s) => s.designs);
@@ -52,11 +225,38 @@ function WorkspaceSection() {
   const requestWorkspaceRebind = useCodesignStore((s) => s.requestWorkspaceRebind);
   const [picking, setPicking] = useState(false);
   const [folderExists, setFolderExists] = useState<boolean | null>(null);
+  const [previewModeInput, setPreviewModeInput] = useState<PreviewMode>('managed-file');
+  const [previewUrlInput, setPreviewUrlInput] = useState('');
+  const [savingPreview, setSavingPreview] = useState(false);
+  const [detectingPreview, setDetectingPreview] = useState(false);
+  const [detectResult, setDetectResult] = useState<PreviewDetectResult | null>(null);
+  const [previewOptionsOpen, setPreviewOptionsOpen] = useState(false);
+  const autoDetectDesignRef = useRef<string | null>(null);
 
   const currentDesign = designs.find((d) => d.id === currentDesignId);
   const workspacePath = currentDesign?.workspacePath ?? null;
   const isCurrentDesignGenerating = isGenerating && generatingDesignId === currentDesignId;
   const disabled = picking || isCurrentDesignGenerating;
+  const integratedPreviewBlocked = looksLikeApplicationWorkspace(files);
+  const savedPreviewMode = currentDesign?.previewMode ?? null;
+  const savedPreviewUrl = currentDesign?.previewUrl ?? '';
+  const effectivePreviewMode = effectivePreviewModeForDesign({
+    previewMode: savedPreviewMode,
+    previewUrl: savedPreviewUrl,
+    files,
+  });
+  const previewSummary = previewModeSummary({
+    mode: effectivePreviewMode,
+    previewUrl: savedPreviewUrl,
+    integratedPreviewBlocked,
+  });
+  const previewSummaryText = t(previewSummary.key, previewSummary.options);
+  const previewConfigured = Boolean(savedPreviewMode || savedPreviewUrl);
+  const previewNeedsUrl =
+    previewModeInput === 'connected-url' || previewModeInput === 'external-app';
+  const normalizedPreviewUrl = normalizeConnectedPreviewUrlInput(previewUrlInput);
+  const previewUrlInvalid =
+    previewNeedsUrl && previewUrlInput.trim().length > 0 && !normalizedPreviewUrl;
 
   useEffect(() => {
     if (!workspacePath || !currentDesignId) {
@@ -75,6 +275,135 @@ function WorkspaceSection() {
         });
       });
   }, [currentDesignId, workspacePath, t]);
+
+  useEffect(() => {
+    setPreviewModeInput(effectivePreviewMode);
+    setPreviewUrlInput(savedPreviewUrl);
+    setDetectResult(null);
+  }, [effectivePreviewMode, savedPreviewUrl]);
+
+  const refreshDesigns = useCallback(async () => {
+    const updated = await window.codesign?.snapshots.listDesigns?.();
+    if (updated) useCodesignStore.setState({ designs: updated });
+  }, []);
+
+  const savePreviewMode = useCallback(
+    async (mode: PreviewMode, rawUrl = previewUrlInput, options: { quiet?: boolean } = {}) => {
+      if (!currentDesignId || !window.codesign?.snapshots.updatePreview) return;
+      const trimmedUrl = rawUrl.trim();
+      const normalizedUrl =
+        mode === 'connected-url' || mode === 'external-app'
+          ? normalizeConnectedPreviewUrlInput(trimmedUrl)
+          : null;
+      if (mode === 'connected-url' && normalizedUrl === null) {
+        if (!options.quiet) {
+          useCodesignStore.getState().pushToast({
+            variant: 'error',
+            title: t('canvas.workspace.preview.saveFailed'),
+            description: t('canvas.workspace.preview.urlRequired'),
+          });
+        }
+        return;
+      }
+      if (mode === 'external-app' && trimmedUrl.length > 0 && normalizedUrl === null) {
+        if (!options.quiet) {
+          useCodesignStore.getState().pushToast({
+            variant: 'error',
+            title: t('canvas.workspace.preview.saveFailed'),
+            description: t('canvas.workspace.preview.urlInvalid'),
+          });
+        }
+        return;
+      }
+      try {
+        setSavingPreview(true);
+        await window.codesign.snapshots.updatePreview(currentDesignId, mode, normalizedUrl);
+        await refreshDesigns();
+      } catch (err) {
+        if (!options.quiet) {
+          useCodesignStore.getState().pushToast({
+            variant: 'error',
+            title: t('canvas.workspace.preview.saveFailed'),
+            description: err instanceof Error ? err.message : t('errors.unknown'),
+          });
+        }
+      } finally {
+        setSavingPreview(false);
+      }
+    },
+    [currentDesignId, previewUrlInput, refreshDesigns, t],
+  );
+
+  async function handlePreviewModeChange(event: ChangeEvent<HTMLSelectElement>) {
+    const nextMode = event.currentTarget.value as PreviewMode;
+    const safeMode = nextMode === 'managed-file' && integratedPreviewBlocked ? 'none' : nextMode;
+    setPreviewModeInput(safeMode);
+    setDetectResult(null);
+    if (safeMode === 'connected-url' && !normalizeConnectedPreviewUrlInput(previewUrlInput)) return;
+    await savePreviewMode(safeMode, previewUrlInput);
+  }
+
+  async function handlePreviewUrlApply() {
+    await savePreviewMode(previewModeInput, previewUrlInput);
+  }
+
+  async function handlePreviewUrlKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== 'Enter') return;
+    event.currentTarget.blur();
+    await handlePreviewUrlApply();
+  }
+
+  const handleDetectPreview = useCallback(
+    async (options: { quiet?: boolean } = {}) => {
+      if (!currentDesignId || !window.codesign?.snapshots.detectPreview) return;
+      try {
+        setDetectingPreview(true);
+        if (!options.quiet) setDetectResult(null);
+        const result = await window.codesign.snapshots.detectPreview(currentDesignId);
+        if (!options.quiet) setDetectResult(result);
+        const target = detectedPreviewTarget(result);
+        if (target) {
+          setPreviewModeInput(target.mode);
+          setPreviewUrlInput(target.url);
+          await savePreviewMode(target.mode, target.url, { quiet: options.quiet === true });
+          return;
+        }
+        if (!options.quiet) {
+          useCodesignStore.getState().pushToast({
+            variant: 'info',
+            title: t('canvas.workspace.preview.detectNone'),
+            description: result.message,
+          });
+        }
+      } catch (err) {
+        if (!options.quiet) {
+          useCodesignStore.getState().pushToast({
+            variant: 'error',
+            title: t('canvas.workspace.preview.detectFailed'),
+            description: err instanceof Error ? err.message : t('errors.unknown'),
+          });
+        }
+      } finally {
+        setDetectingPreview(false);
+      }
+    },
+    [currentDesignId, savePreviewMode, t],
+  );
+
+  useEffect(() => {
+    if (!currentDesignId) return;
+    if (!integratedPreviewBlocked) return;
+    if (savedPreviewMode || savedPreviewUrl) return;
+    if (autoDetectDesignRef.current === currentDesignId) return;
+    autoDetectDesignRef.current = currentDesignId;
+    void handleDetectPreview({ quiet: true });
+  }, [
+    currentDesignId,
+    handleDetectPreview,
+    integratedPreviewBlocked,
+    savedPreviewMode,
+    savedPreviewUrl,
+  ]);
 
   async function handlePickWorkspace() {
     if (!window.codesign?.snapshots.pickWorkspaceFolder) return;
@@ -127,52 +456,177 @@ function WorkspaceSection() {
   }
 
   return (
-    <div className="flex items-center gap-[var(--space-2)] px-[var(--space-4)] py-[var(--space-2)] border-b border-[var(--color-border-muted)] min-w-0">
-      <span className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium shrink-0">
-        {t('canvas.workspace.sectionTitle')}
-      </span>
-      <span
-        className="flex-1 min-w-0 truncate text-[10px] text-[var(--color-text-secondary)]"
-        title={workspacePath ?? undefined}
-        style={{ fontFamily: 'var(--font-mono)' }}
-      >
-        {workspacePath ? (
-          <>
-            {truncatePath(workspacePath)}
-            {folderExists === false && (
-              <span className="ml-1 text-[var(--color-text-warning,_theme(colors.amber.500))]">
-                !
-              </span>
-            )}
-          </>
-        ) : (
-          <span className="text-[var(--color-text-muted)] not-italic">
-            {t('canvas.workspace.default')}
-          </span>
-        )}
-      </span>
-      <div className="flex items-center gap-[var(--space-1)] shrink-0">
-        <button
-          type="button"
-          onClick={handlePickWorkspace}
-          disabled={disabled}
-          className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1"
-          title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
+    <div className="border-b border-[var(--color-border-muted)] px-[var(--space-4)] py-[var(--space-3)]">
+      <div className="flex min-w-0 items-center gap-[var(--space-2)]">
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)]">
+          {t('canvas.workspace.sectionTitle')}
+        </span>
+        <span
+          className="min-w-0 flex-1 truncate text-[10px] text-[var(--color-text-secondary)]"
+          title={workspacePath ?? undefined}
+          style={{ fontFamily: 'var(--font-mono)' }}
         >
-          <Folder className="w-3 h-3" aria-hidden />
-          {workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
-        </button>
-        {workspacePath && (
+          {workspacePath ? (
+            <>
+              {truncatePath(workspacePath)}
+              {folderExists === false && (
+                <span className="ml-1 text-[var(--color-text-warning,_theme(colors.amber.500))]">
+                  !
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-[var(--color-text-muted)] not-italic">
+              {t('canvas.workspace.default')}
+            </span>
+          )}
+        </span>
+        <div className="flex shrink-0 items-center gap-[var(--space-1)]">
           <button
             type="button"
-            onClick={handleOpenWorkspace}
-            disabled={picking}
-            className="h-6 px-2 rounded-[var(--radius-sm)] text-[10px] text-[var(--color-text-secondary)] border border-[var(--color-border)] hover:bg-[var(--color-surface-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            title={t('canvas.workspace.open')}
+            onClick={handlePickWorkspace}
+            disabled={disabled}
+            className="inline-flex h-6 items-center gap-1 rounded-[var(--radius-sm)] border border-[var(--color-border)] px-2 text-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+            title={workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
           >
-            <FolderOpen className="w-3 h-3" aria-hidden />
+            <Folder className="h-3 w-3" aria-hidden />
+            {workspacePath ? t('canvas.workspace.change') : t('canvas.workspace.choose')}
           </button>
-        )}
+          {workspacePath && (
+            <button
+              type="button"
+              onClick={handleOpenWorkspace}
+              disabled={picking}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+              title={t('canvas.workspace.open')}
+            >
+              <FolderOpen className="h-3 w-3" aria-hidden />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-[var(--space-3)] rounded-[var(--radius-md)] border border-[var(--color-border-muted)] bg-[var(--color-surface-raised)]">
+        <div className="flex min-w-0 items-center gap-[var(--space-2)] p-[var(--space-2)]">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border-muted)] text-[var(--color-text-muted)]">
+            <Globe2 className="h-3.5 w-3.5" aria-hidden />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-[var(--space-1)]">
+              <span className="text-[10px] font-medium uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)]">
+                {t('canvas.workspace.preview.label')}
+              </span>
+              <span className="rounded-[var(--radius-pill)] border border-[var(--color-border-muted)] px-1.5 py-0.5 text-[9px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-secondary)]">
+                {previewConfigured
+                  ? t('canvas.workspace.preview.status.saved')
+                  : t('canvas.workspace.preview.status.auto')}
+                : {t(previewModeLabelKey(effectivePreviewMode))}
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => handleDetectPreview()}
+            disabled={disabled || savingPreview || detectingPreview || !workspacePath}
+            className="inline-flex h-7 shrink-0 items-center gap-1 rounded-[var(--radius-sm)] border border-[var(--color-border)] px-2 text-[10px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+            title={t('canvas.workspace.preview.detect')}
+          >
+            <RefreshCw
+              className={`h-3 w-3 ${detectingPreview ? 'animate-spin' : ''}`}
+              aria-hidden
+            />
+            {t('canvas.workspace.preview.detect')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setPreviewOptionsOpen((open) => !open)}
+            aria-expanded={previewOptionsOpen}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)]"
+            title={
+              previewOptionsOpen
+                ? t('canvas.workspace.preview.actions.hideOptions')
+                : t('canvas.workspace.preview.actions.showOptions')
+            }
+          >
+            <ChevronRight
+              className={`h-3.5 w-3.5 transition-transform ${previewOptionsOpen ? 'rotate-90' : ''}`}
+              aria-hidden
+            />
+          </button>
+        </div>
+        {previewOptionsOpen ? (
+          <div className="border-t border-[var(--color-border-muted)] p-[var(--space-2)]">
+            <div className="grid gap-[var(--space-2)]">
+              <p
+                className="m-0 text-[10px] leading-[var(--leading-body)] text-[var(--color-text-muted)]"
+                title={detectResult?.message ?? previewSummaryText}
+              >
+                {detectingPreview
+                  ? t('canvas.workspace.preview.summary.detecting')
+                  : (detectResult?.message ?? previewSummaryText)}
+              </p>
+              <label className="grid gap-1 text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)]">
+                {t('canvas.workspace.preview.mode.label')}
+                <select
+                  value={previewModeInput}
+                  onChange={handlePreviewModeChange}
+                  disabled={disabled || savingPreview}
+                  className="h-8 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-background)] px-2 text-[11px] normal-case tracking-normal text-[var(--color-text-secondary)] outline-none transition-colors focus:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                  title={t(previewModeLabelKey(effectivePreviewMode))}
+                >
+                  <option value="managed-file" disabled={integratedPreviewBlocked}>
+                    {t('canvas.workspace.preview.mode.integrated')}
+                  </option>
+                  <option value="connected-url">
+                    {t('canvas.workspace.preview.mode.connectedUrl')}
+                  </option>
+                  <option value="external-app">
+                    {t('canvas.workspace.preview.mode.externalApp')}
+                  </option>
+                  <option value="none">{t('canvas.workspace.preview.mode.off')}</option>
+                </select>
+              </label>
+              {previewNeedsUrl ? (
+                <label className="grid gap-1 text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)]">
+                  {t('canvas.workspace.preview.urlLabel')}
+                  <div className="flex min-w-0 items-center gap-[var(--space-1)]">
+                    <input
+                      value={previewUrlInput}
+                      onChange={(event) => setPreviewUrlInput(event.currentTarget.value)}
+                      onBlur={() => {
+                        if (previewModeInput === 'external-app' || normalizedPreviewUrl) {
+                          void handlePreviewUrlApply();
+                        }
+                      }}
+                      onKeyDown={handlePreviewUrlKeyDown}
+                      placeholder={t('canvas.workspace.preview.urlPlaceholder')}
+                      disabled={disabled || savingPreview}
+                      className={`h-8 min-w-0 flex-1 rounded-[var(--radius-sm)] border bg-[var(--color-background)] px-2 text-[11px] normal-case tracking-normal text-[var(--color-text-secondary)] outline-none transition-colors focus:border-[var(--color-accent)] disabled:cursor-not-allowed disabled:opacity-50 ${
+                        previewUrlInvalid
+                          ? 'border-[var(--color-danger)]'
+                          : 'border-[var(--color-border)]'
+                      }`}
+                    />
+                    <button
+                      type="button"
+                      onClick={handlePreviewUrlApply}
+                      disabled={disabled || savingPreview || previewUrlInvalid}
+                      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+                      title={t('canvas.workspace.preview.apply')}
+                    >
+                      <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+                    </button>
+                  </div>
+                </label>
+              ) : null}
+              <p className="m-0 text-[10px] leading-[var(--leading-body)] text-[var(--color-text-muted)]">
+                {integratedPreviewBlocked
+                  ? t('canvas.workspace.preview.hint.appWorkspace')
+                  : t('canvas.workspace.preview.hint.simpleWorkspace')}
+              </p>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -332,8 +786,13 @@ export function shouldShowTweakPanelForFile(input: {
 export function shouldUseDesignPreviewResolverForFile(input: {
   path: string;
   previewKind: FilePreviewKind;
+  source?: DesignFileSource | undefined;
 }): boolean {
-  return input.previewKind === 'runtime' && isMainDesignSourcePath(input.path);
+  return (
+    input.previewKind === 'runtime' &&
+    isMainDesignSourcePath(input.path) &&
+    input.source === 'preview-html'
+  );
 }
 
 export function defaultWorkspacePreviewPath(files: DesignFileEntry[]): string | null {
@@ -352,6 +811,18 @@ export function defaultWorkspacePreviewPath(files: DesignFileEntry[]): string | 
     files.find((f) => previewKindForFile(f.path, f.kind) === 'text')?.path ??
     files[0]?.path ??
     null
+  );
+}
+
+export function externalAppManagedFallbackPath(input: {
+  selectedPath: string | null;
+  defaultPath: string | null;
+  hasPersistedPreview: boolean;
+}): string | null {
+  return (
+    input.selectedPath ??
+    input.defaultPath ??
+    (input.hasPersistedPreview ? DEFAULT_SOURCE_ENTRY : null)
   );
 }
 
@@ -448,6 +919,7 @@ interface WorkspaceFilePreviewProps {
   path: string;
   file?: DesignFileEntry | null | undefined;
   files?: DesignFileEntry[] | null | undefined;
+  interactive?: boolean | undefined;
 }
 
 interface WorkspaceFilePreviewMessageHandlerInput {
@@ -836,7 +1308,119 @@ function NativeFilePreview({
   );
 }
 
-export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreviewProps) {
+function ConnectedUrlPreview({ url }: { url: string }) {
+  const t = useT();
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const handleOpenExternal = useCallback(async () => {
+    try {
+      await window.codesign?.openExternal(url);
+    } catch (err) {
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.preview.openFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
+    }
+  }, [t, url]);
+
+  return (
+    <div className="relative h-full min-h-0 bg-[var(--color-background-secondary)]">
+      <iframe
+        key={`${url}:${reloadKey}`}
+        title={`connected-preview-${url}`}
+        src={url}
+        sandbox="allow-forms allow-modals allow-popups allow-same-origin allow-scripts"
+        className="block h-full w-full border-0 bg-white"
+      />
+      <div className="absolute right-[var(--space-3)] top-[var(--space-3)] flex items-center gap-[var(--space-1)]">
+        <button
+          type="button"
+          onClick={() => setReloadKey((value) => value + 1)}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-surface-hover)]"
+          title={t('canvas.workspace.preview.reload')}
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={handleOpenExternal}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-secondary)] shadow-[var(--shadow-soft)] transition-colors hover:bg-[var(--color-surface-hover)]"
+          title={t('canvas.workspace.preview.openConnected')}
+        >
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NoPreviewPlaceholder() {
+  const t = useT();
+  return (
+    <div className="flex h-full items-center justify-center bg-[var(--color-background-secondary)] px-[var(--space-8)] text-center">
+      <div className="max-w-[360px] text-[13px] leading-[var(--leading-body)] text-[var(--color-text-muted)]">
+        <Globe2 className="mx-auto mb-[var(--space-3)] h-6 w-6 text-[var(--color-text-muted)]" />
+        {t('canvas.workspace.preview.placeholder.off')}
+      </div>
+    </div>
+  );
+}
+
+function DevServerRequiredPlaceholder() {
+  const t = useT();
+  return (
+    <div className="flex h-full items-center justify-center bg-[var(--color-background-secondary)] px-[var(--space-8)] text-center">
+      <div className="max-w-[420px] text-[13px] leading-[var(--leading-body)] text-[var(--color-text-muted)]">
+        <Globe2 className="mx-auto mb-[var(--space-3)] h-6 w-6 text-[var(--color-text-muted)]" />
+        {t('canvas.workspace.preview.placeholder.devServerRequired')}
+      </div>
+    </div>
+  );
+}
+
+function ExternalAppPreviewPlaceholder({ url }: { url: string | null }) {
+  const t = useT();
+
+  const handleOpenExternal = useCallback(async () => {
+    if (!url) return;
+    try {
+      await window.codesign?.openExternal(url);
+    } catch (err) {
+      useCodesignStore.getState().pushToast({
+        variant: 'error',
+        title: t('canvas.workspace.preview.openFailed'),
+        description: err instanceof Error ? err.message : t('errors.unknown'),
+      });
+    }
+  }, [t, url]);
+
+  return (
+    <div className="flex h-full items-center justify-center bg-[var(--color-background-secondary)] px-[var(--space-8)] text-center">
+      <div className="max-w-[420px] text-[13px] leading-[var(--leading-body)] text-[var(--color-text-muted)]">
+        <ExternalLink className="mx-auto mb-[var(--space-3)] h-6 w-6 text-[var(--color-text-muted)]" />
+        <p className="m-0">{t('canvas.workspace.preview.placeholder.external')}</p>
+        {url ? (
+          <button
+            type="button"
+            onClick={handleOpenExternal}
+            className="mt-[var(--space-4)] inline-flex h-8 items-center gap-2 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)]"
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            {t('canvas.workspace.preview.openConnected')}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceFilePreview({
+  path,
+  file,
+  files,
+  interactive = true,
+}: WorkspaceFilePreviewProps) {
   const t = useT();
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
   const designs = useCodesignStore((s) => s.designs);
@@ -855,7 +1439,11 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
   const prefersPreviewSource = effectiveFile?.source === 'preview-html';
   const previewKind = previewKindForFile(path, effectiveFile?.kind);
   const renderable = previewKind === 'runtime';
-  const useDesignPreviewResolver = shouldUseDesignPreviewResolverForFile({ path, previewKind });
+  const useDesignPreviewResolver = shouldUseDesignPreviewResolverForFile({
+    path,
+    previewKind,
+    source: effectiveFile?.source,
+  });
   const textPreview = previewKind === 'markdown' || previewKind === 'text';
   const documentPreview = previewKind === 'document';
   const nativePreview =
@@ -864,11 +1452,13 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
     previewKind === 'audio' ||
     previewKind === 'pdf';
   const [previewSource, setPreviewSource] = useState<WorkspacePreviewSource | null>(null);
-  const showTweakPanel = shouldShowTweakPanelForFile({
-    path,
-    previewKind,
-    hasPreviewSource: previewSource !== null,
-  });
+  const showTweakPanel =
+    interactive &&
+    shouldShowTweakPanelForFile({
+      path,
+      previewKind,
+      hasPreviewSource: previewSource !== null,
+    });
   const previewDependencyKey = workspacePreviewDependencyKey(
     workspaceFiles,
     path,
@@ -891,9 +1481,15 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
         event.data,
         createWorkspaceFilePreviewMessageHandlers({
           previewZoom,
-          selectCanvasElement,
-          openCommentBubble,
-          applyLiveRects,
+          selectCanvasElement: (selection) => {
+            if (interactive) selectCanvasElement(selection);
+          },
+          openCommentBubble: (bubble) => {
+            if (interactive) openCommentBubble(bubble);
+          },
+          applyLiveRects: (entries) => {
+            if (interactive) applyLiveRects(entries);
+          },
           pushIframeError,
         }),
       );
@@ -901,11 +1497,22 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [pushIframeError, previewZoom, selectCanvasElement, openCommentBubble, applyLiveRects]);
+  }, [
+    pushIframeError,
+    previewZoom,
+    selectCanvasElement,
+    openCommentBubble,
+    applyLiveRects,
+    interactive,
+  ]);
 
   useEffect(() => {
-    postModeToPreviewWindow(iframeRef.current?.contentWindow, interactionMode, pushIframeError);
-  }, [interactionMode, pushIframeError]);
+    postModeToPreviewWindow(
+      iframeRef.current?.contentWindow,
+      interactive ? interactionMode : 'default',
+      pushIframeError,
+    );
+  }, [interactionMode, pushIframeError, interactive]);
 
   useEffect(() => {
     // Re-read when the file watcher reports changed metadata for either the
@@ -992,10 +1599,13 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
     () => workspacePreviewSourceStableKey(activePreviewSource),
     [activePreviewSource],
   );
+  const workspaceDevServerRequired =
+    Boolean(activePreviewSource?.path.toLowerCase().endsWith('.html')) &&
+    htmlRequiresWorkspaceDevServer(activePreviewSource?.content ?? '');
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: previewSourceStableKey intentionally masks EDITMODE-only token changes so live tweaks can update via postMessage without rebuilding the iframe.
   const srcDoc = useMemo(() => {
-    if (!activePreviewSource || !renderable) return null;
+    if (!activePreviewSource || !renderable || workspaceDevServerRequired) return null;
     try {
       const baseHref = workspaceBaseHrefForFile({
         designId: currentDesignId,
@@ -1016,6 +1626,7 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
     activePreviewSource?.path,
     previewSourceStableKey,
     renderable,
+    workspaceDevServerRequired,
   ]);
 
   if (nativePreview) {
@@ -1033,6 +1644,10 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
         {t('canvas.filesTabEmpty')}
       </div>
     );
+  }
+
+  if (workspaceDevServerRequired) {
+    return <DevServerRequiredPlaceholder />;
   }
 
   if (!srcDoc) {
@@ -1061,7 +1676,7 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
         srcDoc={srcDoc}
         onLoad={() => {
           const win = iframeRef.current?.contentWindow;
-          postModeToPreviewWindow(win, interactionMode, pushIframeError);
+          postModeToPreviewWindow(win, interactive ? interactionMode : 'default', pushIframeError);
         }}
         className="w-full h-full bg-white border-0 block"
       />
@@ -1074,44 +1689,330 @@ export function WorkspaceFilePreview({ path, file, files }: WorkspaceFilePreview
   );
 }
 
-export function FilesTabView() {
+export function FilesTabView({ activePath = null }: { activePath?: string | null }) {
   const t = useT();
   const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const designs = useCodesignStore((s) => s.designs);
   const openFileTab = useCodesignStore((s) => s.openCanvasFileTab);
-  const { files } = useDesignFiles(currentDesignId);
+  const setActiveCanvasTab = useCodesignStore((s) => s.setActiveCanvasTab);
+  const currentPreviewSource = useCodesignStore((s) => s.previewSource);
+  const { files, tree: fileTree, loadDirectory } = useLazyDesignFileTree(currentDesignId);
 
   const defaultPath = useMemo(() => defaultWorkspacePreviewPath(files), [files]);
 
-  const [selectedPath, setSelectedPath] = useState<string | null>(defaultPath);
+  const [selectedPath, setSelectedPath] = useState<string | null>(activePath ?? defaultPath);
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
+  const [fileBrowserWidth, setFileBrowserWidth] = useState(initialFileBrowserWidth);
+  const [isFileBrowserResizing, setIsFileBrowserResizing] = useState(false);
+  const expandedDesignRef = useRef<string | null>(currentDesignId);
+  const isDedicatedFileTab = activePath !== null;
+  const currentDesign = designs.find((d) => d.id === currentDesignId);
+  const effectivePreviewMode = useMemo(
+    () =>
+      effectivePreviewModeForDesign({
+        previewMode: currentDesign?.previewMode,
+        previewUrl: currentDesign?.previewUrl,
+        files,
+      }),
+    [currentDesign?.previewMode, currentDesign?.previewUrl, files],
+  );
+  const selectedFile = selectedPath ? (files.find((f) => f.path === selectedPath) ?? null) : null;
+  const connectedPreviewUrl = normalizeConnectedPreviewUrlInput(currentDesign?.previewUrl ?? '');
+  const externalFallbackPath = externalAppManagedFallbackPath({
+    selectedPath,
+    defaultPath,
+    hasPersistedPreview:
+      Boolean(currentPreviewSource?.trim()) ||
+      Boolean(currentDesign?.thumbnailText && currentDesign.thumbnailText.length > 0),
+  });
+  const externalFallbackFile = externalFallbackPath
+    ? (files.find((f) => f.path === externalFallbackPath) ?? null)
+    : null;
+  const usesExternalPreview =
+    effectivePreviewMode === 'connected-url' || effectivePreviewMode === 'external-app';
+  const showPreviewHeaderAction =
+    (effectivePreviewMode === 'managed-file' && selectedPath !== null) ||
+    (usesExternalPreview && connectedPreviewUrl !== null);
+
+  const handleOpenPreviewTarget = useCallback(async () => {
+    if (usesExternalPreview && connectedPreviewUrl) {
+      try {
+        await window.codesign?.openExternal(connectedPreviewUrl);
+      } catch (err) {
+        useCodesignStore.getState().pushToast({
+          variant: 'error',
+          title: t('canvas.workspace.preview.openFailed'),
+          description: err instanceof Error ? err.message : t('errors.unknown'),
+        });
+      }
+      return;
+    }
+    if (selectedPath) openFileTab(selectedPath);
+  }, [connectedPreviewUrl, openFileTab, selectedPath, t, usesExternalPreview]);
+
+  const handleFileTreeFileClick = useCallback(
+    (path: string) => {
+      setSelectedPath(path);
+      if (isDedicatedFileTab) setActiveCanvasTab(0);
+    },
+    [isDedicatedFileTab, setActiveCanvasTab],
+  );
+
+  const handleFileBrowserResizeStart = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = fileBrowserWidth;
+      setIsFileBrowserResizing(true);
+
+      const onMove = (moveEvent: MouseEvent) => {
+        const nextWidth = clampFileBrowserWidth(
+          startWidth + moveEvent.clientX - startX,
+          window.innerWidth,
+        );
+        setFileBrowserWidth(nextWidth);
+      };
+
+      const onUp = () => {
+        setIsFileBrowserResizing(false);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [fileBrowserWidth],
+  );
 
   useEffect(() => {
+    try {
+      window.localStorage.setItem(FILE_BROWSER_WIDTH_STORAGE_KEY, String(fileBrowserWidth));
+    } catch {
+      // Layout preference persistence is best-effort.
+    }
+  }, [fileBrowserWidth]);
+
+  function renderPreviewPane() {
+    if (effectivePreviewMode === 'connected-url') {
+      return connectedPreviewUrl ? (
+        <ConnectedUrlPreview url={connectedPreviewUrl} />
+      ) : (
+        <NoPreviewPlaceholder />
+      );
+    }
+    if (effectivePreviewMode === 'external-app') {
+      if (externalFallbackPath) {
+        return (
+          <WorkspaceFilePreview
+            path={externalFallbackPath}
+            file={externalFallbackFile}
+            files={files}
+            interactive={isDedicatedFileTab}
+          />
+        );
+      }
+      return <ExternalAppPreviewPlaceholder url={connectedPreviewUrl} />;
+    }
+    if (effectivePreviewMode === 'none') {
+      if (
+        selectedPath &&
+        selectedFile &&
+        previewKindForFile(selectedPath, selectedFile.kind) === 'runtime'
+      ) {
+        return (
+          <WorkspaceFilePreview
+            path={selectedPath}
+            file={selectedFile}
+            files={files}
+            interactive={isDedicatedFileTab}
+          />
+        );
+      }
+      return <NoPreviewPlaceholder />;
+    }
+    if (selectedPath) {
+      return (
+        <WorkspaceFilePreview
+          path={selectedPath}
+          file={selectedFile}
+          files={files}
+          interactive={isDedicatedFileTab}
+        />
+      );
+    }
+    return (
+      <div className="flex h-full items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
+        {t('canvas.filesTabEmpty')}
+      </div>
+    );
+  }
+
+  useEffect(() => {
+    if (activePath) {
+      setSelectedPath(activePath);
+      return;
+    }
     if (!selectedPath || !files.find((f) => f.path === selectedPath)) {
       setSelectedPath(defaultPath);
     }
-  }, [defaultPath, files, selectedPath]);
+  }, [activePath, defaultPath, files, selectedPath]);
 
-  if (files.length === 0) {
+  useEffect(() => {
+    if (expandedDesignRef.current === currentDesignId) return;
+    expandedDesignRef.current = currentDesignId;
+    setExpandedDirs(new Set());
+  }, [currentDesignId]);
+
+  function toggleDirectory(node: FileTreeNode) {
+    if (node.type !== 'directory') return;
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      if (next.has(node.path)) {
+        next.delete(node.path);
+      } else {
+        next.add(node.path);
+        if (!node.loaded && !node.loading) void loadDirectory(node.path);
+      }
+      return next;
+    });
+  }
+
+  function renderFileTreeNode(node: FileTreeNode, depth: number): ReactNode {
+    if (node.type === 'directory') {
+      const isExpanded = expandedDirs.has(node.path);
+      return (
+        <li key={node.path}>
+          <button
+            type="button"
+            onClick={() => toggleDirectory(node)}
+            aria-expanded={isExpanded}
+            className="group flex h-9 w-full min-w-0 items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] px-[var(--space-2)] text-left text-[var(--text-sm)] text-[var(--color-text-secondary)] transition-colors duration-[var(--duration-faster)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]"
+            style={{ paddingLeft: `calc(var(--space-2) + ${depth * 16}px)` }}
+          >
+            <ChevronRight
+              className={`size-3.5 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+              aria-hidden
+            />
+            {isExpanded ? (
+              <FolderOpen className="size-4 shrink-0" aria-hidden />
+            ) : (
+              <Folder className="size-4 shrink-0" aria-hidden />
+            )}
+            <span className="min-w-0 flex-1 truncate font-medium" title={node.path}>
+              {node.name}
+            </span>
+            <span
+              className="shrink-0 text-[10px] text-[var(--color-text-muted)]"
+              style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+            >
+              {node.fileCount ?? ''}
+            </span>
+          </button>
+          {isExpanded && node.loading ? (
+            <div
+              className="flex h-8 items-center px-[var(--space-2)] text-[var(--text-xs)] text-[var(--color-text-muted)]"
+              style={{ paddingLeft: `calc(var(--space-2) + ${(depth + 1) * 16 + 20}px)` }}
+            >
+              {t('common.loading')}
+            </div>
+          ) : null}
+          {isExpanded && node.children.length > 0 ? (
+            <ul className="list-none p-0 m-0">
+              {node.children.map((child) => renderFileTreeNode(child, depth + 1))}
+            </ul>
+          ) : null}
+        </li>
+      );
+    }
+
+    const f = node.file;
+    const isActive = f.path === selectedPath;
     return (
-      <div className="flex h-full min-h-0">
-        <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
-          <WorkspaceSection />
+      <li key={node.path} className="relative">
+        {isActive ? (
+          <span
+            aria-hidden
+            className="absolute left-0 top-[6px] bottom-[6px] w-[2px] bg-[var(--color-accent)] rounded-r-full"
+          />
+        ) : null}
+        <button
+          type="button"
+          onClick={() => handleFileTreeFileClick(f.path)}
+          onDoubleClick={() => openFileTab(f.path)}
+          title={f.path}
+          aria-current={isActive ? 'page' : undefined}
+          className={`group flex h-9 w-full items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] pr-[var(--space-2)] text-left transition-colors duration-[var(--duration-faster)] ${
+            isActive
+              ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)]'
+              : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]'
+          }`}
+          style={{ paddingLeft: `calc(var(--space-2) + ${depth * 16 + 20}px)` }}
+        >
+          <FileCode2
+            className={`size-4 shrink-0 ${
+              isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'
+            }`}
+            aria-hidden
+          />
+          <span className="flex min-w-0 flex-1 flex-col gap-[1px]">
+            <span
+              className="truncate text-[var(--text-sm)] leading-[var(--leading-ui)]"
+              style={{ fontFamily: 'var(--font-mono)' }}
+            >
+              {node.name}
+            </span>
+            <span
+              className="text-[10px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)]"
+              style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
+            >
+              {formatBytes(f.size)}
+            </span>
+          </span>
+        </button>
+      </li>
+    );
+  }
+
+  if (files.length === 0 && fileTree.length === 0) {
+    return (
+      <div className="relative flex h-full min-h-0">
+        {isFileBrowserResizing ? <div className="absolute inset-0 z-20 cursor-col-resize" /> : null}
+        <aside
+          className="shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col"
+          style={{ width: fileBrowserWidth }}
+        >
+          <WorkspaceSection files={files} />
           <div className="flex-1 flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)] px-[var(--space-6)]">
             {t('canvas.filesTabEmpty')}
           </div>
         </aside>
-        <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
-          {t('canvas.filesTabEmpty')}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          onMouseDown={handleFileBrowserResizeStart}
+          className="relative z-10 w-[5px] shrink-0 cursor-col-resize bg-[var(--color-background)] transition-colors duration-100 hover:bg-[var(--color-accent)]/15 active:bg-[var(--color-accent)]/25"
+          title="Resize files"
+        />
+        <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)]">
+          {renderPreviewPane()}
         </div>
       </div>
     );
   }
 
-  const selectedFile = selectedPath ? (files.find((f) => f.path === selectedPath) ?? null) : null;
-
   return (
-    <div className="flex h-full min-h-0">
-      <aside className="w-[35%] shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col">
-        <WorkspaceSection />
+    <div className="relative flex h-full min-h-0">
+      {isFileBrowserResizing ? <div className="absolute inset-0 z-20 cursor-col-resize" /> : null}
+      <aside
+        className="shrink-0 border-r border-[var(--color-border-muted)] bg-[var(--color-background)] overflow-y-auto flex flex-col"
+        style={{ width: fileBrowserWidth }}
+      >
+        <WorkspaceSection files={files} />
         <div className="px-[var(--space-6)] py-[var(--space-6)]">
           <div className="mb-[var(--space-4)] flex items-center gap-[var(--space-2)]">
             <h2 className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] font-medium m-0">
@@ -1126,53 +2027,7 @@ export function FilesTabView() {
           </div>
 
           <ul className="list-none p-0 m-0 flex flex-col gap-[var(--space-1)]">
-            {files.map((f) => {
-              const isActive = f.path === selectedPath;
-              const segments = f.path.split('/');
-              const name = segments[segments.length - 1] ?? f.path;
-              return (
-                <li key={f.path} className="relative">
-                  {isActive ? (
-                    <span
-                      aria-hidden
-                      className="absolute left-0 top-[6px] bottom-[6px] w-[2px] bg-[var(--color-accent)] rounded-r-full"
-                    />
-                  ) : null}
-                  <button
-                    type="button"
-                    onClick={() => setSelectedPath(f.path)}
-                    onDoubleClick={() => openFileTab(f.path)}
-                    title={f.path}
-                    className={`group w-full flex items-center gap-[var(--space-3)] h-[44px] pl-[var(--space-4)] pr-[var(--space-3)] text-left rounded-[var(--radius-md)] transition-colors duration-[var(--duration-faster)] ${
-                      isActive
-                        ? 'bg-[var(--color-surface-active)] text-[var(--color-text-primary)]'
-                        : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]'
-                    }`}
-                  >
-                    <FileCode2
-                      className={`w-[16px] h-[16px] shrink-0 ${
-                        isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'
-                      }`}
-                      aria-hidden
-                    />
-                    <span className="flex-1 min-w-0 flex flex-col gap-[1px]">
-                      <span
-                        className="truncate text-[var(--text-sm)] leading-[var(--leading-ui)]"
-                        style={{ fontFamily: 'var(--font-mono)' }}
-                      >
-                        {name}
-                      </span>
-                      <span
-                        className="text-[10px] text-[var(--color-text-muted)] uppercase tracking-[var(--tracking-label)]"
-                        style={{ fontFamily: 'var(--font-mono)', fontFeatureSettings: "'tnum'" }}
-                      >
-                        {formatBytes(f.size)}
-                      </span>
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
+            {fileTree.map((node) => renderFileTreeNode(node, 0))}
           </ul>
 
           <p className="mt-[var(--space-6)] text-[11px] text-[var(--color-text-muted)] leading-[var(--leading-body)]">
@@ -1180,30 +2035,29 @@ export function FilesTabView() {
           </p>
         </div>
       </aside>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        onMouseDown={handleFileBrowserResizeStart}
+        className="relative z-10 w-[5px] shrink-0 cursor-col-resize bg-[var(--color-background)] transition-colors duration-100 hover:bg-[var(--color-accent)]/15 active:bg-[var(--color-accent)]/25"
+        title="Resize files"
+      />
       <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex flex-col min-h-0">
-        <div className="shrink-0 h-[36px] px-[var(--space-4)] flex items-center justify-between gap-[var(--space-3)] border-b border-[var(--color-border-muted)] bg-[var(--color-background)]">
-          <span
-            className="truncate text-[12px] text-[var(--color-text-secondary)]"
-            style={{ fontFamily: 'var(--font-mono)' }}
-          >
-            {selectedFile?.path ?? selectedPath ?? ''}
-          </span>
-          <button
-            type="button"
-            onClick={() => selectedPath && openFileTab(selectedPath)}
-            className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors"
-          >
-            {t('canvas.openInTab')}
-          </button>
-        </div>
+        {showPreviewHeaderAction ? (
+          <div className="flex h-[36px] shrink-0 items-center justify-end border-b border-[var(--color-border-muted)] bg-[var(--color-background)] px-[var(--space-4)]">
+            <button
+              type="button"
+              onClick={handleOpenPreviewTarget}
+              className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-accent)]"
+            >
+              {usesExternalPreview
+                ? t('canvas.workspace.preview.openConnected')
+                : t('canvas.openInTab')}
+            </button>
+          </div>
+        ) : null}
         <div className="flex-1 min-h-0 bg-[var(--color-background-secondary)]">
-          {selectedPath ? (
-            <WorkspaceFilePreview path={selectedPath} file={selectedFile} files={files} />
-          ) : (
-            <div className="h-full flex items-center justify-center text-[var(--text-sm)] text-[var(--color-text-muted)]">
-              {t('canvas.filesTabEmpty')}
-            </div>
-          )}
+          {renderPreviewPane()}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.test.ts
@@ -3,6 +3,7 @@ import { useCodesignStore } from '../store';
 import {
   computeFitPreviewZoom,
   handlePreviewMessage,
+  isPreviewPaneWelcomeState,
   isTrustedPreviewMessageSource,
   postModeToPreviewWindow,
   previewArtboardFrameClass,
@@ -96,6 +97,32 @@ describe('preview artboard frame', () => {
         viewport: 'desktop',
       }),
     ).toBe(100);
+  });
+});
+
+describe('preview pane welcome state', () => {
+  it('hides chrome only for the empty base files tab', () => {
+    expect(
+      isPreviewPaneWelcomeState({
+        activeTab: { kind: 'files' },
+        tabCount: 1,
+        errorMessage: null,
+        previewSource: null,
+        designHasContent: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps tabs visible for opened file tabs without preview content', () => {
+    expect(
+      isPreviewPaneWelcomeState({
+        activeTab: { kind: 'file', path: 'index.html' },
+        tabCount: 2,
+        errorMessage: null,
+        previewSource: null,
+        designHasContent: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/src/components/PreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/components/PreviewPane.tsx
@@ -25,11 +25,12 @@ import {
 } from '../preview/helpers';
 import { inferPreviewSourcePath } from '../preview/workspace-source';
 import { useCodesignStore } from '../store';
+import type { CanvasTab } from '../store/slices/tabs';
 import { CanvasErrorBar } from './CanvasErrorBar';
 import { CanvasTabBar } from './CanvasTabBar';
 import { CommentBubble } from './comment/CommentBubble';
 import { PinOverlay } from './comment/PinOverlay';
-import { FilesTabView, WorkspaceFilePreview } from './FilesTabView';
+import { FilesTabView } from './FilesTabView';
 import { PhoneFrame } from './PhoneFrame';
 import { PreviewToolbar } from './PreviewToolbar';
 
@@ -90,6 +91,17 @@ const PREVIEW_PANE_LAYOUT_CLASSES = {
 
 export function previewPaneLayoutClasses(): typeof PREVIEW_PANE_LAYOUT_CLASSES {
   return PREVIEW_PANE_LAYOUT_CLASSES;
+}
+
+export function isPreviewPaneWelcomeState(input: {
+  activeTab: CanvasTab | undefined;
+  tabCount: number;
+  errorMessage: string | null;
+  previewSource: string | null;
+  designHasContent: boolean;
+}): boolean {
+  const onlyBaseFilesTab = input.tabCount <= 1 && input.activeTab?.kind === 'files';
+  return onlyBaseFilesTab && !input.errorMessage && !input.previewSource && !input.designHasContent;
 }
 
 export function previewViewportDimensions(viewport: PreviewSlotProps['viewport']): {
@@ -562,7 +574,7 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   } else if (activeTab?.kind === 'files') {
     body = <FilesTabView />;
   } else if (activeTab?.kind === 'file') {
-    body = <WorkspaceFilePreview path={activeTab.path} />;
+    body = <FilesTabView activePath={activeTab.path} />;
   } else {
     // Pool slots stay mounted even when the current design has no preview —
     // background iframes for recently-visited designs keep their documents
@@ -601,7 +613,13 @@ export function PreviewPane({ onPickStarter }: PreviewPaneProps) {
   }
 
   const hasTabs = canvasTabs.length > 0;
-  const isWelcome = !errorMessage && !previewSource && !designHasContent;
+  const isWelcome = isPreviewPaneWelcomeState({
+    activeTab,
+    tabCount: canvasTabs.length,
+    errorMessage,
+    previewSource,
+    designHasContent,
+  });
 
   return (
     <div className={PREVIEW_PANE_LAYOUT_CLASSES.root}>

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useT } from '@open-codesign/i18n';
 import type { LocalInputFile, OnboardingState } from '@open-codesign/shared';
 import { FolderOpen, Link2, Paperclip, X } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useCodesignStore } from '../store';
 import { AskModal } from './AskModal';
 import { AddMenu } from './chat/AddMenu';
@@ -12,9 +12,7 @@ import { PromptInput, type PromptInputHandle } from './chat/PromptInput';
 import { ModelSwitcher } from './ModelSwitcher';
 
 export interface SidebarProps {
-  prompt: string;
-  setPrompt: (value: string) => void;
-  onSubmit: () => void;
+  prefillPrompt: { id: number; text: string } | null;
 }
 
 interface ComposerContextItem {
@@ -74,7 +72,7 @@ function ContextIcon({ icon }: { icon: ComposerContextItem['icon'] }) {
  * stays deferred; the design name + "+" header shows the single current
  * design only.
  */
-export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
+export function Sidebar({ prefillPrompt }: SidebarProps) {
   const t = useT();
   const config = useCodesignStore((s) => s.config);
   const isGenerating = useCodesignStore(
@@ -100,12 +98,28 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
   const designs = useCodesignStore((s) => s.designs);
   const _sidebarCollapsed = useCodesignStore((s) => s.sidebarCollapsed);
   const _setSidebarCollapsed = useCodesignStore((s) => s.setSidebarCollapsed);
+  const sendPrompt = useCodesignStore((s) => s.sendPrompt);
 
   const promptInputRef = useRef<PromptInputHandle>(null);
   const handlePickStarter = (starterPrompt: string): void => {
-    setPrompt(starterPrompt);
+    promptInputRef.current?.setPrompt(starterPrompt);
     promptInputRef.current?.focus();
   };
+
+  useEffect(() => {
+    if (prefillPrompt === null) return;
+    promptInputRef.current?.setPrompt(prefillPrompt.text);
+    promptInputRef.current?.focus();
+  }, [prefillPrompt]);
+
+  const handleSubmit = useCallback(
+    (text: string): void => {
+      const trimmed = text.trim();
+      if (!trimmed || isGenerating) return;
+      void sendPrompt({ prompt: trimmed });
+    },
+    [isGenerating, sendPrompt],
+  );
 
   const designSystem = config?.designSystem ?? null;
   const _currentDesign = designs.find((d) => d.id === currentDesignId) ?? null;
@@ -150,9 +164,7 @@ export function Sidebar({ prompt, setPrompt, onSubmit }: SidebarProps) {
         <CommentChipBar />
         <PromptInput
           ref={promptInputRef}
-          prompt={prompt}
-          setPrompt={setPrompt}
-          onSubmit={onSubmit}
+          onSubmit={handleSubmit}
           onCancel={cancelGeneration}
           isGenerating={isGenerating}
           onImportFiles={async (input) => {

--- a/apps/desktop/src/renderer/src/components/chat/PromptInput.tsx
+++ b/apps/desktop/src/renderer/src/components/chat/PromptInput.tsx
@@ -95,9 +95,7 @@ function resizeTextarea(el: HTMLTextAreaElement): void {
 }
 
 export interface PromptInputProps {
-  prompt: string;
-  setPrompt: (value: string) => void;
-  onSubmit: () => void;
+  onSubmit: (prompt: string) => void;
   onCancel: () => void;
   isGenerating: boolean;
   /** Optional content rendered above the textarea, inside the composer card. */
@@ -113,6 +111,7 @@ export interface PromptInputProps {
 
 export interface PromptInputHandle {
   focus: () => void;
+  setPrompt: (value: string) => void;
 }
 
 /**
@@ -125,21 +124,13 @@ export interface PromptInputHandle {
  *   Shift+Enter     — newline
  */
 export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(function PromptInput(
-  {
-    prompt,
-    setPrompt,
-    onSubmit,
-    onCancel,
-    isGenerating,
-    contextSummary,
-    leadingAction,
-    onImportFiles,
-  },
+  { onSubmit, onCancel, isGenerating, contextSummary, leadingAction, onImportFiles },
   ref,
 ) {
   const t = useT();
   const taRef = useRef<HTMLTextAreaElement>(null);
   const compositionActiveRef = useRef(false);
+  const [prompt, setPrompt] = useState('');
   const generationStage = useCodesignStore((s) => s.generationStage);
   const generationStartedAt = useCodesignStore((s) => {
     const currentDesignId = s.currentDesignId;
@@ -193,12 +184,19 @@ export const PromptInput = forwardRef<PromptInputHandle, PromptInputProps>(funct
     focus: () => {
       taRef.current?.focus();
     },
+    setPrompt: (value) => {
+      setPrompt(value);
+      requestAnimationFrame(() => {
+        if (taRef.current) resizeTextarea(taRef.current);
+      });
+    },
   }));
 
   function handleSubmit(e: FormEvent): void {
     e.preventDefault();
     if (!prompt.trim() || isGenerating) return;
-    onSubmit();
+    onSubmit(prompt.trim());
+    setPrompt('');
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {

--- a/apps/desktop/src/renderer/src/hooks/useAgentStream.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAgentStream.ts
@@ -162,10 +162,8 @@ export function useAgentStream(): void {
         toolCallId: event.toolCallId,
         status: initialStatus,
       });
-      // set_title runs with no side effects on disk — its whole job is
-      // to rename the design. Trigger the rename immediately off the
-      // start event so the sidebar label flips without waiting for the
-      // result round-trip.
+      // set_title updates design metadata only. Moving the workspace folder
+      // here can race with file reads/writes from the active generation.
       if (toolName === 'set_title') {
         const rawTitle = (event.args as { title?: unknown } | undefined)?.title;
         if (typeof rawTitle === 'string' && rawTitle.trim().length > 0) {
@@ -174,7 +172,7 @@ export function useAgentStream(): void {
             .replace(/[\s.,;:!?—–-]+$/u, '')
             .slice(0, 60);
           if (cleaned.length > 0) {
-            void renameDesign(designId, cleaned);
+            void renameDesign(designId, cleaned, { renameWorkspace: false });
           }
         }
       }

--- a/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDesignFiles.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_SOURCE_ENTRY } from '@open-codesign/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { WorkspaceFileKind } from '../../../preload/index';
+import type { WorkspaceDirectoryEntry, WorkspaceFileKind } from '../../../preload/index';
+import { buildLazyFileTree, type FileTreeNode, type LazyDirectoryMap } from '../lib/file-tree';
 import { useCodesignStore } from '../store';
 import { tr } from '../store/lib/locale';
 
@@ -19,6 +20,11 @@ export interface UseDesignFilesResult {
   files: DesignFileEntry[];
   loading: boolean;
   backend: 'workspace' | 'snapshots';
+}
+
+export interface UseLazyDesignFileTreeResult extends UseDesignFilesResult {
+  tree: FileTreeNode[];
+  loadDirectory: (path: string) => Promise<void>;
 }
 
 export interface WorkspaceListErrorToastState {
@@ -291,6 +297,298 @@ export function useDesignFiles(designId: string | null): UseDesignFilesResult {
   }, [backend, designId, pushToast, refetch, workspacePath]);
 
   return { files, loading, backend };
+}
+
+function filesFromLazyDirectories(directories: LazyDirectoryMap): DesignFileEntry[] {
+  const byPath = new Map<string, DesignFileEntry>();
+  for (const state of Object.values(directories)) {
+    if (!state?.loaded) continue;
+    for (const entry of state.entries) {
+      if (entry.type !== 'file') continue;
+      byPath.set(entry.path, {
+        path: entry.path,
+        kind: entry.kind ?? 'asset',
+        updatedAt: entry.updatedAt ?? new Date().toISOString(),
+        source: 'workspace',
+        ...(entry.size !== undefined ? { size: entry.size } : {}),
+      });
+    }
+  }
+  return Array.from(byPath.values()).sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function useLazyDesignFileTree(designId: string | null): UseLazyDesignFileTreeResult {
+  const previewSource = useCodesignStore((s) => s.previewSource);
+  const workspacePath = useCodesignStore((s) =>
+    designId === null ? null : (s.designs.find((d) => d.id === designId)?.workspacePath ?? null),
+  );
+  const designUpdatedAt = useCodesignStore((s) =>
+    designId === null ? undefined : s.designs.find((d) => d.id === designId)?.updatedAt,
+  );
+  const pushToast = useCodesignStore((s) => s.pushToast);
+  const dismissToast = useCodesignStore((s) => s.dismissToast);
+  const [directories, setDirectories] = useState<LazyDirectoryMap>({});
+  const [loading, setLoading] = useState(false);
+  const listErrorToastRef = useRef<WorkspaceListErrorToastState>({ key: null, toastId: null });
+  const refetchSeqRef = useRef(0);
+  const directoriesRef = useRef<LazyDirectoryMap>({});
+  const loadContextRef = useRef<{
+    designId: string | null;
+    backend: 'workspace' | 'snapshots';
+    workspacePath: string | null;
+  }>({ designId, backend: 'snapshots', workspacePath });
+  const backend: 'workspace' | 'snapshots' =
+    typeof window !== 'undefined' &&
+    typeof (window.codesign as unknown as { files?: { listDir?: unknown } })?.files?.listDir ===
+      'function'
+      ? 'workspace'
+      : 'snapshots';
+
+  loadContextRef.current = { designId, backend, workspacePath };
+
+  const updateDirectories = useCallback((updater: (prev: LazyDirectoryMap) => LazyDirectoryMap) => {
+    setDirectories((prev) => {
+      const next = updater(prev);
+      directoriesRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const loadDirectory = useCallback(
+    async (path: string) => {
+      const normalizedPath = path.length === 0 ? '.' : path;
+      if (!designId || backend !== 'workspace' || workspacePath === null) return;
+      const context = { designId, backend, workspacePath };
+      const isCurrentContext = () => {
+        const current = loadContextRef.current;
+        return (
+          current.designId === context.designId &&
+          current.backend === context.backend &&
+          current.workspacePath === context.workspacePath
+        );
+      };
+      updateDirectories((prev) => ({
+        ...prev,
+        [normalizedPath]: {
+          entries: prev[normalizedPath]?.entries ?? [],
+          loaded: prev[normalizedPath]?.loaded === true,
+          loading: true,
+        },
+      }));
+      try {
+        const rows = await (
+          window.codesign as unknown as {
+            files: {
+              listDir: (id: string, dirPath: string) => Promise<WorkspaceDirectoryEntry[]>;
+            };
+          }
+        ).files.listDir(designId, normalizedPath);
+        if (!isCurrentContext()) return;
+        updateDirectories((prev) => ({
+          ...prev,
+          [normalizedPath]: { entries: rows, loaded: true, loading: false },
+        }));
+        handleWorkspaceListSuccessToast(
+          listErrorToastRef.current,
+          dismissToast,
+          currentWorkspaceListFailureToastIds(),
+        );
+      } catch (err) {
+        if (!isCurrentContext()) return;
+        const message = err instanceof Error ? err.message : tr('errors.unknown');
+        updateDirectories((prev) => ({
+          ...prev,
+          [normalizedPath]: {
+            entries: prev[normalizedPath]?.entries ?? [],
+            loaded: prev[normalizedPath]?.loaded === true,
+            loading: false,
+          },
+        }));
+        handleWorkspaceListErrorToast({
+          state: listErrorToastRef.current,
+          key: `${designId}:${workspacePath}:${normalizedPath}:${message}`,
+          message,
+          pushToast,
+          dismissToast,
+        });
+      }
+    },
+    [backend, designId, dismissToast, pushToast, updateDirectories, workspacePath],
+  );
+
+  const reloadLoadedDirectories = useCallback(async () => {
+    const seq = ++refetchSeqRef.current;
+    const isCurrent = () => refetchSeqRef.current === seq;
+    if (!designId) {
+      handleWorkspaceListSuccessToast(
+        listErrorToastRef.current,
+        dismissToast,
+        currentWorkspaceListFailureToastIds(),
+      );
+      if (isCurrent()) updateDirectories(() => ({}));
+      return;
+    }
+    if (backend !== 'workspace' || workspacePath === null) {
+      handleWorkspaceListSuccessToast(
+        listErrorToastRef.current,
+        dismissToast,
+        currentWorkspaceListFailureToastIds(),
+      );
+      if (isCurrent()) updateDirectories(() => ({}));
+      return;
+    }
+
+    const context = { designId, backend, workspacePath };
+    const isCurrentContext = () => {
+      const current = loadContextRef.current;
+      return (
+        current.designId === context.designId &&
+        current.backend === context.backend &&
+        current.workspacePath === context.workspacePath
+      );
+    };
+    const currentDirectories = directoriesRef.current;
+    const currentlyLoaded = Object.keys(currentDirectories).filter(
+      (key) => currentDirectories[key]?.loaded === true,
+    );
+    const paths = currentlyLoaded.length > 0 ? currentlyLoaded : ['.'];
+    try {
+      if (isCurrent()) setLoading(true);
+      const rows = await Promise.all(
+        paths.map(async (dirPath) => ({
+          dirPath,
+          entries: await (
+            window.codesign as unknown as {
+              files: {
+                listDir: (id: string, dirPath: string) => Promise<WorkspaceDirectoryEntry[]>;
+              };
+            }
+          ).files.listDir(designId, dirPath),
+        })),
+      );
+      if (!isCurrent() || !isCurrentContext()) return;
+      updateDirectories((prev) => {
+        const next: LazyDirectoryMap = { ...prev };
+        for (const row of rows) {
+          next[row.dirPath] = { entries: row.entries, loaded: true, loading: false };
+        }
+        return next;
+      });
+      handleWorkspaceListSuccessToast(
+        listErrorToastRef.current,
+        dismissToast,
+        currentWorkspaceListFailureToastIds(),
+      );
+    } catch (err) {
+      if (!isCurrent() || !isCurrentContext()) return;
+      const message = err instanceof Error ? err.message : tr('errors.unknown');
+      updateDirectories(() => ({}));
+      handleWorkspaceListErrorToast({
+        state: listErrorToastRef.current,
+        key: `${designId}:${workspacePath}:${message}`,
+        message,
+        pushToast,
+        dismissToast,
+      });
+    } finally {
+      if (isCurrent() && isCurrentContext()) setLoading(false);
+    }
+  }, [backend, designId, dismissToast, pushToast, updateDirectories, workspacePath]);
+
+  useEffect(() => {
+    updateDirectories(() => ({}));
+    void loadDirectory('.');
+  }, [loadDirectory, updateDirectories]);
+
+  const throttleRef = useRef<{ pending: boolean; lastRun: number }>({
+    pending: false,
+    lastRun: 0,
+  });
+  useEffect(() => {
+    if (backend !== 'workspace') return;
+    if (!designId || !window.codesign) return;
+    const off = window.codesign.chat?.onAgentEvent?.((event) => {
+      if (event.designId !== designId) return;
+      const relevant =
+        event.type === 'fs_updated' ||
+        event.type === 'tool_call_result' ||
+        event.type === 'turn_end' ||
+        event.type === 'agent_end';
+      if (!relevant) return;
+      const slot = throttleRef.current;
+      const now = Date.now();
+      const elapsed = now - slot.lastRun;
+      if (elapsed > 250) {
+        slot.lastRun = now;
+        void reloadLoadedDirectories();
+        return;
+      }
+      if (!slot.pending) {
+        slot.pending = true;
+        setTimeout(
+          () => {
+            slot.pending = false;
+            slot.lastRun = Date.now();
+            void reloadLoadedDirectories();
+          },
+          Math.max(0, 250 - elapsed),
+        );
+      }
+    });
+    return () => {
+      off?.();
+    };
+  }, [backend, designId, reloadLoadedDirectories]);
+
+  useEffect(() => {
+    if (backend !== 'workspace') return;
+    if (!designId || workspacePath === null) return;
+    const filesApi = window.codesign?.files as
+      | {
+          subscribe?: (id: string) => Promise<unknown>;
+          unsubscribe?: (id: string) => Promise<unknown>;
+          onChanged?: (cb: (e: { designId: string }) => void) => () => void;
+        }
+      | undefined;
+    if (!filesApi?.subscribe || !filesApi.unsubscribe || !filesApi.onChanged) return;
+    void filesApi.subscribe(designId).catch((err: unknown) => {
+      pushToast({
+        variant: 'error',
+        title: tr('canvas.workspace.updateFailed'),
+        description: err instanceof Error ? err.message : tr('errors.unknown'),
+      });
+    });
+    const off = filesApi.onChanged((event) => {
+      if (event.designId !== designId) return;
+      void reloadLoadedDirectories();
+    });
+    return () => {
+      off();
+      void filesApi.unsubscribe?.(designId);
+    };
+  }, [backend, designId, pushToast, reloadLoadedDirectories, workspacePath]);
+
+  const workspaceFiles = filesFromLazyDirectories(directories);
+  const files = withPreviewSourceFallback(workspaceFiles, previewSource, designUpdatedAt);
+  const tree =
+    workspaceFiles.length === 0 && files.length > 0
+      ? buildLazyFileTree({
+          '.': {
+            entries: files.map((file) => ({
+              path: file.path,
+              name: file.path,
+              type: 'file' as const,
+              kind: file.kind,
+              updatedAt: file.updatedAt,
+              ...(file.size !== undefined ? { size: file.size } : {}),
+            })),
+            loaded: true,
+            loading: false,
+          },
+        })
+      : buildLazyFileTree(directories);
+
+  return { files, tree, loading, backend, loadDirectory };
 }
 
 // Format an ISO timestamp as "22h ago" / "3d ago". Pure for testability.

--- a/apps/desktop/src/renderer/src/lib/file-ingest.ts
+++ b/apps/desktop/src/renderer/src/lib/file-ingest.ts
@@ -28,9 +28,21 @@ export function dataTransferFilesToWorkspaceFiles(
 export async function clipboardFilesToWorkspaceBlobs(
   dataTransfer: DataTransfer,
 ): Promise<{ files: WorkspaceImportFileInput[]; blobs: WorkspaceImportBlobInput[] }> {
+  return filesToWorkspaceImport(Array.from(dataTransfer.files));
+}
+
+export async function fileListToWorkspaceImport(
+  fileList: FileList | readonly File[],
+): Promise<{ files: WorkspaceImportFileInput[]; blobs: WorkspaceImportBlobInput[] }> {
+  return filesToWorkspaceImport(Array.from(fileList));
+}
+
+async function filesToWorkspaceImport(
+  sourceFiles: readonly File[],
+): Promise<{ files: WorkspaceImportFileInput[]; blobs: WorkspaceImportBlobInput[] }> {
   const files: WorkspaceImportFileInput[] = [];
   const blobs: WorkspaceImportBlobInput[] = [];
-  for (const file of Array.from(dataTransfer.files)) {
+  for (const file of sourceFiles) {
     const localPath = (file as FileWithPath).path;
     if (typeof localPath === 'string' && localPath.length > 0) {
       files.push({ path: localPath, name: file.name, size: file.size });

--- a/apps/desktop/src/renderer/src/lib/file-tree.ts
+++ b/apps/desktop/src/renderer/src/lib/file-tree.ts
@@ -1,0 +1,172 @@
+import type { WorkspaceDirectoryEntry } from '../../../preload';
+import type { DesignFileEntry } from '../hooks/useDesignFiles';
+
+export type DesignFiles = DesignFileEntry[];
+export type DesignFile = DesignFiles[number];
+
+export interface FileTreeFileNode {
+  type: 'file';
+  name: string;
+  path: string;
+  file: DesignFile;
+}
+
+export interface FileTreeDirectoryNode {
+  type: 'directory';
+  name: string;
+  path: string;
+  fileCount?: number;
+  loaded?: boolean;
+  loading?: boolean;
+  children: FileTreeNode[];
+}
+
+export type FileTreeNode = FileTreeFileNode | FileTreeDirectoryNode;
+
+interface MutableDirectoryNode {
+  name: string;
+  path: string;
+  fileCount: number;
+  directories: Map<string, MutableDirectoryNode>;
+  files: Map<string, FileTreeFileNode>;
+}
+
+function normalizeFileTreePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+}
+
+function compareFileTreeNodes(a: FileTreeNode, b: FileTreeNode): number {
+  if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+  return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function materializeDirectory(node: MutableDirectoryNode): FileTreeDirectoryNode {
+  const children: FileTreeNode[] = [
+    ...Array.from(node.directories.values()).map(materializeDirectory),
+    ...Array.from(node.files.values()),
+  ].sort(compareFileTreeNodes);
+  return {
+    type: 'directory',
+    name: node.name,
+    path: node.path,
+    fileCount: node.fileCount,
+    children,
+  };
+}
+
+export function buildFileTree(files: DesignFiles): FileTreeNode[] {
+  const root: MutableDirectoryNode = {
+    name: '',
+    path: '',
+    fileCount: 0,
+    directories: new Map(),
+    files: new Map(),
+  };
+
+  for (const file of files) {
+    const normalized = normalizeFileTreePath(file.path);
+    if (normalized.length === 0) continue;
+    const parts = normalized.split('/').filter((part) => part.length > 0);
+    if (parts.length === 0) continue;
+
+    root.fileCount += 1;
+    let cursor = root;
+    for (const [index, part] of parts.entries()) {
+      const nodePath = parts.slice(0, index + 1).join('/');
+      const isFile = index === parts.length - 1;
+      if (isFile) {
+        cursor.files.set(part, {
+          type: 'file',
+          name: part,
+          path: normalized,
+          file: { ...file, path: normalized },
+        });
+        continue;
+      }
+
+      let next = cursor.directories.get(part);
+      if (next === undefined) {
+        next = {
+          name: part,
+          path: nodePath,
+          fileCount: 0,
+          directories: new Map(),
+          files: new Map(),
+        };
+        cursor.directories.set(part, next);
+      }
+      next.fileCount += 1;
+      cursor = next;
+    }
+  }
+
+  return [
+    ...Array.from(root.directories.values()).map(materializeDirectory),
+    ...Array.from(root.files.values()),
+  ].sort(compareFileTreeNodes);
+}
+
+export function collectDirectoryPaths(nodes: FileTreeNode[]): string[] {
+  const out: string[] = [];
+  function walk(items: FileTreeNode[]) {
+    for (const item of items) {
+      if (item.type !== 'directory') continue;
+      out.push(item.path);
+      walk(item.children);
+    }
+  }
+  walk(nodes);
+  return out;
+}
+
+export function defaultExpandedDirectoryPaths(nodes: FileTreeNode[]): string[] {
+  return nodes
+    .filter((node): node is FileTreeDirectoryNode => node.type === 'directory')
+    .map((node) => node.path);
+}
+
+export function parentDirectoryPathsForFilePath(path: string): string[] {
+  const parts = normalizeFileTreePath(path).split('/').filter(Boolean);
+  parts.pop();
+  return parts.map((_, index) => parts.slice(0, index + 1).join('/'));
+}
+
+export interface LazyDirectoryState {
+  entries: WorkspaceDirectoryEntry[];
+  loaded: boolean;
+  loading: boolean;
+}
+
+export type LazyDirectoryMap = Record<string, LazyDirectoryState | undefined>;
+
+export function buildLazyFileTree(directories: LazyDirectoryMap): FileTreeNode[] {
+  const makeNode = (entry: WorkspaceDirectoryEntry): FileTreeNode => {
+    if (entry.type === 'directory') {
+      const state = directories[entry.path];
+      return {
+        type: 'directory',
+        name: entry.name,
+        path: normalizeFileTreePath(entry.path),
+        ...(state?.loaded ? { fileCount: state.entries.length } : {}),
+        loaded: state?.loaded === true,
+        loading: state?.loading === true,
+        children: state?.loaded ? state.entries.map(makeNode).sort(compareFileTreeNodes) : [],
+      };
+    }
+    const normalizedPath = normalizeFileTreePath(entry.path);
+    return {
+      type: 'file',
+      name: entry.name,
+      path: normalizedPath,
+      file: {
+        path: normalizedPath,
+        kind: entry.kind ?? 'asset',
+        updatedAt: entry.updatedAt ?? new Date().toISOString(),
+        source: 'workspace',
+        ...(entry.size !== undefined ? { size: entry.size } : {}),
+      },
+    };
+  };
+
+  return (directories['.']?.entries ?? []).map(makeNode).sort(compareFileTreeNodes);
+}

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -369,13 +369,17 @@ describe('useCodesignStore generation cancellation', () => {
     });
 
     await vi.waitFor(() =>
-      expect(renameDesign).toHaveBeenCalledWith(designId, '设计 Apple Watch 跑步教练屏幕'),
+      expect(renameDesign).toHaveBeenCalledWith(designId, '设计 Apple Watch 跑步教练屏幕', {
+        renameWorkspace: false,
+      }),
     );
     expect(generateTitle).toHaveBeenCalledOnce();
 
     titleTask.resolve('Apple Watch 跑步教练');
     await vi.waitFor(() =>
-      expect(renameDesign).toHaveBeenCalledWith(designId, 'Apple Watch 跑步教练'),
+      expect(renameDesign).toHaveBeenCalledWith(designId, 'Apple Watch 跑步教练', {
+        renameWorkspace: false,
+      }),
     );
 
     generateTask.resolve({ artifacts: [{ content: '<html></html>' }], message: 'Done.' });
@@ -1221,6 +1225,40 @@ describe('useCodesignStore design management', () => {
       '<html>first</html>',
     );
     expect(useCodesignStore.getState().generationByDesign).toEqual({});
+  });
+
+  it('blocks generation when another session is already running for the same workspace', async () => {
+    const designA = { ...DEFAULT_DESIGN, id: 'design-a', workspacePath: '/tmp/shared' };
+    const designB = { ...DEFAULT_DESIGN, id: 'design-b', workspacePath: '/tmp/shared/' };
+    const generate = vi.fn(async () => ({
+      artifacts: [{ content: '<html>blocked</html>' }],
+      message: 'should not run',
+    }));
+
+    vi.stubGlobal('window', {
+      codesign: {
+        generate,
+        chat: mockChatApi(),
+        comments: mockCommentsApi(),
+        snapshots: mockSnapshotsApi(),
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({
+      designs: [designA, designB],
+      currentDesignId: 'design-b',
+      generationByDesign: {
+        'design-a': { generationId: 'gen-design-a', stage: 'streaming' },
+      },
+    });
+
+    await useCodesignStore.getState().sendPrompt({ prompt: 'same workspace prompt' });
+
+    expect(generate).not.toHaveBeenCalled();
+    expect(useCodesignStore.getState().toasts[0]?.title).toBe(
+      'A generation is already running for this workspace',
+    );
   });
 
   it('refreshes the current design when selecting it again from the hub', async () => {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -19,6 +19,7 @@ import { create } from 'zustand';
 import type {
   CodesignApi,
   ExportFormat,
+  RenameDesignOptions,
   WorkspaceImportBlobInput,
   WorkspaceImportFileInput,
   WorkspaceImportResult,
@@ -324,7 +325,7 @@ export interface CodesignState {
   createNewDesign: (workspacePath?: string | null) => Promise<Design | null>;
   switchDesign: (id: string) => Promise<void>;
   renameCurrentDesign: (name: string) => Promise<void>;
-  renameDesign: (id: string, name: string) => Promise<void>;
+  renameDesign: (id: string, name: string, options?: RenameDesignOptions) => Promise<void>;
   duplicateDesign: (id: string) => Promise<Design | null>;
   softDeleteDesign: (id: string) => Promise<void>;
   openDesignsView: () => void;

--- a/apps/desktop/src/renderer/src/store/slices/chat.ts
+++ b/apps/desktop/src/renderer/src/store/slices/chat.ts
@@ -1,5 +1,6 @@
 import {
   type ChatAppendInput,
+  type ChatMessageRow,
   type ChatToolCallPayload,
   LEGACY_SOURCE_ENTRY,
 } from '@open-codesign/shared';
@@ -17,6 +18,127 @@ import {
   persistArtifactSnapshot,
   recordPreviewSourceInPool,
 } from './snapshots.js';
+
+const CHAT_UI_ROW_LIMIT = 220;
+const CHAT_UI_TEXT_LIMIT = 20_000;
+const CHAT_UI_TOOL_TEXT_LIMIT = 1_200;
+const CHAT_UI_DETAIL_LIMIT = 8_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function truncateForUi(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return `${text.slice(0, Math.max(0, limit - 3))}...`;
+}
+
+function jsonSize(value: unknown): number {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function compactLargeStringFields(value: unknown, limit: number): unknown {
+  if (typeof value === 'string') return truncateForUi(value, limit);
+  if (Array.isArray(value))
+    return value.slice(0, 20).map((item) => compactLargeStringFields(item, limit));
+  if (!isRecord(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'screenshot' || key === 'imageDataUrl' || key === 'dataUrl') {
+      out[key] = '[stripped for UI]';
+      continue;
+    }
+    out[key] = compactLargeStringFields(item, limit);
+  }
+  return out;
+}
+
+function compactDetailsForUi(details: unknown): unknown {
+  if (!isRecord(details)) return details;
+  const compacted = compactLargeStringFields(details, CHAT_UI_TOOL_TEXT_LIMIT);
+  if (jsonSize(compacted) <= CHAT_UI_DETAIL_LIMIT) return compacted;
+
+  const summary: Record<string, unknown> = {
+    summarized: true,
+    keys: Object.keys(details).slice(0, 12),
+  };
+  for (const key of [
+    'command',
+    'path',
+    'name',
+    'status',
+    'reason',
+    'ok',
+    'summary',
+    'errorCount',
+    'kind',
+    'destPath',
+    'bytes',
+  ]) {
+    const value = details[key];
+    if (value !== undefined)
+      summary[key] = compactLargeStringFields(value, CHAT_UI_TOOL_TEXT_LIMIT);
+  }
+  return summary;
+}
+
+function compactToolResultForUi(result: unknown): unknown {
+  if (!isRecord(result)) return result;
+  const content = result['content'];
+  const compactedContent = Array.isArray(content)
+    ? content.slice(0, 8).map((item) => {
+        if (!isRecord(item) || item['type'] !== 'text' || typeof item['text'] !== 'string') {
+          return compactLargeStringFields(item, CHAT_UI_TOOL_TEXT_LIMIT);
+        }
+        return { ...item, text: truncateForUi(item['text'], CHAT_UI_TOOL_TEXT_LIMIT) };
+      })
+    : undefined;
+  return {
+    ...result,
+    ...(compactedContent !== undefined ? { content: compactedContent } : {}),
+    ...(result['details'] !== undefined ? { details: compactDetailsForUi(result['details']) } : {}),
+  };
+}
+
+function compactChatRowForUi(row: ChatMessageRow): ChatMessageRow {
+  if (row.kind === 'tool_call') {
+    const payload = isRecord(row.payload) ? (row.payload as unknown as ChatToolCallPayload) : null;
+    if (payload === null) return row;
+    return {
+      ...row,
+      payload: {
+        ...payload,
+        ...(payload.result !== undefined ? { result: compactToolResultForUi(payload.result) } : {}),
+        ...(payload.error?.message !== undefined
+          ? {
+              error: {
+                ...payload.error,
+                message: truncateForUi(payload.error.message, CHAT_UI_TEXT_LIMIT),
+              },
+            }
+          : {}),
+      },
+    };
+  }
+
+  if (!isRecord(row.payload) || typeof row.payload['text'] !== 'string') return row;
+  return {
+    ...row,
+    payload: {
+      ...row.payload,
+      text: truncateForUi(row.payload['text'], CHAT_UI_TEXT_LIMIT),
+    },
+  };
+}
+
+export function compactChatRowsForUi(rows: ChatMessageRow[]): ChatMessageRow[] {
+  return rows.slice(-CHAT_UI_ROW_LIMIT).map(compactChatRowForUi);
+}
 
 type SetState = (
   updater: ((state: CodesignState) => Partial<CodesignState> | object) | Partial<CodesignState>,
@@ -52,7 +174,7 @@ export function makeChatSlice(set: SetState, get: GetState): ChatSliceActions {
         // Guard against a design switch happening while the IPC was in flight —
         // we'd otherwise render the previous design's chat into the new one.
         if (get().currentDesignId !== designId) return;
-        set({ chatMessages: rows, chatLoaded: true });
+        set({ chatMessages: compactChatRowsForUi(rows), chatLoaded: true });
       } catch (err) {
         const msg = err instanceof Error ? err.message : tr('errors.unknown');
         console.warn('[open-codesign] loadChatForCurrentDesign failed:', msg);
@@ -67,7 +189,7 @@ export function makeChatSlice(set: SetState, get: GetState): ChatSliceActions {
         // Only merge into state if the append belongs to the current design —
         // a background append to a previous design must not pollute the view.
         if (get().currentDesignId === input.designId) {
-          set((s) => ({ chatMessages: [...s.chatMessages, row] }));
+          set((s) => ({ chatMessages: compactChatRowsForUi([...s.chatMessages, row]) }));
         }
         return row;
       } catch (err) {
@@ -157,19 +279,21 @@ export function makeChatSlice(set: SetState, get: GetState): ChatSliceActions {
       // immediately without waiting for a list reload.
       if (get().currentDesignId !== designId) return;
       set((s) => ({
-        chatMessages: s.chatMessages.map((m) => {
-          if (m.designId !== designId || m.seq !== seq || m.kind !== 'tool_call') return m;
-          const prev = (m.payload as ChatToolCallPayload | null) ?? null;
-          if (!prev) return m;
-          const nextPayload: ChatToolCallPayload = {
-            ...prev,
-            status,
-            ...(result !== undefined ? { result } : {}),
-            ...(durationMs !== undefined ? { durationMs } : {}),
-            ...(errorMessage !== undefined ? { error: { message: errorMessage } } : {}),
-          };
-          return { ...m, payload: nextPayload };
-        }),
+        chatMessages: compactChatRowsForUi(
+          s.chatMessages.map((m) => {
+            if (m.designId !== designId || m.seq !== seq || m.kind !== 'tool_call') return m;
+            const prev = (m.payload as ChatToolCallPayload | null) ?? null;
+            if (!prev) return m;
+            const nextPayload: ChatToolCallPayload = {
+              ...prev,
+              status,
+              ...(result !== undefined ? { result } : {}),
+              ...(durationMs !== undefined ? { durationMs } : {}),
+              ...(errorMessage !== undefined ? { error: { message: errorMessage } } : {}),
+            };
+            return { ...m, payload: nextPayload };
+          }),
+        ),
       }));
     },
 

--- a/apps/desktop/src/renderer/src/store/slices/designs.ts
+++ b/apps/desktop/src/renderer/src/store/slices/designs.ts
@@ -23,6 +23,7 @@ async function resolveDesignPreview(
     designId,
     snapshotSource,
     read: window.codesign.files?.read,
+    preferSnapshotSource: true,
   });
 }
 
@@ -81,6 +82,35 @@ function buildSelectedDesignState(
   };
 }
 
+function nextUntitledDesignName(designs: CodesignState['designs']): string {
+  const existingNames = new Set(designs.map((d) => d.name));
+  let n = 1;
+  while (existingNames.has(`Untitled design ${n}`)) n += 1;
+  return `Untitled design ${n}`;
+}
+
+function buildFreshDesignState(state: CodesignState, designId: string): Partial<CodesignState> {
+  return {
+    currentDesignId: designId,
+    ...projectGenerationForDesign(state, designId),
+    previewSource: null,
+    errorMessage: null,
+    iframeErrors: [],
+    selectedElement: null,
+    lastPromptInput: null,
+    designsViewOpen: false,
+    chatMessages: [],
+    chatLoaded: false,
+    pendingToolCalls: [],
+    comments: [],
+    commentsLoaded: false,
+    commentBubble: null,
+    currentSnapshotId: null,
+    canvasTabs: DEFAULT_CANVAS_TABS,
+    activeCanvasTab: 0,
+  };
+}
+
 export function makeDesignsSlice(set: SetState, get: GetState): DesignsSliceActions {
   return {
     async loadDesigns() {
@@ -125,31 +155,10 @@ export function makeDesignsSlice(set: SetState, get: GetState): DesignsSliceActi
 
     async createNewDesign(workspacePath?: string | null) {
       if (!window.codesign) return null;
-      const existingNames = new Set(get().designs.map((d) => d.name));
-      let n = 1;
-      while (existingNames.has(`Untitled design ${n}`)) n += 1;
-      const name = `Untitled design ${n}`;
+      const name = nextUntitledDesignName(get().designs);
       try {
         const design = await window.codesign.snapshots.createDesign(name, workspacePath);
-        set({
-          currentDesignId: design.id,
-          ...projectGenerationForDesign(get(), design.id),
-          previewSource: null,
-          errorMessage: null,
-          iframeErrors: [],
-          selectedElement: null,
-          lastPromptInput: null,
-          designsViewOpen: false,
-          chatMessages: [],
-          chatLoaded: false,
-          pendingToolCalls: [],
-          comments: [],
-          commentsLoaded: false,
-          commentBubble: null,
-          currentSnapshotId: null,
-          canvasTabs: DEFAULT_CANVAS_TABS,
-          activeCanvasTab: 0,
-        });
+        set((state) => buildFreshDesignState(state, design.id));
         await get().loadDesigns();
         void get().loadChatForCurrentDesign();
         void get().loadCommentsForCurrentDesign();
@@ -318,12 +327,16 @@ export function makeDesignsSlice(set: SetState, get: GetState): DesignsSliceActi
       await get().renameDesign(id, name);
     },
 
-    async renameDesign(id: string, name: string) {
+    async renameDesign(id: string, name: string, options) {
       if (!window.codesign) return;
       const trimmed = name.trim();
       if (!trimmed) return;
       try {
-        const updated = await window.codesign.snapshots.renameDesign(id, trimmed);
+        const renameWorkspace =
+          options?.renameWorkspace ?? get().generationByDesign[id] === undefined;
+        const updated = await window.codesign.snapshots.renameDesign(id, trimmed, {
+          renameWorkspace,
+        });
         // Use the persisted row instead of synthesizing a partial design; v0.2
         // designs must carry a real workspace binding.
         set((s) => {

--- a/apps/desktop/src/renderer/src/store/slices/generation.ts
+++ b/apps/desktop/src/renderer/src/store/slices/generation.ts
@@ -10,6 +10,7 @@ import { DEFAULT_SOURCE_ENTRY, LEGACY_SOURCE_ENTRY } from '@open-codesign/shared
 import type { CodesignApi, ExportFormat } from '../../../../preload/index.js';
 import { recordAction } from '../../lib/action-timeline.js';
 import { redactUrls } from '../../lib/redact.js';
+import { workspacePathComparisonKey } from '../../lib/workspace-path.js';
 import {
   hasWorkspaceSourceReference,
   inferPreviewSourcePath,
@@ -98,6 +99,21 @@ function findDesignIdForGeneration(
 ): string | null {
   for (const [designId, run] of Object.entries(generationByDesign)) {
     if (run.generationId === generationId) return designId;
+  }
+  return null;
+}
+
+function findRunningDesignForWorkspace(
+  state: CodesignState,
+  workspacePath: string,
+  excludeDesignId: string,
+): string | null {
+  const targetKey = workspacePathComparisonKey(workspacePath);
+  for (const designId of Object.keys(state.generationByDesign)) {
+    if (designId === excludeDesignId) continue;
+    const design = state.designs.find((candidate) => candidate.id === designId);
+    if (!design?.workspacePath) continue;
+    if (workspacePathComparisonKey(design.workspacePath) === targetKey) return designId;
   }
   return null;
 }
@@ -745,7 +761,7 @@ export function makeGenerationSlice(set: SetState, get: GetState): GenerationSli
 
       const designIdAtStart = get().currentDesignId;
       const activeDesign = get().designs.find((design) => design.id === designIdAtStart);
-      if (designIdAtStart === null || activeDesign?.workspacePath === null) {
+      if (designIdAtStart === null || !activeDesign?.workspacePath) {
         const msg = tr('err.WORKSPACE_MISSING');
         set({ errorMessage: msg, lastError: msg });
         get().pushToast({
@@ -762,6 +778,20 @@ export function makeGenerationSlice(set: SetState, get: GetState): GenerationSli
         }
       }
       if (get().generationByDesign[designIdAtStart] !== undefined) return;
+      const runningForWorkspace = findRunningDesignForWorkspace(
+        get(),
+        activeDesign.workspacePath,
+        designIdAtStart,
+      );
+      if (runningForWorkspace !== null) {
+        if (!input.silent) {
+          get().pushToast({
+            variant: 'info',
+            title: tr('projects.notifications.workspaceBusyGenerating'),
+          });
+        }
+        return;
+      }
 
       const generationId = newId();
       startGenerationForDesign(set, designIdAtStart, generationId);

--- a/apps/desktop/src/renderer/src/store/slices/snapshots.ts
+++ b/apps/desktop/src/renderer/src/store/slices/snapshots.ts
@@ -194,7 +194,7 @@ async function maybeAutoRename(
   // Rename immediately with a local fallback so the design never stays on
   // "Untitled design N" while the model title request is still in flight.
   const fallbackName = autoNameFromPrompt(firstPrompt);
-  await renameDesignAndRefresh(get, designId, fallbackName);
+  await renameDesignAndRefresh(get, designId, fallbackName, { renameWorkspace: false });
   try {
     const api = window.codesign as unknown as {
       generateTitle?: (prompt: string) => Promise<string>;
@@ -209,7 +209,7 @@ async function maybeAutoRename(
         latest !== undefined &&
         (latest.name === fallbackName || isDefaultDesignName(latest.name))
       ) {
-        await renameDesignAndRefresh(get, designId, trimmed);
+        await renameDesignAndRefresh(get, designId, trimmed, { renameWorkspace: false });
       }
     }
   } catch (err) {
@@ -224,9 +224,10 @@ async function renameDesignAndRefresh(
   get: GetState,
   designId: string,
   name: string,
+  options?: { renameWorkspace?: boolean },
 ): Promise<void> {
   try {
-    await window.codesign?.snapshots.renameDesign(designId, name);
+    await window.codesign?.snapshots.renameDesign(designId, name, options);
     await get().loadDesigns();
   } catch (err) {
     const msg = err instanceof Error ? err.message : tr('errors.unknown');

--- a/apps/desktop/src/renderer/src/views/hub/DesignCardPreview.needsJsxRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/views/hub/DesignCardPreview.needsJsxRuntime.test.ts
@@ -129,4 +129,47 @@ describe('DesignCardPreview source helpers', () => {
       clearPreviewCardCachesForTest();
     }
   });
+
+  it('uses the files API to resolve snapshot references to workspace source', async () => {
+    clearPreviewCardCachesForTest();
+    const globalWithWindow = globalThis as unknown as { window?: { codesign?: unknown } };
+    const previousWindow = globalWithWindow.window;
+    const list = vi.fn(async () => [
+      {
+        artifactSource: '<!doctype html><body><!-- artifact source lives in index.jsx --></body>',
+      },
+    ]);
+    const read = vi.fn(async (_designId: string, path: string) => ({
+      path,
+      kind: 'jsx' as const,
+      size: 53,
+      updatedAt: '2026-05-05T00:00:00.000Z',
+      content: 'function App(){ return <main id="workspace-source">Hi</main>; }',
+    }));
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        codesign: {
+          snapshots: { list },
+          files: { read },
+        },
+      },
+    });
+
+    try {
+      const result = await readPreviewSourceForCard('design-1', '2026-05-05T00:00:01.000Z');
+
+      expect(result).toEqual({
+        path: 'index.jsx',
+        content: 'function App(){ return <main id="workspace-source">Hi</main>; }',
+      });
+      expect(read).toHaveBeenCalledWith('design-1', 'index.jsx');
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: previousWindow,
+      });
+      clearPreviewCardCachesForTest();
+    }
+  });
 });

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -952,20 +952,23 @@ describe('generateViaAgent()', () => {
     expect(result.artifacts[0]?.entryPath).toBe('index.html');
   });
 
-  it('throws GENERATION_INCOMPLETE when workspace changed without done ok', async () => {
+  it('keeps a valid artifact with a warning when workspace changed without done ok', async () => {
     scriptedAgent = { assistantText: RESPONSE_WITH_ARTIFACT };
-    await expect(
-      generateViaAgent(
-        {
-          prompt: 'design a meditation app',
-          history: [],
-          model: MODEL,
-          apiKey: 'sk-test',
-          initialResourceState: resourceState({ mutationSeq: 1 }),
-        },
-        { fs: makeStubFs({ 'App.jsx': SAMPLE_HTML }) },
-      ),
-    ).rejects.toMatchObject({ code: ERROR_CODES.GENERATION_INCOMPLETE });
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+        initialResourceState: resourceState({ mutationSeq: 1 }),
+      },
+      { fs: makeStubFs({ 'App.jsx': SAMPLE_HTML }) },
+    );
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.warnings).toEqual([
+      'The agent edited the workspace but did not call done(status="ok"); keeping the generated artifact available.',
+    ]);
   });
 
   it('keeps a valid artifact with a warning when done reported errors', async () => {
@@ -1226,29 +1229,32 @@ describe('generateViaAgent()', () => {
     expect(result.artifacts).toHaveLength(1);
   });
 
-  it('requires another done after a later mutation', async () => {
+  it('keeps a valid artifact with a warning after a later mutation', async () => {
     scriptedAgent = { assistantText: RESPONSE_WITH_ARTIFACT };
-    await expect(
-      generateViaAgent(
-        {
-          prompt: 'design a meditation app',
-          history: [],
-          model: MODEL,
-          apiKey: 'sk-test',
-          initialResourceState: resourceState({
-            mutationSeq: 2,
-            lastDone: {
-              status: 'ok',
-              path: 'App.jsx',
-              mutationSeq: 1,
-              errorCount: 0,
-              checkedAt: '2026-04-28T00:00:00.000Z',
-            },
-          }),
-        },
-        { fs: makeStubFs({ 'App.jsx': SAMPLE_HTML }) },
-      ),
-    ).rejects.toMatchObject({ code: ERROR_CODES.GENERATION_INCOMPLETE });
+    const result = await generateViaAgent(
+      {
+        prompt: 'design a meditation app',
+        history: [],
+        model: MODEL,
+        apiKey: 'sk-test',
+        initialResourceState: resourceState({
+          mutationSeq: 2,
+          lastDone: {
+            status: 'ok',
+            path: 'App.jsx',
+            mutationSeq: 1,
+            errorCount: 0,
+            checkedAt: '2026-04-28T00:00:00.000Z',
+          },
+        }),
+      },
+      { fs: makeStubFs({ 'App.jsx': SAMPLE_HTML }) },
+    );
+
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.warnings).toEqual([
+      'The workspace changed after the last successful done() call; keeping the latest artifact available.',
+    ]);
   });
 
   it('emits agent lifecycle events through onEvent subscriber in order', async () => {
@@ -1718,7 +1724,7 @@ describe('generateViaAgent()', () => {
     expect(sys).toContain('Do not emit `<artifact>`');
     expect(sys).toContain('design source to `App.jsx`');
     expect(sys).toContain('Local workspace assets and scaffolded files are allowed');
-    expect(sys).toContain('`done(path)` after the final mutation');
+    expect(sys).toContain('call `done(path)` as the final self-check');
     expect(sys).toContain('stop after 3 error rounds');
     expect(sys).not.toContain('text_editor.create(');
     expect(sys).not.toContain('view("index.html"');

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -504,7 +504,7 @@ function agenticToolGuidance(input: {
       : []),
     `${input.inspectWorkspace ? '5' : '4'}. Match the workspace files to the request. For visual/web work, write/edit the primary preview source at \`${DEFAULT_SOURCE_ENTRY}\`; for document-first work, create the requested Markdown/handoff file without inventing a visual shell.`,
     tweakStep,
-    `${input.inspectWorkspace ? '7' : '6'}. Call \`preview(path)\` for previewable HTML/JSX/TSX files, then call \`done(path)\` after the final mutation. If done reports errors, fix and retry, but stop after ${MAX_DONE_ERROR_ROUNDS} error rounds.`,
+    `${input.inspectWorkspace ? '7' : '6'}. Call \`preview(path)\` for previewable HTML/JSX/TSX files after the final mutation, then call \`done(path)\` as the final self-check. If done reports errors, fix and retry, but stop after ${MAX_DONE_ERROR_ROUNDS} error rounds.`,
   ];
   return [
     '## Workspace output contract',
@@ -515,7 +515,7 @@ function agenticToolGuidance(input: {
     '- For document-first requests such as design briefs, content outlines, or handoff notes, create the requested `.md` file directly and skip `App.jsx` unless a visual preview is also useful.',
     '- Prefer progressive generation when it is natural: write a coherent first pass, then add sections, data, interactions, and polish in focused edits before previewing.',
     '- Fresh visual sequence: `set_title` -> optional `set_todos`/`skill` -> required `scaffold` when a matching starter/frame/shell/primitive exists -> `create App.jsx` with a coherent first pass -> focused edits if needed -> `preview(App.jsx)`.',
-    '- Fresh document sequence: `set_title` -> optional `set_todos`/`skill` -> create the requested document file -> `done(path)`.',
+    '- Fresh document sequence: `set_title` -> optional `set_todos`/`skill` -> create the requested document file -> `done(path)` self-check.',
     '- Do not call `preview` while a previewable artifact is still only a scaffold, loading state, skeleton, placeholder, or empty lower section. Preview should represent a coherent first pass unless the user explicitly asked for a loading-state design.',
     '- Existing-source sequence: optional `set_todos` -> `inspect_workspace` when available -> `view` the source -> `str_replace`/`insert`. Do not edit an existing source from memory, and do not rebuild unless the user explicitly asks.',
     '- If the design is still named `Untitled design` or `Untitled design N`, naming is not optional: call `set_title` before other work, even when a scaffold or reference source already exists.',

--- a/packages/core/src/prompts/sections/workflow.md
+++ b/packages/core/src/prompts/sections/workflow.md
@@ -10,7 +10,7 @@ Work in a visible loop:
 6. **Preview the complete pass** — call `preview(path)` only for previewable HTML/JSX/TSX files, after the artifact can stand on its own without "Loading", "Generating", gray skeleton blocks, placeholder cards, or empty lower sections, unless the user explicitly asked for a loading-state design.
 7. **Design baton** — create, repair, or update the workspace `DESIGN.md` for substantive visual artifacts, multi-screen work, adopted brand refs, or stable reusable tokens.
 8. **Expose tweaks selectively** — call `tweaks()` only when the user asked for controls, answered that controls would help, or the artifact has 2-5 obvious high-leverage values. Skip tweak work for narrow edits, throwaway sketches, or when the user declines; they can ask for controls in a later turn.
-9. **Finish** — call `done(path)` for the primary verification target. If a previewable source is part of the package, finish on that source after all files are complete; otherwise finish on the primary document path. After it succeeds, answer with 1-2 concise sentences and no code.
+9. **Finish** — call `done(path)` as the final self-check. If a previewable source is part of the package, finish on that source after all files are complete; otherwise finish on the primary document path. If the host still keeps the artifact after a missed self-check, answer with 1-2 concise sentences and no code.
 
 ## Visible progress
 

--- a/packages/core/src/resource-state.test.ts
+++ b/packages/core/src/resource-state.test.ts
@@ -48,4 +48,57 @@ describe('resource finalization gate', () => {
       }),
     ).toEqual([]);
   });
+
+  it('surfaces optional skill quality misses as warnings instead of blocking artifacts', () => {
+    const state = cloneResourceState(undefined);
+    state.loadedSkills.push('craft-polish');
+    recordMutation(state);
+    recordDone(state, { status: 'ok', path: 'App.jsx', errorCount: 0 });
+
+    expect(
+      assertFinalizationGate({
+        state,
+        fs: makeFs({
+          'App.jsx': 'export default function App() { return <button>Save</button>; }',
+        }),
+        enforce: true,
+      }),
+    ).toEqual([
+      'Loaded skill craft-polish, but App.jsx is missing basic focus, hover, or non-happy-path state signals.',
+    ]);
+  });
+
+  it('keeps a generated artifact available when done was skipped', () => {
+    const state = cloneResourceState(undefined);
+    recordMutation(state);
+
+    expect(
+      assertFinalizationGate({
+        state,
+        fs: makeFs({ 'App.jsx': 'export default function App() { return <main>Saved</main>; }' }),
+        enforce: true,
+        allowUnresolvedDoneWithArtifact: true,
+      }),
+    ).toEqual([
+      'The agent edited the workspace but did not call done(status="ok"); keeping the generated artifact available.',
+    ]);
+  });
+
+  it('keeps a generated artifact available when edits happened after done', () => {
+    const state = cloneResourceState(undefined);
+    recordMutation(state);
+    recordDone(state, { status: 'ok', path: 'App.jsx', errorCount: 0 });
+    state.mutationSeq += 1;
+
+    expect(
+      assertFinalizationGate({
+        state,
+        fs: makeFs({ 'App.jsx': 'export default function App() { return <main>Updated</main>; }' }),
+        enforce: true,
+        allowUnresolvedDoneWithArtifact: true,
+      }),
+    ).toEqual([
+      'The workspace changed after the last successful done() call; keeping the latest artifact available.',
+    ]);
+  });
 });

--- a/packages/core/src/resource-state.ts
+++ b/packages/core/src/resource-state.ts
@@ -124,6 +124,11 @@ export function assertFinalizationGate(input: FinalizationGateInput): string[] {
     );
   }
   if (done === null) {
+    if (input.allowUnresolvedDoneWithArtifact) {
+      return [
+        'The agent edited the workspace but did not call done(status="ok"); keeping the generated artifact available.',
+      ];
+    }
     throw new CodesignError(
       'Generation incomplete: the agent edited the workspace but did not call done(status="ok").',
       ERROR_CODES.GENERATION_INCOMPLETE,
@@ -139,6 +144,11 @@ export function assertFinalizationGate(input: FinalizationGateInput): string[] {
     );
   }
   if (done.mutationSeq !== input.state.mutationSeq) {
+    if (input.allowUnresolvedDoneWithArtifact) {
+      return [
+        'The workspace changed after the last successful done() call; keeping the latest artifact available.',
+      ];
+    }
     throw new CodesignError(
       'Generation incomplete: the workspace changed after the last successful done() call.',
       ERROR_CODES.GENERATION_INCOMPLETE,
@@ -148,10 +158,7 @@ export function assertFinalizationGate(input: FinalizationGateInput): string[] {
     ? validationFailures(input.state, file.content, file.path)
     : [];
   if (failures.length > 0) {
-    throw new CodesignError(
-      `Generation incomplete: ${failures.join(' ')}`,
-      ERROR_CODES.GENERATION_INCOMPLETE,
-    );
+    return failures;
   }
   return [];
 }

--- a/packages/core/src/tools/ask.test.ts
+++ b/packages/core/src/tools/ask.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { type AskInput, type AskResult, makeAskTool, validateAskInput } from './ask';
+import {
+  type AskInput,
+  type AskResult,
+  makeAskTool,
+  summarizeAskResult,
+  validateAskInput,
+} from './ask';
 
 describe('validateAskInput', () => {
   it('accepts a valid single-question payload', () => {
@@ -79,7 +85,23 @@ describe('makeAskTool', () => {
     });
     expect(bridge).toHaveBeenCalledOnce();
     expect(result.details).toEqual(canned);
-    expect(result.content[0]).toMatchObject({ type: 'text', text: 'user answered 2 question(s)' });
+    expect(result.content[0]).toMatchObject({ type: 'text' });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('user answered 2 question(s)');
+    expect(text).toContain('- q1: Minimal');
+    expect(text).toContain('- q2: 16');
+  });
+
+  it('includes uploaded file answers in the text seen by the model', () => {
+    expect(
+      summarizeAskResult({
+        status: 'answered',
+        answers: [
+          { questionId: 'logo', value: 'references/logo.png' },
+          { questionId: 'screenshots', value: ['references/one.png', 'references/two.png'] },
+        ],
+      }),
+    ).toContain('references/logo.png');
   });
 
   it('short-circuits on invalid input (0 questions) without calling the bridge', async () => {

--- a/packages/core/src/tools/ask.ts
+++ b/packages/core/src/tools/ask.ts
@@ -273,6 +273,30 @@ function validateAskQuestion(
 
 export type AskBridge = (input: AskInput) => Promise<AskResult>;
 
+const MAX_ASK_VALUE_CHARS = 500;
+
+function truncateAskValue(value: string): string {
+  if (value.length <= MAX_ASK_VALUE_CHARS) return value;
+  return `${value.slice(0, MAX_ASK_VALUE_CHARS - 1)}...`;
+}
+
+function summarizeAskAnswerValue(value: AskAnswer['value']): string {
+  if (value === null) return 'empty';
+  if (Array.isArray(value)) {
+    return value.length > 0 ? truncateAskValue(value.join(', ')) : 'empty';
+  }
+  return truncateAskValue(String(value));
+}
+
+export function summarizeAskResult(result: AskResult): string {
+  if (result.status === 'cancelled') return 'user cancelled';
+  const lines = [`user answered ${result.answers.length} question(s)`];
+  for (const answer of result.answers) {
+    lines.push(`- ${answer.questionId}: ${summarizeAskAnswerValue(answer.value)}`);
+  }
+  return lines.join('\n');
+}
+
 export function makeAskTool(askBridge: AskBridge): AgentTool<typeof AskInput, AskResult> {
   return {
     name: 'ask',
@@ -294,12 +318,8 @@ export function makeAskTool(askBridge: AskBridge): AgentTool<typeof AskInput, As
         };
       }
       const result = await askBridge(params);
-      const summary =
-        result.status === 'answered'
-          ? `user answered ${result.answers.length} question(s)`
-          : 'user cancelled';
       return {
-        content: [{ type: 'text', text: summary }],
+        content: [{ type: 'text', text: summarizeAskResult(result) }],
         details: result,
       };
     },

--- a/packages/core/src/tools/done.ts
+++ b/packages/core/src/tools/done.ts
@@ -460,7 +460,7 @@ export function makeDoneTool(
       'syntax checks AND loads the file in an isolated runtime to capture ' +
       'console errors / load failures, then replies with ' +
       '`{ status: "ok" | "has_errors", errors: [...] }`. If errors come back, ' +
-      'you MUST fix them with str_replace_based_edit_tool and call `done` again. ' +
+      'fix them with str_replace_based_edit_tool and call `done` again. ' +
       'Stop calling once status is "ok" or after 3 error rounds. If errors still ' +
       'remain with a valid artifact after those repair rounds, the host may ' +
       'keep the latest artifact but will surface warnings to the user.',

--- a/packages/core/src/tools/inspect-workspace.test.ts
+++ b/packages/core/src/tools/inspect-workspace.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { inspectWorkspaceFiles, makeInspectWorkspaceTool } from './inspect-workspace.js';
+import {
+  inspectWorkspaceFiles,
+  makeInspectWorkspaceTool,
+  summarizeWorkspaceInspection,
+} from './inspect-workspace.js';
 
 describe('inspect_workspace', () => {
   it('classifies workspace files into design-oriented groups', async () => {
@@ -23,6 +27,7 @@ describe('inspect_workspace', () => {
     expect(inspection.assets).toContain('assets/logo.svg');
     expect(inspection.totalFiles).toBe(7);
     expect(inspection.truncated).toBe(false);
+    expect(summarizeWorkspaceInspection(inspection)).toContain('assets/logo.svg');
   });
 
   it('returns an empty inventory for an empty workspace', async () => {
@@ -39,6 +44,23 @@ describe('inspect_workspace', () => {
       type: 'text',
       text: expect.stringContaining('0 file'),
     });
+  });
+
+  it('surfaces asset paths in the tool text seen by the model', async () => {
+    const tool = makeInspectWorkspaceTool(async () =>
+      inspectWorkspaceFiles([
+        { file: 'App.jsx', contents: 'function App() {}' },
+        { file: 'references/logo.png' },
+        { file: 'references/brand-screenshot.webp' },
+      ]),
+    );
+
+    const result = await tool.execute('inspect-assets', {});
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).toContain('2 asset(s)');
+    expect(text).toContain('references/logo.png');
+    expect(text).toContain('references/brand-screenshot.webp');
   });
 
   it('bounds large groups and marks the inventory as truncated', () => {

--- a/packages/core/src/tools/inspect-workspace.ts
+++ b/packages/core/src/tools/inspect-workspace.ts
@@ -109,6 +109,22 @@ export function inspectWorkspaceFiles(
 
 export type InspectWorkspaceFn = () => Promise<WorkspaceInspection>;
 
+function summarizeGroup(label: string, values: readonly string[]): string {
+  return values.length > 0 ? `${label}: ${values.join(', ')}` : `${label}: none`;
+}
+
+export function summarizeWorkspaceInspection(result: WorkspaceInspection): string {
+  return [
+    `workspace inspection: ${result.totalFiles} file(s), ${result.entryCandidates.length} entry candidate(s), ${result.sourceFiles.length} source file(s), ${result.referenceDocs.length} reference doc(s), ${result.assets.length} asset(s), truncated: ${result.truncated ? 'yes' : 'no'}`,
+    summarizeGroup('entry candidates', result.entryCandidates),
+    summarizeGroup('source files', result.sourceFiles),
+    summarizeGroup('style files', result.styleFiles),
+    summarizeGroup('design docs', result.designDocs),
+    summarizeGroup('reference docs', result.referenceDocs),
+    summarizeGroup('assets', result.assets),
+  ].join('\n');
+}
+
 export function makeInspectWorkspaceTool(
   inspectWorkspace: InspectWorkspaceFn,
 ): AgentTool<typeof InspectWorkspaceParams, WorkspaceInspection> {
@@ -124,7 +140,7 @@ export function makeInspectWorkspaceTool(
         content: [
           {
             type: 'text',
-            text: `workspace inspection: ${result.totalFiles} file(s), ${result.entryCandidates.length} entry candidate(s), ${result.sourceFiles.length} source file(s), ${result.referenceDocs.length} reference doc(s), truncated: ${result.truncated ? 'yes' : 'no'}`,
+            text: summarizeWorkspaceInspection(result),
           },
         ],
         details: result,

--- a/packages/core/src/tools/scaffold.ts
+++ b/packages/core/src/tools/scaffold.ts
@@ -175,11 +175,12 @@ export interface ScaffoldResult {
 }
 
 function destinationPathForSource(destPath: string, sourcePath: string): string {
+  const normalizedDestPath = destPath.replace(/\\/g, '/');
   const sourceExt = path.extname(sourcePath);
-  if (sourceExt.length === 0) return destPath;
-  const parsed = path.parse(destPath);
-  if (parsed.ext.toLowerCase() === sourceExt.toLowerCase()) return destPath;
-  return path.join(parsed.dir, `${parsed.name}${sourceExt}`);
+  if (sourceExt.length === 0) return normalizedDestPath;
+  const parsed = path.posix.parse(normalizedDestPath);
+  if (parsed.ext.toLowerCase() === sourceExt.toLowerCase()) return normalizedDestPath;
+  return path.posix.join(parsed.dir, `${parsed.name}${sourceExt}`);
 }
 
 export async function runScaffold(req: ScaffoldRequest): Promise<ScaffoldResult> {

--- a/packages/core/src/tools/text-editor.test.ts
+++ b/packages/core/src/tools/text-editor.test.ts
@@ -88,6 +88,43 @@ describe('str_replace_based_edit_tool', () => {
     ).rejects.toThrow(/insert requires numeric insert_line/);
   });
 
+  it('normalizes Windows path separators before touching the virtual workspace', async () => {
+    const tool = makeTextEditorTool(makeMapFs(new Map([['src/App.jsx', 'one']])));
+
+    const result = await tool.execute('call-1', {
+      command: 'view',
+      path: 'src\\App.jsx',
+    });
+
+    expect(result.details).toMatchObject({ command: 'view', path: 'src/App.jsx' });
+    expect(result.content[0]?.type === 'text' ? result.content[0].text : '').toBe('one');
+  });
+
+  it('rejects absolute and traversal paths before reaching the virtual workspace', async () => {
+    const tool = makeTextEditorTool(makeFs('one'));
+
+    await expect(
+      tool.execute('call-1', {
+        command: 'view',
+        path: '../App.jsx',
+      }),
+    ).rejects.toThrow(/workspace-relative/);
+
+    await expect(
+      tool.execute('call-2', {
+        command: 'view',
+        path: 'C:\\Users\\Musson\\App.jsx',
+      }),
+    ).rejects.toThrow(/workspace-relative/);
+
+    await expect(
+      tool.execute('call-3', {
+        command: 'view',
+        path: '/tmp/App.jsx',
+      }),
+    ).rejects.toThrow(/workspace-relative/);
+  });
+
   it('returns a recoverable error when editing an existing file before viewing it', async () => {
     const tool = makeTextEditorTool(makeFs('one'));
 
@@ -231,6 +268,76 @@ describe('str_replace_based_edit_tool', () => {
     expect(afterRewrite.content[0]?.type === 'text' ? afterRewrite.content[0].text : '').toContain(
       'Edited App.jsx',
     );
+  });
+
+  it('does not treat workspace write failures as exact edit misses', async () => {
+    const fs = makeFs('one');
+    const originalReplace = fs.strReplace;
+    let failOnce = true;
+    fs.strReplace = (path, oldStr, newStr) => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error('Workspace write-through failed for App.jsx: permission request timed out');
+      }
+      return originalReplace(path, oldStr, newStr);
+    };
+    const tool = makeTextEditorTool(fs);
+    await tool.execute('view', { command: 'view', path: 'App.jsx' });
+
+    const failed = await tool.execute('write-fail', {
+      command: 'str_replace',
+      path: 'App.jsx',
+      old_str: 'one',
+      new_str: 'two',
+    });
+    const failedText = failed.content[0]?.type === 'text' ? failed.content[0].text : '';
+    expect(failedText).toContain('could not write App.jsx to the workspace');
+    expect(failedText).toContain('Stop retrying this edit');
+
+    const afterWriteRestored = await tool.execute('write-ok', {
+      command: 'str_replace',
+      path: 'App.jsx',
+      old_str: 'one',
+      new_str: 'two',
+    });
+    expect(
+      afterWriteRestored.content[0]?.type === 'text' ? afterWriteRestored.content[0].text : '',
+    ).toContain('Edited App.jsx');
+  });
+
+  it('does not tell the agent to re-read after workspace insert write failures', async () => {
+    const fs = makeFs('jsx', { 'App.css': 'body {}' });
+    const originalInsert = fs.insert;
+    let failOnce = true;
+    fs.insert = (path, line, text) => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error('Workspace write-through failed for App.css: permission request timed out');
+      }
+      return originalInsert(path, line, text);
+    };
+    const tool = makeTextEditorTool(fs);
+    await tool.execute('view-css', { command: 'view', path: 'App.css' });
+
+    const failed = await tool.execute('insert-fail', {
+      command: 'insert',
+      path: 'App.css',
+      insert_line: 1,
+      new_str: '.card {}',
+    });
+    const failedText = failed.content[0]?.type === 'text' ? failed.content[0].text : '';
+    expect(failedText).toContain('could not write App.css to the workspace');
+    expect(failedText).not.toContain('Re-read the target range');
+
+    const afterWriteRestored = await tool.execute('insert-ok', {
+      command: 'insert',
+      path: 'App.css',
+      insert_line: 1,
+      new_str: '.card {}',
+    });
+    expect(
+      afterWriteRestored.content[0]?.type === 'text' ? afterWriteRestored.content[0].text : '',
+    ).toContain('Inserted at App.css:1');
   });
 
   it('does not treat a directory view as viewing a concrete file', async () => {

--- a/packages/core/src/tools/text-editor.ts
+++ b/packages/core/src/tools/text-editor.ts
@@ -23,7 +23,7 @@ export interface TextEditorFsCallbacks {
     newStr: string,
   ): Promise<{ path: string }> | { path: string };
   insert(path: string, line: number, text: string): Promise<{ path: string }> | { path: string };
-  /** Optional: list files for `view` on a directory. Returns sorted paths. */
+  /** Optional: list files under `dir` for `view` on a directory. */
   listDir(dir: string): string[];
 }
 
@@ -85,6 +85,18 @@ function exactEditFailuresExceededText(path: string, count: number): string {
   return `Too many failed exact edits for ${path} (${count}). Stop using str_replace/insert on this file in this run. Re-read the relevant range and use create to rewrite the complete corrected file, or ask the user to continue.`;
 }
 
+function isExactEditFailure(message: string, path: string): boolean {
+  return (
+    message === `old_str not found in ${path}` ||
+    message === `old_str is ambiguous in ${path}; provide more context`
+  );
+}
+
+function workspaceWriteFailureText(path: string, message: string): string | null {
+  if (!message.startsWith(`Workspace write-through failed for ${path}:`)) return null;
+  return `Edit failed because Open CoDesign could not write ${path} to the workspace. Stop retrying this edit; ask the user to resolve the workspace write problem. Details: ${message}`;
+}
+
 function requireString(
   value: unknown,
   field: string,
@@ -105,6 +117,23 @@ function requireNumber(
     throw new Error(`${command} requires numeric ${field}`);
   }
   return value;
+}
+
+function normalizeToolPath(rawPath: string): string {
+  const normalized = rawPath.trim().replace(/\\/g, '/').replace(/\/+/g, '/');
+  if (normalized.length === 0 || normalized === '.') return '.';
+  if (normalized.startsWith('/') || /^[A-Za-z]:\//.test(normalized)) {
+    throw new Error('Tool paths must be workspace-relative and use "/" separators.');
+  }
+  const parts: string[] = [];
+  for (const part of normalized.split('/')) {
+    if (part.length === 0 || part === '.') continue;
+    if (part === '..') {
+      throw new Error('Tool paths must be workspace-relative and cannot contain traversal.');
+    }
+    parts.push(part);
+  }
+  return parts.join('/') || '.';
 }
 
 export function makeTextEditorTool(
@@ -141,7 +170,7 @@ export function makeTextEditorTool(
       'Without view_range, repeated `view` of the same path within a single run returns only a short summary to protect context.',
     parameters: TextEditorParams,
     async execute(_toolCallId, params): Promise<AgentToolResult<TextEditorDetails>> {
-      const path = params.path;
+      const path = normalizeToolPath(params.path);
       switch (params.command) {
         case 'view': {
           const file = fs.view(path);
@@ -228,9 +257,18 @@ export function makeTextEditorTool(
             changedThisRunPaths.add(path);
             return ok(`Edited ${result.path}`, { command: 'str_replace', path, result });
           } catch (err) {
-            const nextFailedCount = failedCount + 1;
-            failedExactEditCountByPath.set(path, nextFailedCount);
             const message = err instanceof Error ? err.message : String(err);
+            const workspaceFailure = workspaceWriteFailureText(path, message);
+            if (workspaceFailure !== null) {
+              return ok(workspaceFailure, {
+                command: 'str_replace',
+                path,
+                result: { failed: true, message, reason: 'workspace_write_failed' },
+              });
+            }
+            const isExactFailure = isExactEditFailure(message, path);
+            const nextFailedCount = isExactFailure ? failedCount + 1 : failedCount;
+            if (isExactFailure) failedExactEditCountByPath.set(path, nextFailedCount);
             const prefix =
               nextFailedCount >= FAILED_EXACT_EDIT_LIMIT
                 ? `Edit failed: ${message}\n${exactEditFailuresExceededText(path, nextFailedCount)}`
@@ -256,13 +294,19 @@ export function makeTextEditorTool(
             changedThisRunPaths.add(path);
             return ok(`Inserted at ${result.path}:${line}`, { command: 'insert', path, result });
           } catch (err) {
-            const nextFailedCount = failedCount + 1;
-            failedExactEditCountByPath.set(path, nextFailedCount);
             const message = err instanceof Error ? err.message : String(err);
+            const workspaceFailure = workspaceWriteFailureText(path, message);
+            if (workspaceFailure !== null) {
+              return ok(workspaceFailure, {
+                command: 'insert',
+                path,
+                result: { failed: true, message, reason: 'workspace_write_failed' },
+              });
+            }
             return ok(`Edit failed: ${message}. Re-read the target range before retrying.`, {
               command: 'insert',
               path,
-              result: { failed: true, failureCount: nextFailedCount, message },
+              result: { failed: true, failureCount: failedCount, message },
             });
           }
         }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -95,7 +95,60 @@
       "rebindDescription": "This design already has a workspace folder. Choose how to proceed:",
       "rebindCancel": "Cancel",
       "rebindSwitchOnly": "Switch without copying",
-      "rebindSwitchAndCopy": "Switch and copy files"
+      "rebindSwitchAndCopy": "Switch and copy files",
+      "preview": {
+        "label": "Preview",
+        "detect": "Detect",
+        "apply": "Apply preview URL",
+        "reload": "Reload preview",
+        "openConnected": "Open",
+        "openFailed": "Could not open preview",
+        "saveFailed": "Could not update preview",
+        "detectFailed": "Could not detect preview",
+        "detectNone": "No running preview found",
+        "urlLabel": "Preview URL",
+        "urlPlaceholder": "localhost:5173",
+        "urlRequired": "Enter a local preview URL first.",
+        "urlInvalid": "Enter a valid http or https URL.",
+        "actions": {
+          "showOptions": "Show preview options",
+          "hideOptions": "Hide preview options"
+        },
+        "status": {
+          "saved": "Saved",
+          "auto": "Auto"
+        },
+        "mode": {
+          "label": "Mode",
+          "integrated": "Integrated file",
+          "integratedShort": "Integrated",
+          "connectedUrl": "Connected URL",
+          "connectedUrlShort": "Connected",
+          "externalApp": "External app",
+          "externalAppShort": "External",
+          "off": "Off",
+          "offShort": "Off"
+        },
+        "summary": {
+          "detecting": "Looking for a running local preview.",
+          "integrated": "Rendering workspace files inside Open CoDesign.",
+          "integratedBlocked": "This workspace looks like an app; use its own dev server for preview.",
+          "connected": "Previewing {{url}}.",
+          "waitingUrl": "Enter the running local preview URL.",
+          "external": "Use the app's own preview window.",
+          "externalWithUrl": "External preview configured at {{url}}.",
+          "off": "Preview is off for this workspace."
+        },
+        "hint": {
+          "appWorkspace": "App workspaces usually preview best in their own dev server or app window.",
+          "simpleWorkspace": "Integrated preview renders App.jsx or index.html inside Open CoDesign."
+        },
+        "placeholder": {
+          "off": "Preview is off for this workspace.",
+          "external": "This workspace is meant to be previewed in its own app window or browser.",
+          "devServerRequired": "This file is an app entry. Start its dev server, then use Detect or Connected URL for preview."
+        }
+      }
     },
     "rail": {
       "title": "Files",
@@ -947,6 +1000,7 @@
       "switchFailed": "Could not switch design",
       "switchBlockedGenerating": "Wait for generation to finish before switching",
       "busyGenerating": "Wait for the current generation to finish, then try again",
+      "workspaceBusyGenerating": "A generation is already running for this workspace",
       "renameFailed": "Could not rename the design",
       "duplicated": "Duplicated as \"{{name}}\"",
       "duplicateFailed": "Could not duplicate the design",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -95,7 +95,60 @@
       "rebindDescription": "Este diseño ya tiene una carpeta de espacio de trabajo. Elige cómo proceder:",
       "rebindCancel": "Cancelar",
       "rebindSwitchOnly": "Cambiar sin copiar",
-      "rebindSwitchAndCopy": "Cambiar y copiar archivos"
+      "rebindSwitchAndCopy": "Cambiar y copiar archivos",
+      "preview": {
+        "label": "Vista previa",
+        "detect": "Detectar",
+        "apply": "Aplicar URL de vista previa",
+        "reload": "Recargar vista previa",
+        "openConnected": "Abrir",
+        "openFailed": "No se pudo abrir la vista previa",
+        "saveFailed": "No se pudo actualizar la vista previa",
+        "detectFailed": "No se pudo detectar la vista previa",
+        "detectNone": "No se encontró una vista previa en ejecución",
+        "urlLabel": "URL de vista previa",
+        "urlPlaceholder": "localhost:5173",
+        "urlRequired": "Introduce primero una URL de vista previa local.",
+        "urlInvalid": "Introduce una URL http o https válida.",
+        "actions": {
+          "showOptions": "Mostrar opciones de vista previa",
+          "hideOptions": "Ocultar opciones de vista previa"
+        },
+        "status": {
+          "saved": "Guardada",
+          "auto": "Auto"
+        },
+        "mode": {
+          "label": "Modo",
+          "integrated": "Archivo integrado",
+          "integratedShort": "Integrado",
+          "connectedUrl": "URL conectada",
+          "connectedUrlShort": "Conectada",
+          "externalApp": "App externa",
+          "externalAppShort": "Externa",
+          "off": "Desactivada",
+          "offShort": "Off"
+        },
+        "summary": {
+          "detecting": "Buscando una vista previa local en ejecución.",
+          "integrated": "Renderizando archivos del espacio de trabajo dentro de Open CoDesign.",
+          "integratedBlocked": "Este espacio parece una app; usa su propio servidor de desarrollo para la vista previa.",
+          "connected": "Mostrando {{url}}.",
+          "waitingUrl": "Introduce la URL local de vista previa en ejecución.",
+          "external": "Usa la propia ventana de vista previa de la app.",
+          "externalWithUrl": "Vista previa externa configurada en {{url}}.",
+          "off": "La vista previa está desactivada para este espacio."
+        },
+        "hint": {
+          "appWorkspace": "Los espacios de app suelen verse mejor en su propio servidor de desarrollo o ventana.",
+          "simpleWorkspace": "La vista integrada renderiza App.jsx o index.html dentro de Open CoDesign."
+        },
+        "placeholder": {
+          "off": "La vista previa está desactivada para este espacio.",
+          "external": "Este espacio debe previsualizarse en su propia ventana de app o navegador.",
+          "devServerRequired": "Este archivo es una entrada de app. Inicia su servidor de desarrollo y usa Detect o Connected URL para la vista previa."
+        }
+      }
     },
     "rail": {
       "title": "Archivos",
@@ -892,6 +945,7 @@
       "switchFailed": "No se pudo cambiar de diseño",
       "switchBlockedGenerating": "Espera a que termine la generación antes de cambiar",
       "busyGenerating": "Espera a que termine la generación actual, luego intenta de nuevo",
+      "workspaceBusyGenerating": "Ya hay una generación en curso para este espacio de trabajo",
       "renameFailed": "No se pudo renombrar el diseño",
       "duplicated": "Duplicado como \"{{name}}\"",
       "duplicateFailed": "No se pudo duplicar el diseño",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -95,7 +95,60 @@
       "rebindDescription": "Este design já tem uma pasta de espaço de trabalho. Escolha como prosseguir:",
       "rebindCancel": "Cancelar",
       "rebindSwitchOnly": "Alternar sem copiar",
-      "rebindSwitchAndCopy": "Alternar e copiar arquivos"
+      "rebindSwitchAndCopy": "Alternar e copiar arquivos",
+      "preview": {
+        "label": "Prévia",
+        "detect": "Detectar",
+        "apply": "Aplicar URL da prévia",
+        "reload": "Recarregar prévia",
+        "openConnected": "Abrir",
+        "openFailed": "Não foi possível abrir a prévia",
+        "saveFailed": "Não foi possível atualizar a prévia",
+        "detectFailed": "Não foi possível detectar a prévia",
+        "detectNone": "Nenhuma prévia em execução encontrada",
+        "urlLabel": "URL da prévia",
+        "urlPlaceholder": "localhost:5173",
+        "urlRequired": "Informe primeiro uma URL local de prévia.",
+        "urlInvalid": "Informe uma URL http ou https válida.",
+        "actions": {
+          "showOptions": "Mostrar opções da prévia",
+          "hideOptions": "Ocultar opções da prévia"
+        },
+        "status": {
+          "saved": "Salva",
+          "auto": "Auto"
+        },
+        "mode": {
+          "label": "Modo",
+          "integrated": "Arquivo integrado",
+          "integratedShort": "Integrada",
+          "connectedUrl": "URL conectada",
+          "connectedUrlShort": "Conectada",
+          "externalApp": "App externo",
+          "externalAppShort": "Externa",
+          "off": "Desativada",
+          "offShort": "Off"
+        },
+        "summary": {
+          "detecting": "Procurando uma prévia local em execução.",
+          "integrated": "Renderizando arquivos do espaço de trabalho dentro do Open CoDesign.",
+          "integratedBlocked": "Este espaço parece um app; use o próprio servidor de desenvolvimento dele para prévia.",
+          "connected": "Prévia de {{url}}.",
+          "waitingUrl": "Informe a URL local da prévia em execução.",
+          "external": "Use a própria janela de prévia do app.",
+          "externalWithUrl": "Prévia externa configurada em {{url}}.",
+          "off": "A prévia está desativada para este espaço."
+        },
+        "hint": {
+          "appWorkspace": "Espaços de app normalmente funcionam melhor no próprio servidor de desenvolvimento ou janela.",
+          "simpleWorkspace": "A prévia integrada renderiza App.jsx ou index.html dentro do Open CoDesign."
+        },
+        "placeholder": {
+          "off": "A prévia está desativada para este espaço.",
+          "external": "Este espaço deve ser pré-visualizado na própria janela do app ou navegador.",
+          "devServerRequired": "Este arquivo e uma entrada de app. Inicie o servidor de desenvolvimento e use Detect ou Connected URL para a previa."
+        }
+      }
     },
     "rail": {
       "title": "Arquivos",
@@ -853,6 +906,7 @@
       "switchFailed": "Não foi possível trocar de design",
       "switchBlockedGenerating": "Aguarde a geração terminar antes de trocar",
       "busyGenerating": "Aguarde a geração atual terminar e tente novamente",
+      "workspaceBusyGenerating": "Já existe uma geração em andamento para este workspace",
       "renameFailed": "Não foi possível renomear o design",
       "duplicated": "Duplicado como \"{{name}}\"",
       "duplicateFailed": "Não foi possível duplicar o design",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -95,7 +95,60 @@
       "rebindDescription": "此设计已有工作区文件夹。请选择如何继续：",
       "rebindCancel": "取消",
       "rebindSwitchOnly": "仅切换（不复制文件）",
-      "rebindSwitchAndCopy": "切换并复制文件"
+      "rebindSwitchAndCopy": "切换并复制文件",
+      "preview": {
+        "label": "预览",
+        "detect": "检测",
+        "apply": "应用预览 URL",
+        "reload": "重新加载预览",
+        "openConnected": "打开",
+        "openFailed": "无法打开预览",
+        "saveFailed": "无法更新预览",
+        "detectFailed": "无法检测预览",
+        "detectNone": "未找到正在运行的预览",
+        "urlLabel": "预览 URL",
+        "urlPlaceholder": "localhost:5173",
+        "urlRequired": "请先输入本地预览 URL。",
+        "urlInvalid": "请输入有效的 http 或 https URL。",
+        "actions": {
+          "showOptions": "显示预览选项",
+          "hideOptions": "隐藏预览选项"
+        },
+        "status": {
+          "saved": "已保存",
+          "auto": "自动"
+        },
+        "mode": {
+          "label": "模式",
+          "integrated": "集成文件",
+          "integratedShort": "集成",
+          "connectedUrl": "连接 URL",
+          "connectedUrlShort": "连接",
+          "externalApp": "外部应用",
+          "externalAppShort": "外部",
+          "off": "关闭",
+          "offShort": "关闭"
+        },
+        "summary": {
+          "detecting": "正在查找运行中的本地预览。",
+          "integrated": "在 Open CoDesign 内渲染工作区文件。",
+          "integratedBlocked": "此工作区看起来像应用项目；请使用它自己的开发服务器预览。",
+          "connected": "正在预览 {{url}}。",
+          "waitingUrl": "输入正在运行的本地预览 URL。",
+          "external": "使用应用自己的预览窗口。",
+          "externalWithUrl": "外部预览已配置为 {{url}}。",
+          "off": "此工作区的预览已关闭。"
+        },
+        "hint": {
+          "appWorkspace": "应用工作区通常更适合在自己的开发服务器或应用窗口中预览。",
+          "simpleWorkspace": "集成预览会在 Open CoDesign 内渲染 App.jsx 或 index.html。"
+        },
+        "placeholder": {
+          "off": "此工作区的预览已关闭。",
+          "external": "此工作区应在自己的应用窗口或浏览器中预览。",
+          "devServerRequired": "此文件是应用入口。请启动开发服务器，然后使用 Detect 或 Connected URL 预览。"
+        }
+      }
     },
     "rail": {
       "title": "文件",
@@ -943,6 +996,7 @@
       "switchFailed": "无法切换设计",
       "switchBlockedGenerating": "等当前生成完成后再切换",
       "busyGenerating": "当前生成还没完成，稍等一下再试",
+      "workspaceBusyGenerating": "此工作区已有生成正在运行",
       "renameFailed": "无法重命名设计",
       "duplicated": "已复制为“{{name}}”",
       "duplicateFailed": "无法复制设计",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -402,7 +402,9 @@ export type {
   DesignFile,
   DesignMessage,
   DesignSnapshot,
+  PreviewMode,
   SnapshotCreateInput,
+  WorkspaceMode,
 } from './snapshot';
 export {
   ChatMessageKind,

--- a/packages/shared/src/snapshot.ts
+++ b/packages/shared/src/snapshot.ts
@@ -23,8 +23,13 @@ export const DesignV1 = z.object({
   thumbnailText: z.string().nullable().default(null),
   deletedAt: z.string().nullable().default(null),
   workspacePath: z.string().nullable().default(null),
+  workspaceMode: z.enum(['blank-canvas', 'work-on-project']).optional(),
+  previewMode: z.enum(['managed-file', 'connected-url', 'external-app', 'none']).optional(),
+  previewUrl: z.string().nullable().optional(),
 });
 export type Design = z.infer<typeof DesignV1>;
+export type WorkspaceMode = NonNullable<Design['workspaceMode']>;
+export type PreviewMode = NonNullable<Design['previewMode']>;
 
 export const DesignMessageV1 = z.object({
   schemaVersion: z.literal(1).default(1),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      ms:
+        specifier: 2.1.3
+        version: 2.1.3
       puppeteer-core:
         specifier: ^24.42.0
         version: 24.42.0


### PR DESCRIPTION
## Summary
- add workspace-backed design creation, rebinding, file browsing, import, and preview hydration flows
- wire local workspace reads/writes through main/preload/renderer and core agent tools
- tighten workspace path validation, preview source resolution, local loopback preview support, and generation coordination
- package the preview executor's `ms` runtime dependency so packaged builds can load `debug`/`puppeteer-core`
- add focused coverage for workspace IPC, file tree loading, preview hydration, generation races, and tool behavior

## Verification
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm --filter @open-codesign/desktop test -- preview-runtime.test.ts
- pnpm --filter @open-codesign/desktop build:dir
- inspected generated app.asar and confirmed `node_modules/ms` is packaged alongside `node_modules/debug/src/common.js`
- pre-push hook: typecheck + lint + test

## Scope
This intentionally excludes local doc-only changes from the working tree and keeps the PR focused on the local workspace workflow.