### PR TITLE
fix(desktop): support --no-sandbox when launched as uid 0

### DIFF
--- a/apps/desktop/scripts/dev.cjs
+++ b/apps/desktop/scripts/dev.cjs
@@ -10,6 +10,14 @@ const env = { ...process.env };
 // so Electron behaves like Node. The desktop dev app must launch real Electron.
 env.ELECTRON_RUN_AS_NODE = undefined;
 
+// Electron exits fatally when launched as uid 0 unless --no-sandbox is passed.
+// Containers, dev VMs, and CI runners commonly run as root; without this they
+// can never `pnpm dev` at all. electron-vite reads NO_SANDBOX=1 and forwards
+// --no-sandbox to the spawned Electron process (see electron-vite/dist startElectron).
+if (process.getuid && process.getuid() === 0 && !env.NO_SANDBOX) {
+  env.NO_SANDBOX = '1';
+}
+
 const child = spawn(process.execPath, [electronViteBin, 'dev', ...process.argv.slice(2)], {
   env,
   stdio: ['inherit', 'inherit', 'pipe'],

--- a/apps/desktop/src/main/preview-runtime.ts
+++ b/apps/desktop/src/main/preview-runtime.ts
@@ -118,6 +118,10 @@ export async function runPreview(opts: RunPreviewOptions): Promise<PreviewResult
         // dialogs that would otherwise stall the launch handshake.
         '--no-first-run',
         '--no-default-browser-check',
+        // Chrome's zygote refuses to start as uid 0 without this. Containers,
+        // dev VMs, and CI runners frequently run as root; gating to root keeps
+        // the production launch path unchanged on macOS/Windows/user-mode Linux.
+        ...(process.getuid?.() === 0 ? ['--no-sandbox'] : []),
       ],
     });
     page = await browser.newPage();


### PR DESCRIPTION
## What

Two Chrome/Chromium spawn sites in the desktop app crash immediately when launched as uid 0, with:

```
FATAL: Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

1. **`apps/desktop/scripts/dev.cjs`** — spawns Electron via electron-vite. `pnpm dev` exits within seconds, before the renderer can attach.
2. **`apps/desktop/src/main/preview-runtime.ts`** — spawns Chrome via puppeteer-core to render preview artifacts. **9 of the 17 `preview-runtime.test.ts` cases fail** as root, all with the same FATAL line in the failure payload.

Both make the repo effectively unusable inside any rootful container, dev VM, or CI runner — environments where Node toolchains are commonly already root.

## Fix

Gated to `process.getuid?.() === 0` so the macOS / Windows / user-mode-Linux launch paths are unchanged:

- **dev launcher** sets `NO_SANDBOX=1`, which electron-vite already reads and forwards as `--no-sandbox` to the spawned Electron process (see `electron-vite/dist .../lib-q6ns0vZr.js:234`).
- **preview-runtime** conditionally appends `'--no-sandbox'` to the puppeteer launch args.

8 + 4 = 12 added lines, 2 files, no other code touched.

## Verification

Local environment: Linux container, uid 0, Node 22.22.3, pnpm 10.33.4.

**Before patch:**
- `pnpm dev` → `[FATAL:electron_main_delegate.cc:216] Running as root without --no-sandbox is not supported.`
- `pnpm --filter @open-codesign/desktop test` → `Test Files 1 failed | 109 passed (110)`, `Tests 9 failed | 1332 passed (1341)` — every failure points back to the same FATAL line.

**After patch:**
- `pnpm dev` → Electron now reaches `Missing X server or $DISPLAY` (expected on a headless box; out of scope for this PR).
- Full pre-push gate green: `pnpm -r typecheck` ✅, `pnpm lint` ✅ (Biome, 524 files), `pnpm test` ✅ **110/110 files, 1341/1341 tests** (vs 9 failing on `main`).

## Principles check

- **Compatibility** ✅ — non-root behavior unchanged; uid 0 is the only branch.
- **Upgradeability** ✅ — no schema, no IPC, no config.
- **No bloat** ✅ — uses an env var electron-vite already supports; no new deps; ~12 lines.
- **Elegance** ✅ — both call sites use the same `getuid?.() === 0` guard; comments explain *why* (per CLAUDE.md).

No changeset added — this is an internal dev-experience fix that doesn't change shipped behavior. Happy to add one if the project prefers.