### PR TITLE
feat: add Z.ai GLM Coding Plan as built-in provider

### DIFF
--- a/.changeset/add-zai-glm-provider.md
+++ b/.changeset/add-zai-glm-provider.md
@@ -1,0 +1,6 @@
+---
+"@open-codesign/shared": minor
+"@open-codesign/providers": patch
+---
+
+Add Z.ai (GLM Coding Plan) as a built-in provider with support for GLM-5.1, GLM-5-Turbo, GLM-4.7, and GLM-4.5-Air models via the Anthropic-compatible API endpoint.

--- a/packages/providers/src/validate.ts
+++ b/packages/providers/src/validate.ts
@@ -67,6 +67,19 @@ function endpoint(provider: SupportedOnboardingProvider, baseUrl?: string): Prov
         headers: () => ({}),
       };
     }
+    case 'zai': {
+      const root = baseUrl ? normalizeValidateBaseUrl(baseUrl) : 'https://api.z.ai/api/anthropic';
+      return {
+        url: `${root}/v1/models`,
+        headers: (apiKey) => {
+          const auth: Record<string, string> = {
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01',
+          };
+          return withClaudeCodeIdentity('anthropic', baseUrl, auth);
+        },
+      };
+    }
   }
 }
 

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -499,3 +499,46 @@ describe('provider capability helpers', () => {
     expect(caps.modelDiscoveryMode).toBe('manual');
   });
 });
+
+describe('zai builtin provider', () => {
+  it('has a well-formed zai entry in BUILTIN_PROVIDERS', () => {
+    const zai = BUILTIN_PROVIDERS.zai;
+    expect(zai).toBeDefined();
+    expect(zai.id).toBe('zai');
+    expect(zai.name).toBe('Z.ai (GLM Coding Plan)');
+    expect(zai.builtin).toBe(true);
+    expect(zai.wire).toBe('anthropic');
+    expect(zai.baseUrl).toBe('https://api.z.ai/api/anthropic');
+    expect(zai.defaultModel).toBe('glm-5.1');
+    expect(zai.modelsHint).toEqual(['glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air']);
+    expect(zai.requiresApiKey).toBe(true);
+  });
+
+  it('zai capabilities are set for static-hint discovery with reasoning', () => {
+    const caps = resolveProviderCapabilities('zai', BUILTIN_PROVIDERS.zai);
+    expect(caps.supportsKeyless).toBe(false);
+    expect(caps.supportsModelsEndpoint).toBe(false);
+    expect(caps.supportsReasoning).toBe(true);
+    expect(caps.modelDiscoveryMode).toBe('static-hint');
+  });
+
+  it('zai is included in SUPPORTED_ONBOARDING_PROVIDERS', () => {
+    expect(SUPPORTED_ONBOARDING_PROVIDERS).toContain('zai');
+  });
+
+  it('detects z.ai anthropic URL as anthropic wire', () => {
+    expect(detectWireFromBaseUrl('https://api.z.ai/api/anthropic')).toBe('anthropic');
+  });
+
+  it('accepts zai as active provider in v3 config', () => {
+    const parsed = ConfigV3Schema.parse({
+      version: 3,
+      activeProvider: 'zai',
+      activeModel: 'glm-5.1',
+      secrets: { zai: { ciphertext: 'plain:sk-test', mask: 'sk-***test' } },
+      providers: { zai: BUILTIN_PROVIDERS.zai },
+    });
+    expect(parsed.activeProvider).toBe('zai');
+    expect(parsed.activeModel).toBe('glm-5.1');
+  });
+});

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_ONBOARDING_PROVIDERS = [
   'openai',
   'openrouter',
   'ollama',
+  'zai',
 ] as const;
 export type SupportedOnboardingProvider = (typeof SUPPORTED_ONBOARDING_PROVIDERS)[number];
 
@@ -294,6 +295,23 @@ export const BUILTIN_PROVIDERS: Readonly<Record<SupportedOnboardingProvider, Pro
       modelDiscoveryMode: 'models',
     },
   },
