### PR TITLE
Add workspace chat tabs

### DIFF
--- a/apps/desktop/src/main/design-workspace.test.ts
+++ b/apps/desktop/src/main/design-workspace.test.ts
@@ -179,6 +179,29 @@ describe('bindWorkspace', () => {
     expect(getDesign(db, design.id)?.workspacePath).toBeNull();
   });
 
+  it('allows an explicit fresh conversation to share an existing workspace binding', async () => {
+    const db = initInMemoryDb();
+    const design = createDesign(db);
+    const otherDesign = createDesign(db, 'Landing page variants');
+    const sharedPath = normalizeWorkspacePath(await makeTempDir('ocd-ws-shared-'));
+    await writeWorkspaceFile(
+      sharedPath,
+      'App.jsx',
+      'export default function App() { return null; }',
+    );
+    updateDesignWorkspace(db, otherDesign.id, sharedPath);
+
+    const rebound = await bindWorkspace(db, design.id, sharedPath, false, 'work-on-project', {
+      allowExistingWorkspaceBinding: true,
+    });
+
+    expect(rebound.workspacePath).toBe(sharedPath);
+    expect(getDesign(db, otherDesign.id)?.workspacePath).toBe(sharedPath);
+    await expect(readFile(path.join(sharedPath, 'App.jsx'), 'utf8')).resolves.toBe(
+      'export default function App() { return null; }',
+    );
+  });
+
   it('rejects empty and relative workspace bindings before touching the db', async () => {
     const db = initInMemoryDb();
     const design = createDesign(db);

--- a/apps/desktop/src/main/design-workspace.ts
+++ b/apps/desktop/src/main/design-workspace.ts
@@ -11,17 +11,12 @@ import {
   listDesigns,
   updateDesignWorkspace,
 } from './snapshots-db';
-import { normalizeWorkspacePath } from './workspace-path';
+import { normalizeWorkspacePath, workspacePathComparisonKey } from './workspace-path';
 import { listWorkspaceFilesAt, resolveSafeWorkspaceChildPath } from './workspace-reader';
 
 export { normalizeWorkspacePath } from './workspace-path';
 
 const logger = getLogger('design-workspace');
-
-function workspacePathComparisonKey(p: string): string {
-  const normalized = normalizeWorkspacePath(p);
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-}
 
 export async function pickWorkspaceFolder(win: BrowserWindow): Promise<string | null> {
   const result = await dialog.showOpenDialog(win, {
@@ -146,6 +141,7 @@ export async function bindWorkspace(
   workspacePath: string | null,
   migrateFiles: boolean,
   workspaceMode?: WorkspaceMode,
+  options?: { allowExistingWorkspaceBinding?: boolean },
 ): Promise<Design> {
   const current = requireDesign(db, designId);
 
@@ -169,7 +165,7 @@ export async function bindWorkspace(
     return current;
   }
   const conflict = findWorkspaceConflict(db, designId, normalizedPath);
-  if (conflict !== null) {
+  if (conflict !== null && options?.allowExistingWorkspaceBinding !== true) {
     throw new Error(workspaceConflictMessage(conflict));
   }
   await assertExistingWorkspaceDirectory(normalizedPath);

--- a/apps/desktop/src/main/generation-ipc.test.ts
+++ b/apps/desktop/src/main/generation-ipc.test.ts
@@ -14,6 +14,21 @@ function makeController() {
   return { abort: vi.fn() } as unknown as AbortController;
 }
 
+function withMockedPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+  try {
+    return run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original);
+    }
+  }
+}
+
 describe('cancelGenerationRequest', () => {
   it('parses the public v1 cancel-generation payload', () => {
     const payload = CancelGenerationPayloadV1.parse({
@@ -222,6 +237,24 @@ describe('acquireInFlightWorkspaceGeneration', () => {
 
     release();
     expect(inFlightByWorkspace.has('/workspace')).toBe(false);
+  });
+
+  it('treats case-only path differences as the same workspace on Windows', () => {
+    withMockedPlatform('win32', () => {
+      const inFlightByWorkspace = new Map<string, { generationId: string; startedAt: number }>();
+      const release = acquireInFlightWorkspaceGeneration(
+        'gen-1',
+        'C:/Users/Roy/Workspace',
+        inFlightByWorkspace,
+      );
+
+      expect(() =>
+        acquireInFlightWorkspaceGeneration('gen-2', 'c:/users/roy/workspace', inFlightByWorkspace),
+      ).toThrow(CodesignError);
+
+      release();
+      expect(inFlightByWorkspace.has('c:/users/roy/workspace')).toBe(false);
+    });
   });
 
   it('allows different workspaces to run concurrently', () => {

--- a/apps/desktop/src/main/generation-ipc.ts
+++ b/apps/desktop/src/main/generation-ipc.ts
@@ -1,4 +1,5 @@
 import { CodesignError, ERROR_CODES } from '@open-codesign/shared';
+import { workspacePathComparisonKey } from './workspace-path';
 
 export interface CancellationLogger {
   info: (event: string, payload: { id: string }) => void;
@@ -85,9 +86,10 @@ export async function withInFlightGenerationForDesign<T>(
 
 export function acquireInFlightWorkspaceGeneration(
   id: string,
-  workspaceKey: string,
+  workspacePath: string,
   inFlightByWorkspace: Map<string, InFlightGeneration>,
 ): () => void {
+  const workspaceKey = workspacePathComparisonKey(workspacePath);
   const existing = inFlightByWorkspace.get(workspaceKey);
   if (existing !== undefined && existing.generationId !== id) {
     throw new CodesignError(

--- a/apps/desktop/src/main/snapshots-ipc.create-design.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.create-design.test.ts
@@ -1,0 +1,127 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import type { Design } from '@open-codesign/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDesign,
+  createSnapshot,
+  initInMemoryDb,
+  listDesigns,
+  listSnapshots,
+  updateDesignWorkspace,
+} from './snapshots-db';
+import { registerSnapshotsIpc } from './snapshots-ipc';
+import { normalizeWorkspacePath } from './workspace-path';
+
+type Handler = (event: unknown, raw: unknown) => unknown;
+
+const handlers = vi.hoisted(() => new Map<string, Handler>());
+const testRoots = vi.hoisted(() => {
+  const fallback = process.platform === 'win32' ? 'C:/Temp' : '/tmp';
+  const base = (process.env['TEMP'] ?? process.env['TMP'] ?? fallback).replaceAll('\\', '/');
+  return { documentsRoot: `${base}/open-codesign-create-design-tests` };
+});
+
+vi.mock('./electron-runtime', () => ({
+  app: {
+    getPath: vi.fn(() => testRoots.documentsRoot),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      handlers.set(channel, handler);
+    }),
+  },
+}));
+
+vi.mock('./logger', () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+function getHandler(channel: string): Handler {
+  const handler = handlers.get(channel);
+  if (!handler) throw new Error(`Missing IPC handler: ${channel}`);
+  return handler;
+}
+
+describe('snapshots create-design workspace reuse', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    handlers.clear();
+    await mkdir(testRoots.documentsRoot, { recursive: true });
+    root = await mkdtemp(path.join(testRoots.documentsRoot, 'case-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('creates a fresh conversation that shares an existing workspace without copying history', async () => {
+    const db = initInMemoryDb();
+    const workspacePath = path.join(root, 'workspace');
+    await mkdir(workspacePath);
+    const source = createDesign(db, 'Existing workspace');
+    updateDesignWorkspace(db, source.id, workspacePath);
+    createSnapshot(db, {
+      designId: source.id,
+      parentId: null,
+      type: 'initial',
+      prompt: 'make a homepage',
+      artifactType: 'html',
+      artifactSource: '<main>Existing</main>',
+    });
+    registerSnapshotsIpc(db);
+
+    const created = (await getHandler('snapshots:v1:create-design')(null, {
+      schemaVersion: 1,
+      name: 'Fresh conversation',
+      workspacePath,
+      workspaceReuse: 'fresh-conversation',
+    })) as Design;
+
+    expect(created.id).not.toBe(source.id);
+    expect(created.workspacePath).toBe(normalizeWorkspacePath(workspacePath));
+    expect(listSnapshots(db, created.id)).toEqual([]);
+    expect(listSnapshots(db, source.id)).toHaveLength(1);
+    expect(
+      listDesigns(db).filter(
+        (design) => design.workspacePath === normalizeWorkspacePath(workspacePath),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('keeps ordinary create-design workspace conflicts exclusive', async () => {
+    const db = initInMemoryDb();
+    const workspacePath = path.join(root, 'workspace');
+    await mkdir(workspacePath);
+    const source = createDesign(db, 'Existing workspace');
+    updateDesignWorkspace(db, source.id, workspacePath);
+    registerSnapshotsIpc(db);
+
+    await expect(
+      getHandler('snapshots:v1:create-design')(null, {
+        schemaVersion: 1,
+        name: 'Ordinary create',
+        workspacePath,
+      }),
+    ).rejects.toMatchObject({ code: 'IPC_CONFLICT' });
+
+    expect(listDesigns(db).map((design) => design.id)).toEqual([source.id]);
+  });
+
+  it('rejects workspace reuse without an explicit workspace path', async () => {
+    const db = initInMemoryDb();
+    registerSnapshotsIpc(db);
+
+    await expect(
+      getHandler('snapshots:v1:create-design')(null, {
+        schemaVersion: 1,
+        name: 'Fresh conversation',
+        workspaceReuse: 'fresh-conversation',
+      }),
+    ).rejects.toMatchObject({ code: 'IPC_BAD_INPUT' });
+  });
+});

--- a/apps/desktop/src/main/snapshots-ipc.ts
+++ b/apps/desktop/src/main/snapshots-ipc.ts
@@ -211,6 +211,18 @@ function parseCreateDesignWorkspacePath(r: Record<string, unknown>): string | un
   }
 }
 
+function parseCreateDesignWorkspaceReuse(
+  r: Record<string, unknown>,
+): 'fresh-conversation' | undefined {
+  const raw = r['workspaceReuse'];
+  if (raw === undefined) return undefined;
+  if (raw === 'fresh-conversation') return raw;
+  throw new CodesignError(
+    'workspaceReuse must be fresh-conversation when provided',
+    'IPC_BAD_INPUT',
+  );
+}
+
 function translateWorkspaceBindError(err: unknown, fallbackMessage: string): CodesignError {
   if (err instanceof CodesignError) return err;
   if (err instanceof Error && err.message.includes('already bound')) {
@@ -1265,6 +1277,13 @@ export function registerSnapshotsIpc(db: Database): void {
       }
       const name = (r['name'] as string).trim();
       const requestedWorkspacePath = parseCreateDesignWorkspacePath(r);
+      const workspaceReuse = parseCreateDesignWorkspaceReuse(r);
+      if (workspaceReuse !== undefined && requestedWorkspacePath === undefined) {
+        throw new CodesignError(
+          'workspaceReuse requires an explicit workspacePath',
+          'IPC_BAD_INPUT',
+        );
+      }
       const design = runDb('create-design', () => createDesign(db, name));
       // v0.2: every design MUST have a workspace — per docs/v0.2-plan.md §2.3.
       // When the user hasn't picked one explicitly, seed
@@ -1282,6 +1301,7 @@ export function registerSnapshotsIpc(db: Database): void {
           workspacePath,
           false,
           requestedWorkspacePath === undefined ? 'blank-canvas' : 'work-on-project',
+          { allowExistingWorkspaceBinding: workspaceReuse === 'fresh-conversation' },
         );
       } catch (err) {
         if (autoWorkspacePath !== null) {

--- a/apps/desktop/src/main/snapshots-ipc.workspace-rename-race.test.ts
+++ b/apps/desktop/src/main/snapshots-ipc.workspace-rename-race.test.ts
@@ -16,13 +16,8 @@ type Handler = (event: unknown, raw: unknown) => unknown;
 
 const handlers = vi.hoisted(() => new Map<string, Handler>());
 const testRoots = vi.hoisted(() => {
-  const base = (
-    process.env['RUNNER_TEMP'] ??
-    process.env['TMPDIR'] ??
-    process.env['TEMP'] ??
-    process.env['TMP'] ??
-    (process.platform === 'win32' ? 'C:/Temp' : '/tmp')
-  ).replaceAll('\\', '/');
+  const fallback = process.platform === 'win32' ? 'C:/Temp' : '/tmp';
+  const base = (process.env['TEMP'] ?? process.env['TMP'] ?? fallback).replaceAll('\\', '/');
   return { documentsRoot: `${base}/open-codesign-rename-tests` };
 });
 const renameControl = vi.hoisted(() => {

--- a/apps/desktop/src/main/workspace-path.ts
+++ b/apps/desktop/src/main/workspace-path.ts
@@ -33,6 +33,11 @@ export function normalizeWorkspacePath(rawPath: string): string {
   return stripTrailingSlash(normalized);
 }
 
+export function workspacePathComparisonKey(workspacePath: string): string {
+  const normalized = stripTrailingSlash(workspacePath.replaceAll('\\', '/'));
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
 export function assertWorkspacePath(rawPath: string): string {
   return normalizeWorkspacePath(rawPath);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -170,6 +170,10 @@ export interface RenameDesignOptions {
   renameWorkspace?: boolean;
 }
 
+export interface CreateDesignOptions {
+  workspaceReuse?: 'fresh-conversation';
+}
+
 export interface ExportInvokeResponse {
   status: 'saved' | 'cancelled';
   path?: string;
@@ -688,11 +692,14 @@ const api = {
   snapshots: {
     listDesigns: () =>
       ipcRenderer.invoke('snapshots:v1:list-designs', { schemaVersion: 1 }) as Promise<Design[]>,
-    createDesign: (name: string, workspacePath?: string | null) =>
+    createDesign: (name: string, workspacePath?: string | null, options?: CreateDesignOptions) =>
       ipcRenderer.invoke('snapshots:v1:create-design', {
         schemaVersion: 1,
         name,
         ...(workspacePath !== undefined ? { workspacePath } : {}),
+        ...(options?.workspaceReuse !== undefined
+          ? { workspaceReuse: options.workspaceReuse }
+          : {}),
       }) as Promise<Design>,
     getDesign: (id: string) =>
       ipcRenderer.invoke('snapshots:v1:get-design', {

--- a/apps/desktop/src/renderer/src/components/CanvasTabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/CanvasTabBar.tsx
@@ -1,6 +1,6 @@
 import { useT } from '@open-codesign/i18n';
-import { Eye, FolderOpen, X } from 'lucide-react';
-import { Fragment, type ReactNode } from 'react';
+import { FolderOpen, X } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useCodesignStore } from '../store';
 
 function fileTabLabel(path: string): string {
@@ -8,7 +8,7 @@ function fileTabLabel(path: string): string {
   return segments[segments.length - 1] ?? path;
 }
 
-type CanvasTabForView = { kind: 'preview' } | { kind: 'files' } | { kind: 'file'; path: string };
+type CanvasTabForView = { kind: 'files' } | { kind: 'file'; path: string };
 
 function tabMeta(
   tab: CanvasTabForView,
@@ -19,19 +19,7 @@ function tabMeta(
   title: string;
   icon: ReactNode;
   mono: boolean;
-  closable: boolean;
 } {
-  if (tab.kind === 'preview') {
-    const label = t('canvas.previewTab');
-    return {
-      key: 'preview',
-      label,
-      title: label,
-      icon: <Eye className="h-3.5 w-3.5 opacity-80" aria-hidden />,
-      mono: false,
-      closable: false,
-    };
-  }
   if (tab.kind === 'files') {
     const label = t('canvas.filesTab');
     return {
@@ -40,7 +28,6 @@ function tabMeta(
       title: label,
       icon: <FolderOpen className="h-3.5 w-3.5 opacity-80" aria-hidden />,
       mono: false,
-      closable: false,
     };
   }
   return {
@@ -49,7 +36,6 @@ function tabMeta(
     title: tab.path,
     icon: null,
     mono: true,
-    closable: true,
   };
 }
 
@@ -58,10 +44,14 @@ export function CanvasTabBar() {
   const tabs = useCodesignStore((s) => s.canvasTabs) as CanvasTabForView[];
   const active = useCodesignStore((s) => s.activeCanvasTab);
   const setActive = useCodesignStore((s) => s.setActiveCanvasTab);
-  const close = useCodesignStore((s) => s.closeCanvasTab);
-  const hasFileTabs = tabs.some((tab) => tab.kind === 'file');
+  const filesTab = tabs
+    .map((tab, index) => ({ tab, index }))
+    .find((entry) => entry.tab.kind === 'files');
 
-  if (tabs.length === 0) return null;
+  if (!filesTab) return null;
+
+  const isActive = filesTab.index === active;
+  const item = tabMeta(filesTab.tab, t);
 
   return (
     <div
@@ -69,67 +59,103 @@ export function CanvasTabBar() {
       aria-label={t('canvas.tabsAriaLabel')}
       className="codesign-scroll-x flex min-w-0 items-stretch overflow-x-auto overflow-y-hidden"
     >
-      {tabs.map((tab, index) => {
+      <div
+        role="tab"
+        aria-selected={isActive}
+        className={`group relative mr-[var(--space-1)] flex shrink-0 items-center gap-[var(--space-2)] rounded-t-[var(--radius-sm)] bg-[var(--color-background)] px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
+          isActive
+            ? 'text-[var(--color-text-primary)]'
+            : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => setActive(filesTab.index)}
+          title={item.title}
+          className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
+        >
+          {item.icon}
+          <span
+            className="max-w-[220px] truncate"
+            style={item.mono ? { fontFamily: 'var(--font-mono)' } : undefined}
+          >
+            {item.label}
+          </span>
+        </button>
+        {isActive ? (
+          <span
+            aria-hidden
+            className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function CanvasFileTabBar() {
+  const t = useT();
+  const tabs = useCodesignStore((s) => s.canvasTabs) as CanvasTabForView[];
+  const active = useCodesignStore((s) => s.activeCanvasTab);
+  const setActive = useCodesignStore((s) => s.setActiveCanvasTab);
+  const close = useCodesignStore((s) => s.closeCanvasTab);
+  const fileTabs = tabs
+    .map((tab, index) => ({ tab, index }))
+    .filter((entry): entry is { tab: { kind: 'file'; path: string }; index: number } => {
+      return entry.tab.kind === 'file';
+    });
+
+  if (fileTabs.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t('canvas.previewTabsAriaLabel')}
+      className="codesign-scroll-x flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden"
+    >
+      {fileTabs.map(({ tab, index }) => {
         const isActive = index === active;
-        const isFilesTab = tab.kind === 'files';
-        const isFileTab = tab.kind === 'file';
         const item = tabMeta(tab, t);
 
         return (
-          <Fragment key={item.key}>
-            <div
-              role="tab"
-              aria-selected={isActive}
-              className={`group relative flex shrink-0 items-center gap-[var(--space-2)] px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
-                isFilesTab
-                  ? 'mr-[var(--space-1)] rounded-t-[var(--radius-sm)] bg-[var(--color-background)]'
-                  : ''
-              } ${isFileTab ? 'rounded-t-[var(--radius-sm)] border-x border-transparent' : ''} ${
-                isActive
-                  ? isFileTab
-                    ? 'border-[var(--color-border-muted)] bg-[var(--color-background)] text-[var(--color-text-primary)]'
-                    : 'text-[var(--color-text-primary)]'
-                  : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
-              }`}
+          <div
+            key={item.key}
+            role="tab"
+            aria-selected={isActive}
+            className={`group relative flex shrink-0 items-center gap-[var(--space-2)] rounded-t-[var(--radius-sm)] border-x border-transparent px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
+              isActive
+                ? 'border-[var(--color-border-muted)] bg-[var(--color-background)] text-[var(--color-text-primary)]'
+                : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => setActive(index)}
+              title={item.title}
+              className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
             >
-              <button
-                type="button"
-                onClick={() => setActive(index)}
-                title={item.title}
-                className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
+              <span
+                className="max-w-[220px] truncate"
+                style={item.mono ? { fontFamily: 'var(--font-mono)' } : undefined}
               >
-                {item.icon}
-                <span
-                  className="max-w-[220px] truncate"
-                  style={item.mono ? { fontFamily: 'var(--font-mono)' } : undefined}
-                >
-                  {item.label}
-                </span>
-              </button>
-              {item.closable ? (
-                <button
-                  type="button"
-                  onClick={() => close(index)}
-                  aria-label={t('canvas.closeTab', { name: item.label })}
-                  className="p-[2px] text-[var(--color-text-muted)] opacity-50 transition-opacity hover:text-[var(--color-text-primary)] hover:opacity-100"
-                >
-                  <X className="h-3 w-3" aria-hidden />
-                </button>
-              ) : null}
-              {isActive ? (
-                <span
-                  aria-hidden
-                  className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
-                />
-              ) : null}
-            </div>
-            {isFilesTab && hasFileTabs ? (
-              <div
+                {item.label}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => close(index)}
+              aria-label={t('canvas.closeTab', { name: item.label })}
+              className="p-[2px] text-[var(--color-text-muted)] opacity-50 transition-opacity hover:text-[var(--color-text-primary)] hover:opacity-100"
+            >
+              <X className="h-3 w-3" aria-hidden />
+            </button>
+            {isActive ? (
+              <span
                 aria-hidden
-                className="my-[7px] h-[18px] w-px shrink-0 bg-[var(--color-border-muted)]"
+                className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
               />
             ) : null}
-          </Fragment>
+          </div>
         );
       })}
     </div>

--- a/apps/desktop/src/renderer/src/components/FilesTabView.tsx
+++ b/apps/desktop/src/renderer/src/components/FilesTabView.tsx
@@ -59,6 +59,7 @@ import {
   resolveDesignPreviewSource,
 } from '../preview/workspace-source';
 import { useCodesignStore } from '../store';
+import { CanvasFileTabBar } from './CanvasTabBar';
 
 export { resolveReferencedWorkspacePreviewPath } from '../preview/workspace-source';
 
@@ -1799,6 +1800,7 @@ export function FilesTabView({ activePath = null }: { activePath?: string | null
   const openFileTab = useCodesignStore((s) => s.openCanvasFileTab);
   const setActiveCanvasTab = useCodesignStore((s) => s.setActiveCanvasTab);
   const currentPreviewSource = useCodesignStore((s) => s.previewSource);
+  const canvasTabs = useCodesignStore((s) => s.canvasTabs);
   const { files, tree: fileTree, loadDirectory } = useLazyDesignFileTree(currentDesignId);
 
   const defaultPath = useMemo(() => defaultWorkspacePreviewPath(files), [files]);
@@ -1839,6 +1841,7 @@ export function FilesTabView({ activePath = null }: { activePath?: string | null
   const showPreviewHeaderAction =
     (effectivePreviewMode === 'managed-file' && selectedPath !== null) ||
     (usesExternalPreview && connectedPreviewUrl !== null);
+  const hasOpenFileTabs = canvasTabs.some((tab) => tab.kind === 'file');
 
   const handleOpenPreviewTarget = useCallback(async () => {
     if (usesExternalPreview && connectedPreviewUrl) {
@@ -2155,17 +2158,20 @@ export function FilesTabView({ activePath = null }: { activePath?: string | null
         title="Resize files"
       />
       <div className="flex-1 min-w-0 h-full bg-[var(--color-background-secondary)] flex flex-col min-h-0">
-        {showPreviewHeaderAction ? (
-          <div className="flex h-[36px] shrink-0 items-center justify-end border-b border-[var(--color-border-muted)] bg-[var(--color-background)] px-[var(--space-4)]">
-            <button
-              type="button"
-              onClick={handleOpenPreviewTarget}
-              className="text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-accent)]"
-            >
-              {usesExternalPreview
-                ? t('canvas.workspace.preview.openConnected')
-                : t('canvas.openInTab')}
-            </button>
+        {hasOpenFileTabs || showPreviewHeaderAction ? (
+          <div className="flex h-[36px] shrink-0 items-center gap-[var(--space-2)] border-b border-[var(--color-border-muted)] bg-[var(--color-background)] pl-[var(--space-2)] pr-[var(--space-4)]">
+            <CanvasFileTabBar />
+            {showPreviewHeaderAction ? (
+              <button
+                type="button"
+                onClick={handleOpenPreviewTarget}
+                className="ml-auto shrink-0 text-[11px] uppercase tracking-[var(--tracking-label)] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-accent)]"
+              >
+                {usesExternalPreview
+                  ? t('canvas.workspace.preview.openConnected')
+                  : t('canvas.openInTab')}
+              </button>
+            ) : null}
           </div>
         ) : null}
         <div className="flex-1 min-h-0 bg-[var(--color-background-secondary)]">

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
 import { useT } from '@open-codesign/i18n';
-import type { LocalInputFile, OnboardingState } from '@open-codesign/shared';
-import { FolderOpen, Link2, Paperclip, X } from 'lucide-react';
-import { useCallback, useEffect, useRef } from 'react';
+import type { Design, LocalInputFile, OnboardingState } from '@open-codesign/shared';
+import { FolderOpen, Link2, Paperclip, Plus, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { workspacePathComparisonKey } from '../lib/workspace-path';
 import { useCodesignStore } from '../store';
 import { AskModal } from './AskModal';
 import { AddMenu } from './chat/AddMenu';
@@ -61,6 +62,172 @@ function ContextIcon({ icon }: { icon: ComposerContextItem['icon'] }) {
   if (icon === 'file') return <Paperclip className="w-3.5 h-3.5" aria-hidden />;
   if (icon === 'url') return <Link2 className="w-3.5 h-3.5" aria-hidden />;
   return <FolderOpen className="w-3.5 h-3.5" aria-hidden />;
+}
+
+function chatWorkspaceKey(workspacePath: string): string {
+  return workspacePathComparisonKey(workspacePath, globalThis.navigator?.platform ?? '');
+}
+
+function chatSessionsForWorkspace(designs: Design[], currentDesign: Design): Design[] {
+  if (!currentDesign.workspacePath) return [currentDesign];
+  const currentWorkspaceKey = chatWorkspaceKey(currentDesign.workspacePath);
+  return designs.filter(
+    (design) =>
+      design.workspacePath !== null &&
+      chatWorkspaceKey(design.workspacePath) === currentWorkspaceKey,
+  );
+}
+
+function ChatSessionTabBar() {
+  const t = useT();
+  const currentDesignId = useCodesignStore((s) => s.currentDesignId);
+  const designs = useCodesignStore((s) => s.designs);
+  const switchDesign = useCodesignStore((s) => s.switchDesign);
+  const softDeleteDesign = useCodesignStore((s) => s.softDeleteDesign);
+  const createNewConversationForCurrentWorkspace = useCodesignStore(
+    (s) => s.createNewConversationForCurrentWorkspace,
+  );
+  const [creating, setCreating] = useState(false);
+  const [conversationToClose, setConversationToClose] = useState<Design | null>(null);
+  const currentDesign = designs.find((design) => design.id === currentDesignId) ?? null;
+  if (currentDesign === null) return null;
+
+  const chatSessions = chatSessionsForWorkspace(designs, currentDesign);
+  const canCreate = currentDesign.workspacePath !== null;
+
+  async function handleNewChat() {
+    if (!canCreate || creating) return;
+    setCreating(true);
+    try {
+      await createNewConversationForCurrentWorkspace();
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleConfirmCloseChat() {
+    if (conversationToClose === null) return;
+    const target = conversationToClose;
+    const fallback =
+      target.id === currentDesignId
+        ? (chatSessions.find((design) => design.id !== target.id) ?? null)
+        : null;
+
+    setConversationToClose(null);
+    if (fallback !== null) {
+      await switchDesign(fallback.id);
+    }
+    await softDeleteDesign(target.id);
+  }
+
+  return (
+    <>
+      <div className="shrink-0 border-b border-[var(--color-border-muted)] bg-[var(--color-background-secondary)] pl-[var(--space-2)]">
+        <div className="flex min-w-0 items-stretch">
+          {canCreate ? (
+            <button
+              type="button"
+              onClick={() => void handleNewChat()}
+              disabled={creating}
+              title={t('projects.switcher.newConversationForWorkspace')}
+              aria-label={t('projects.switcher.newConversationForWorkspace')}
+              className="my-[6px] mr-[var(--space-1)] inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          ) : null}
+          <div
+            role="tablist"
+            aria-label={t('sidebar.chatTabsAriaLabel')}
+            className="codesign-scroll-x flex min-w-0 flex-1 items-stretch overflow-x-auto overflow-y-hidden"
+          >
+            {chatSessions.map((design) => {
+              const isActive = design.id === currentDesignId;
+              return (
+                <div
+                  key={design.id}
+                  role="tab"
+                  aria-selected={isActive}
+                  className={`group relative flex shrink-0 items-center gap-[var(--space-2)] rounded-t-[var(--radius-sm)] px-[var(--space-3)] py-[7px] text-[12px] transition-colors duration-[var(--duration-faster)] ${
+                    isActive
+                      ? 'border-x border-[var(--color-border-muted)] bg-[var(--color-background)] text-[var(--color-text-primary)]'
+                      : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!isActive) void switchDesign(design.id);
+                    }}
+                    title={design.name}
+                    className="flex items-center gap-[var(--space-1_5)] focus:outline-none"
+                  >
+                    <span className="max-w-[160px] truncate">{design.name}</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConversationToClose(design)}
+                    aria-label={t('sidebar.closeChat', { name: design.name })}
+                    className="p-[2px] text-[var(--color-text-muted)] opacity-50 transition-opacity hover:text-[var(--color-text-primary)] hover:opacity-100"
+                  >
+                    <X className="h-3 w-3" aria-hidden />
+                  </button>
+                  {isActive ? (
+                    <span
+                      aria-hidden
+                      className="absolute inset-x-[var(--space-2)] bottom-[-1px] h-[1.5px] bg-[var(--color-accent)]"
+                    />
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      {conversationToClose ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('sidebar.deleteChat.title')}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-overlay)] animate-[overlay-in_120ms_ease-out]"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setConversationToClose(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setConversationToClose(null);
+          }}
+        >
+          <div
+            role="document"
+            className="w-full max-w-sm rounded-[var(--radius-2xl)] border border-[var(--color-border)] bg-[var(--color-background)] p-5 shadow-[var(--shadow-elevated)] space-y-4 animate-[panel-in_160ms_ease-out]"
+          >
+            <h3 className="text-[var(--text-md)] font-medium text-[var(--color-text-primary)]">
+              {t('sidebar.deleteChat.title')}
+            </h3>
+            <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] leading-[var(--leading-body)]">
+              {t('sidebar.deleteChat.body', { name: conversationToClose.name })}
+            </p>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConversationToClose(null)}
+                className="h-9 rounded-[var(--radius-md)] px-3 text-[var(--text-sm)] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text-primary)]"
+              >
+                {t('sidebar.deleteChat.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConfirmCloseChat()}
+                className="h-9 rounded-[var(--radius-md)] bg-[var(--color-error)] px-3 text-[var(--text-sm)] font-medium text-[var(--color-on-accent)] transition-opacity hover:opacity-90"
+              >
+                {t('sidebar.deleteChat.confirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
 }
 
 /**
@@ -141,8 +308,7 @@ export function Sidebar({ prefillPrompt }: SidebarProps) {
       style={{ minHeight: 0, minWidth: 0 }}
       aria-label={t('sidebar.ariaLabel')}
     >
-      {/* Header — clean, no collapse */}
-      <div className="h-[var(--space-3)] shrink-0" />
+      <ChatSessionTabBar />
 
       {/* Chat scroll area */}
       <div className="codesign-scroll-area flex-1 overflow-y-auto px-[var(--space-4)] py-[var(--space-4)]">

--- a/apps/desktop/src/renderer/src/store.test.ts
+++ b/apps/desktop/src/renderer/src/store.test.ts
@@ -1462,6 +1462,58 @@ describe('useCodesignStore design management', () => {
     expect(updateWorkspace).not.toHaveBeenCalled();
   });
 
+  it('creates a fresh conversation for the current workspace with clean UI state', async () => {
+    const existing = { ...DEFAULT_DESIGN, id: 'design-a', workspacePath: '/tmp/shared' };
+    const created = {
+      ...DEFAULT_DESIGN,
+      id: 'design-b',
+      name: 'Untitled design 1',
+      workspacePath: '/tmp/shared',
+    };
+    const createDesign = vi.fn(() => Promise.resolve(created));
+
+    vi.stubGlobal('window', {
+      codesign: {
+        chat: mockChatApi(),
+        comments: mockCommentsApi(),
+        snapshots: {
+          createDesign,
+          listDesigns: vi.fn(() => Promise.resolve([existing, created])),
+          list: vi.fn(() => Promise.resolve([])),
+        },
+      },
+      setTimeout,
+    });
+
+    useCodesignStore.setState({
+      designs: [existing],
+      currentDesignId: existing.id,
+      previewSource: '<main>old</main>',
+      chatMessages: [
+        {
+          schemaVersion: 1 as const,
+          id: 1,
+          designId: existing.id,
+          seq: 0,
+          kind: 'user',
+          payload: { text: 'old context' },
+          snapshotId: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await useCodesignStore.getState().createNewConversationForCurrentWorkspace();
+
+    expect(result?.id).toBe('design-b');
+    expect(createDesign).toHaveBeenCalledWith('Untitled design 1', '/tmp/shared', {
+      workspaceReuse: 'fresh-conversation',
+    });
+    expect(useCodesignStore.getState().currentDesignId).toBe('design-b');
+    expect(useCodesignStore.getState().previewSource).toBeNull();
+    expect(useCodesignStore.getState().chatMessages).toEqual([]);
+  });
+
   it('imports picked files into the workspace and attaches imported paths to the prompt', async () => {
     const imported = [
       {

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -333,6 +333,7 @@ export interface CodesignState {
   openNewDesignDialog: () => void;
   closeNewDesignDialog: () => void;
   createNewDesign: (workspacePath?: string | null) => Promise<Design | null>;
+  createNewConversationForCurrentWorkspace: () => Promise<Design | null>;
   switchDesign: (id: string) => Promise<void>;
   renameCurrentDesign: (name: string) => Promise<void>;
   renameDesign: (id: string, name: string, options?: RenameDesignOptions) => Promise<void>;

--- a/apps/desktop/src/renderer/src/store/slices/designs.ts
+++ b/apps/desktop/src/renderer/src/store/slices/designs.ts
@@ -33,6 +33,7 @@ interface DesignsSliceActions {
   openNewDesignDialog: CodesignState['openNewDesignDialog'];
   closeNewDesignDialog: CodesignState['closeNewDesignDialog'];
   createNewDesign: CodesignState['createNewDesign'];
+  createNewConversationForCurrentWorkspace: CodesignState['createNewConversationForCurrentWorkspace'];
   switchDesign: CodesignState['switchDesign'];
   renameCurrentDesign: CodesignState['renameCurrentDesign'];
   renameDesign: CodesignState['renameDesign'];
@@ -160,6 +161,35 @@ export function makeDesignsSlice(set: SetState, get: GetState): DesignsSliceActi
       const name = nextUntitledDesignName(get().designs);
       try {
         const design = await window.codesign.snapshots.createDesign(name, workspacePath);
+        set((state) => buildFreshDesignState(state, design.id));
+        await get().loadDesigns();
+        void get().loadChatForCurrentDesign();
+        void get().loadCommentsForCurrentDesign();
+        return design;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : tr('errors.unknown');
+        get().pushToast({
+          variant: 'error',
+          title: tr('projects.notifications.createFailed'),
+          description: msg,
+        });
+        return null;
+      }
+    },
+
+    async createNewConversationForCurrentWorkspace() {
+      if (!window.codesign) return null;
+      const currentDesignId = get().currentDesignId;
+      const currentDesign =
+        currentDesignId === null ? undefined : get().designs.find((d) => d.id === currentDesignId);
+      const workspacePath = currentDesign?.workspacePath;
+      if (!workspacePath) return null;
+
+      const name = nextUntitledDesignName(get().designs);
+      try {
+        const design = await window.codesign.snapshots.createDesign(name, workspacePath, {
+          workspaceReuse: 'fresh-conversation',
+        });
         set((state) => buildFreshDesignState(state, design.id));
         await get().loadDesigns();
         void get().loadChatForCurrentDesign();

--- a/apps/desktop/src/renderer/src/views/hub/RecentTab.test.ts
+++ b/apps/desktop/src/renderer/src/views/hub/RecentTab.test.ts
@@ -1,8 +1,8 @@
 import type { Design } from '@open-codesign/shared';
 import { describe, expect, it } from 'vitest';
-import { buildRecentDesigns } from './RecentTab';
+import { buildRecentDesigns, collapseWorkspaceDesigns } from './RecentTab';
 
-function design(id: string, updatedAt: string): Design {
+function design(id: string, updatedAt: string, workspacePath: string | null = null): Design {
   return {
     schemaVersion: 1,
     id,
@@ -11,7 +11,7 @@ function design(id: string, updatedAt: string): Design {
     updatedAt,
     deletedAt: null,
     thumbnailText: null,
-    workspacePath: null,
+    workspacePath,
   };
 }
 
@@ -45,5 +45,42 @@ describe('buildRecentDesigns', () => {
         2,
       ).map((d) => d.id),
     ).toEqual(['working-old', 'recent-1']);
+  });
+
+  it('shows one card per workspace and keeps the newest session as the representative', () => {
+    const designs = [
+      design('new-session', '2026-05-05T11:00:00.000Z', 'C:\\Users\\me\\MotsDits'),
+      design('old-session', '2026-05-05T10:00:00.000Z', 'c:/users/me/motsdits/'),
+      design('other-workspace', '2026-05-05T09:00:00.000Z', 'C:/Users/me/Other'),
+    ];
+
+    expect(buildRecentDesigns(designs, {}, 6).map((d) => d.id)).toEqual([
+      'new-session',
+      'other-workspace',
+    ]);
+  });
+
+  it('uses an active session as the workspace representative', () => {
+    const designs = [
+      design('new-idle-session', '2026-05-05T11:00:00.000Z', 'C:/Users/me/MotsDits'),
+      design('old-working-session', '2026-05-05T10:00:00.000Z', 'C:/Users/me/MotsDits'),
+    ];
+
+    expect(
+      buildRecentDesigns(
+        designs,
+        { 'old-working-session': { generationId: 'gen-old', stage: 'streaming' } },
+        6,
+      ).map((d) => d.id),
+    ).toEqual(['old-working-session']);
+  });
+
+  it('does not collapse designs without a workspace path', () => {
+    expect(
+      collapseWorkspaceDesigns([
+        design('blank-1', '2026-05-05T11:00:00.000Z'),
+        design('blank-2', '2026-05-05T10:00:00.000Z'),
+      ]).map((d) => d.id),
+    ).toEqual(['blank-1', 'blank-2']);
   });
 });

--- a/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/RecentTab.tsx
@@ -11,7 +11,12 @@ interface DesignRun {
 }
 
 export function buildRecentDesigns<
-  T extends { id: string; updatedAt: string; deletedAt: string | null },
+  T extends {
+    id: string;
+    updatedAt: string;
+    deletedAt: string | null;
+    workspacePath?: string | null | undefined;
+  },
 >(designs: T[], generationByDesign: Record<string, DesignRun>, limit = RECENT_LIMIT): T[] {
   const sorted = [...designs]
     .filter((d) => d.deletedAt === null)
@@ -19,7 +24,31 @@ export function buildRecentDesigns<
   const activeIds = new Set([...Object.keys(generationByDesign)]);
   const active = sorted.filter((d) => activeIds.has(d.id));
   const rest = sorted.filter((d) => !activeIds.has(d.id));
-  return [...active, ...rest].slice(0, limit);
+  return collapseWorkspaceDesigns([...active, ...rest]).slice(0, limit);
+}
+
+export function collapseWorkspaceDesigns<
+  T extends { id: string; workspacePath?: string | null | undefined },
+>(designs: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const design of designs) {
+    const key = workspaceGroupKey(design);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(design);
+  }
+  return out;
+}
+
+function workspaceGroupKey(design: {
+  id: string;
+  workspacePath?: string | null | undefined;
+}): string {
+  const raw = design.workspacePath?.trim();
+  if (!raw) return `design:${design.id}`;
+  const normalized = raw.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  return normalized ? `workspace:${normalized}` : `design:${design.id}`;
 }
 
 export function RecentTab() {

--- a/apps/desktop/src/renderer/src/views/hub/YourDesignsTab.tsx
+++ b/apps/desktop/src/renderer/src/views/hub/YourDesignsTab.tsx
@@ -1,6 +1,7 @@
 import { useT } from '@open-codesign/i18n';
 import { useCodesignStore } from '../../store';
 import { DesignGrid } from './DesignGrid';
+import { collapseWorkspaceDesigns } from './RecentTab';
 
 export function YourDesignsTab() {
   const t = useT();
@@ -8,5 +9,5 @@ export function YourDesignsTab() {
   const sorted = [...designs]
     .filter((d) => d.deletedAt === null)
     .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
-  return <DesignGrid designs={sorted} emptyLabel={t('hub.your.empty')} />;
+  return <DesignGrid designs={collapseWorkspaceDesigns(sorted)} emptyLabel={t('hub.your.empty')} />;
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -66,6 +66,7 @@
       }
     },
     "tabsAriaLabel": "Open files",
+    "previewTabsAriaLabel": "Open previews",
     "closeTab": "Close {{name}}",
     "files": {
       "sectionTitle": "Design files",
@@ -253,6 +254,14 @@
     "ariaLabel": "Chat pane",
     "noDesign": "No design",
     "newChat": "New chat",
+    "closeChat": "Close {{name}}",
+    "chatTabsAriaLabel": "Workspace chats",
+    "deleteChat": {
+      "title": "Delete chat?",
+      "body": "This will remove “{{name}}” from this workspace. The workspace files stay untouched.",
+      "cancel": "Cancel",
+      "confirm": "Delete chat"
+    },
     "collapse": "Collapse sidebar",
     "expand": "Expand sidebar",
     "chat": {
@@ -953,6 +962,7 @@
       "currentLabel": "Current design",
       "menuLabel": "Switch design",
       "newDesign": "New design",
+      "newConversationForWorkspace": "New conversation for this workspace",
       "renameCurrent": "Rename",
       "viewAll": "View all designs…",
       "recent": "Recent",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -66,6 +66,7 @@
       }
     },
     "tabsAriaLabel": "Archivos abiertos",
+    "previewTabsAriaLabel": "Vistas previas abiertas",
     "closeTab": "Cerrar {{name}}",
     "files": {
       "sectionTitle": "Archivos de diseño",
@@ -253,6 +254,14 @@
     "ariaLabel": "Panel de chat",
     "noDesign": "Sin diseño",
     "newChat": "Nuevo chat",
+    "closeChat": "Cerrar {{name}}",
+    "chatTabsAriaLabel": "Chats del espacio de trabajo",
+    "deleteChat": {
+      "title": "¿Eliminar chat?",
+      "body": "Esto quitará “{{name}}” de este espacio de trabajo. Los archivos del workspace no se modifican.",
+      "cancel": "Cancelar",
+      "confirm": "Eliminar chat"
+    },
     "collapse": "Contraer barra lateral",
     "expand": "Expandir barra lateral",
     "chat": {
@@ -898,6 +907,7 @@
       "currentLabel": "Diseño actual",
       "menuLabel": "Cambiar diseño",
       "newDesign": "Nuevo diseño",
+      "newConversationForWorkspace": "Nueva conversación para este espacio de trabajo",
       "renameCurrent": "Renombrar",
       "viewAll": "Ver todos los diseños…",
       "recent": "Recientes",

--- a/packages/i18n/src/locales/pt-BR.json
+++ b/packages/i18n/src/locales/pt-BR.json
@@ -66,6 +66,7 @@
       }
     },
     "tabsAriaLabel": "Arquivos abertos",
+    "previewTabsAriaLabel": "Pré-visualizações abertas",
     "closeTab": "Fechar {{name}}",
     "files": {
       "sectionTitle": "Arquivos de design",
@@ -253,6 +254,14 @@
     "ariaLabel": "Painel do chat",
     "noDesign": "Nenhum design",
     "newChat": "Novo chat",
+    "closeChat": "Fechar {{name}}",
+    "chatTabsAriaLabel": "Chats do workspace",
+    "deleteChat": {
+      "title": "Excluir chat?",
+      "body": "Isso removerá “{{name}}” deste workspace. Os arquivos do workspace não serão alterados.",
+      "cancel": "Cancelar",
+      "confirm": "Excluir chat"
+    },
     "collapse": "Recolher barra lateral",
     "expand": "Expandir barra lateral",
     "chat": {
@@ -859,6 +868,7 @@
       "currentLabel": "Design atual",
       "menuLabel": "Trocar design",
       "newDesign": "Novo design",
+      "newConversationForWorkspace": "Nova conversa para este workspace",
       "renameCurrent": "Renomear",
       "viewAll": "Ver todos os designs…",
       "recent": "Recentes",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -66,6 +66,7 @@
       }
     },
     "tabsAriaLabel": "已打开文件",
+    "previewTabsAriaLabel": "已打开预览",
     "closeTab": "关闭 {{name}}",
     "files": {
       "sectionTitle": "设计文件",
@@ -253,6 +254,14 @@
     "ariaLabel": "对话面板",
     "noDesign": "暂无设计",
     "newChat": "新对话",
+    "closeChat": "关闭 {{name}}",
+    "chatTabsAriaLabel": "工作区对话",
+    "deleteChat": {
+      "title": "删除对话？",
+      "body": "这会从此工作区移除“{{name}}”。工作区文件不会被修改。",
+      "cancel": "取消",
+      "confirm": "删除对话"
+    },
     "collapse": "收起侧边栏",
     "expand": "展开侧边栏",
     "chat": {
@@ -953,6 +962,7 @@
       "currentLabel": "当前设计",
       "menuLabel": "切换设计",
       "newDesign": "新建设计",
+      "newConversationForWorkspace": "为此工作区新建对话",
       "renameCurrent": "重命名",
       "viewAll": "查看全部设计…",
       "recent": "最近",


### PR DESCRIPTION
## Summary
- Add chat tabs for designs that share the same workspace, with a plus action for starting a fresh conversation in that workspace.
- Create fresh workspace conversations without copying prior snapshots or chat history.
- Keep workspace/session state consistent when switching, renaming, deleting, and generating across chat tabs.

## Test plan
- [x] Targeted desktop tests for chat tabs, workspace conversation creation, switching, generation, and rename flows.
- [x] Desktop typecheck.
- [x] Full pre-push checks: workspace typecheck, lint, and test suite.
- [x] Windows desktop build via cmd.exe: `pnpm --filter @open-codesign/desktop build`.
- [x] Windows dev app launched from the rebased branch for manual testing.

## Principles
- [x] Compatibility
- [x] Upgradeability
- [x] No bloat
- [x] Elegance

🤖 Generated with [Claude Code](https://claude.com/claude-code)