### PR TITLE
fix(desktop): show main window when ready-to-show never fires

### DIFF
--- a/.changeset/main-window-show-fallback.md
+++ b/.changeset/main-window-show-fallback.md
@@ -1,0 +1,5 @@
+---
+"@open-codesign/desktop": patch
+---
+
+Show the main window via a 2s fallback timer when `ready-to-show` never fires. On software-rendered systems (e.g. VMware/VirtualBox VMs where Chromium falls back to SwiftShader), the compositor never produces a first frame for a hidden window, so the window stayed invisible forever while the app ran healthy underneath.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -103,7 +103,22 @@ function createWindow(): void {
     },
   });
 
-  mainWindow.on('ready-to-show', () => mainWindow?.show());
+  // On software-rendered systems (e.g. VMware SVGA → SwiftShader fallback)
+  // the compositor never produces a first frame for a hidden window, so
+  // ready-to-show never fires and the window stays invisible forever while
+  // the app runs healthy underneath. The fallback timer shows the window
+  // anyway; on healthy systems ready-to-show fires well within 2s and
+  // startup stays flicker-free.
+  const showFallback = setTimeout(() => {
+    if (mainWindow !== null && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      mainWindow.show();
+    }
+  }, 2000);
+  mainWindow.on('ready-to-show', () => {
+    clearTimeout(showFallback);
+    mainWindow?.show();
+  });
+  mainWindow.on('closed', () => clearTimeout(showFallback));
   // Null the reference on close so stale IPC sends from async emitters
   // (autoUpdater, long-running generate runs) become clean no-ops rather
   // than throwing "Object has been destroyed" on a discarded webContents.


### PR DESCRIPTION
## Summary

On software-rendered systems — e.g. a VMware Fusion VM with the `VMware SVGA II` virtual GPU, where Chromium falls back to SwiftShader (`gpu_compositing: disabled_software`) — the compositor never produces a first frame for a *hidden* window. The main window is created with `show: false` and only shown from `ready-to-show` (`apps/desktop/src/main/index.ts`), and that event is driven by the first frame. Result: chicken-and-egg — the window waits for a frame, the frame waits for a visible window. The app boots completely healthy underneath (single-instance lock acquired, snapshots DB up, renderer DOM fully loaded — verified via CDP) but the window stays invisible forever. `--disable-gpu` and `--ozone-platform=wayland` do not help.

This PR adds a 2s fallback timer that shows the window when `ready-to-show` never fires. On healthy systems `ready-to-show` fires well within 2s, cancels the timer, and startup stays flicker-free — no behavior change there.

**Diagnosis evidence:** with the window hidden, `Page.captureScreenshot` over CDP hangs indefinitely (no frames produced); with the window shown, the same call returns the fully rendered UI immediately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Build / CI / tooling
- [ ] Breaking change

## Linked issue

None — happy to open one with the full diagnosis log if you prefer tracking it that way.

## Checklist

- [x] I checked the linked issue / relevant context before starting
- [x] `pnpm lint && pnpm typecheck && pnpm test` passes locally (1366 tests, 111 files)
- [ ] Added/updated tests for the change — `createWindow()` is not exported and is all side effects; covering a window-show timing fallback would require refactoring it for testability, which felt out of proportion for this fix. Glad to add one if you want the refactor.
- [x] Added a changeset (`pnpm changeset`) if user-visible
- [x] Updated docs if behavior changed — n/a, no documented behavior changed

## PRINCIPLES §5b

- ✅ **Compatibility** — no behavior change on systems where `ready-to-show` fires; fallback only triggers where the window previously never appeared at all
- ✅ **Upgradeability** — no new APIs, config, or on-disk state
- ✅ **No bloat** — no new dependencies; +13 lines in one file
- ✅ **Elegance** — keeps the flicker-free `show: false` + `ready-to-show` path as the primary mechanism; the timer is a guarded escape hatch with the *why* documented inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)