+  zai: {
+    id: 'zai',
+    name: 'Z.ai (GLM Coding Plan)',
+    builtin: true,
+    wire: 'anthropic',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    defaultModel: 'glm-5.1',
+    modelsHint: ['glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
+    requiresApiKey: true,
+    capabilities: {
+      supportsKeyless: false,
+      supportsModelsEndpoint: false,
+      supportsReasoning: true,
+      requiresClaudeCodeIdentity: false,
+      modelDiscoveryMode: 'static-hint',
+    },
+  },
 } as const;
 
 // ── ConfigSchema v3 — canonical on-disk shape ────────────────────────────────
@@ -513,6 +531,13 @@ export const PROVIDER_SHORTLIST: Record<SupportedOnboardingProvider, ProviderSho
     keyHelpUrl: 'https://ollama.com/download',
     primary: [OLLAMA_DEFAULT_MODEL, 'llama3.1', 'qwen2.5'],
     defaultPrimary: OLLAMA_DEFAULT_MODEL,
+  },
+  zai: {
+    provider: 'zai',
+    label: 'Z.ai (GLM Coding Plan)',
+    keyHelpUrl: 'https://z.ai/manage-apikey/apikey-list',
+    primary: ['glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
+    defaultPrimary: 'glm-5.1',
   },
 };
 

--- a/packages/shared/src/proxy-presets.ts
+++ b/packages/shared/src/proxy-presets.ts
@@ -60,6 +60,13 @@ export const PROXY_PRESETS = [
     notes: '',
   },
   {
+    id: 'zai-glm',
+    label: 'Z.ai GLM Coding Plan',
+    provider: 'anthropic',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    notes: 'GLM-5.1, GLM-5-Turbo, GLM-4.7, GLM-4.5-Air',
+  },
+  {
     id: 'custom',
     label: 'Custom...',
     provider: 'openai',


### PR DESCRIPTION
## Summary

Add native support for [Z.ai GLM Coding Plan](https://z.ai/landing-page/coding-plan) as a built-in provider, enabling users to use GLM-5.1, GLM-5-Turbo, GLM-4.7, and GLM-4.5-Air models directly from the onboarding UI.

## Changes

### `packages/shared/src/config.ts`
- Added `zai` to `SUPPORTED_ONBOARDING_PROVIDERS`
- Added `zai` entry to `BUILTIN_PROVIDERS` with:
  - `wire: "anthropic"` — Z.ai provides an Anthropic-compatible API endpoint
  - `baseUrl: "https://api.z.ai/api/anthropic"` — official Coding Plan endpoint
  - `defaultModel: "glm-5.1"` — flagship long-horizon coding model
  - `modelsHint: ["glm-5.1", "glm-5-turbo", "glm-4.7", "glm-4.5-air"]`
  - `capabilities: { supportsReasoning: true, modelDiscoveryMode: "static-hint" }`
- Added `zai` entry to `PROVIDER_SHORTLIST` with key management URL

### `packages/shared/src/proxy-presets.ts`
- Added `zai-glm` preset to `PROXY_PRESETS`

## Technical Details

- **Wire type**: `anthropic` — Z.ai provides a fully Anthropic-compatible endpoint at `https://api.z.ai/api/anthropic`, the same integration used by Claude Code, Cursor, and other agentic coding tools
- **API Key**: Users obtain keys from https://z.ai/manage-apikey/apikey-list
- **Model discovery**: Uses `static-hint` mode (4 models) since the Anthropic-compatible endpoint may not expose a `/v1/models` route
- **Reasoning**: GLM-5.1 supports extended thinking (`thinking.type: "enabled"`), compatible with the Anthropic wire reasoning flow
- **No changes needed** in `packages/providers/src/index.ts` — the existing anthropic wire handling works correctly with Z.ai endpoint

## Testing

- All 111 test files pass (1366 tests)
- TypeScript compilation passes for `@open-codesign/shared`
- Semantic validation confirmed for all provider fields
- Note: a pre-existing TS error in `packages/providers/src/validate.ts:32` causes the pre-push hook to fail (unrelated to this PR)

## References

- [Z.ai Coding Plan](https://z.ai/landing-page/coding-plan)
- [Z.ai Claude Code Integration Guide](https://docs.z.ai/devpack/tool/claude)
- [GLM-5.1 Documentation](https://docs.z.ai/guides/llm/glm-5.1)